### PR TITLE
Handle missing flash-attn on SM75 builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1000,12 +1000,20 @@ if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
 if _is_cuda():
-    ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
+    # SM75-only builds intentionally skip vendored vllm-flash-attn in CMake:
+    # the validated 2080 Ti serving path uses FlashQLA/FlashInfer/TurboQuant
+    # fallbacks instead of upstream FA2 kernels. Mark these optional so editable
+    # installs do not fail when the CMake component is a no-op.
+    ext_modules.append(
+        CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C", optional=True)
+    )
     if envs.VLLM_USE_PRECOMPILED or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
     ):
         # FA3 requires CUDA 12.3 or later
-        ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+        ext_modules.append(
+            CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C", optional=True)
+        )
     # FA4 CuteDSL - Python-only component for FA4's cute DSL support
     # Optional since this doesn't produce a .so file, just copies Python files
     ext_modules.append(

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -15,12 +15,30 @@ logger = init_logger(__name__)
 # consistent behavior (similar to IS_AITER_FOUND in _aiter_ops.py).
 _ROCM_FLASH_ATTN_AVAILABLE = False
 
+_CUDA_FLASH_ATTN_AVAILABLE = False
+
 if current_platform.is_cuda():
     from vllm._custom_ops import reshape_and_cache_flash
-    from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
-        flash_attn_varlen_func,
-        get_scheduler_metadata,
-    )
+    try:
+        from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
+            flash_attn_varlen_func,
+            get_scheduler_metadata,
+        )
+
+        _CUDA_FLASH_ATTN_AVAILABLE = True
+    except ImportError as e:
+        _CUDA_FLASH_ATTN_UNAVAILABLE_REASON = str(e)
+
+        def flash_attn_varlen_func(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef,misc]
+            raise ImportError(
+                "CUDA vllm_flash_attn is unavailable. This is expected for "
+                "SM75-only 2080 Ti builds that use FlashQLA/FlashInfer/TurboQuant "
+                "serving paths instead of vendored FA2. Original error: "
+                f"{_CUDA_FLASH_ATTN_UNAVAILABLE_REASON}"
+            )
+
+        def get_scheduler_metadata(*args: Any, **kwargs: Any) -> None:  # type: ignore[no-redef,misc]
+            return None
 
 elif current_platform.is_xpu():
     from vllm import _custom_ops as ops
@@ -249,8 +267,10 @@ def is_flash_attn_varlen_func_available() -> bool:
     Returns:
         bool: True if a working flash_attn_varlen_func implementation is available.
     """
-    if current_platform.is_cuda() or current_platform.is_xpu():
-        # CUDA and XPU always have flash_attn_varlen_func available
+    if current_platform.is_cuda():
+        return _CUDA_FLASH_ATTN_AVAILABLE
+
+    if current_platform.is_xpu():
         return True
 
     if current_platform.is_rocm():


### PR DESCRIPTION
## Summary
- mark vendored vllm flash-attn CUDA extensions optional for SM75 source builds
- allow CUDA model registry import to continue when vllm_flash_attn is absent, so SM75 profiles can fall back to the validated FlashQLA/FlashInfer/TurboQuant routes

## Validation
- python3 -m py_compile setup.py vllm/v1/attention/backends/fa_utils.py
- git diff --check

Closes #12