### PR TITLE
fix: tolerate missing optional flash attention extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ lora_filesystem_resolver = "vllm.plugins.lora_resolvers.filesystem_resolver:regi
 lora_hf_hub_resolver = "vllm.plugins.lora_resolvers.hf_hub_resolver:register_hf_hub_resolver"
 
 [tool.setuptools_scm]
-# no extra settings needed, presence enables setuptools-scm
+fallback_version = "0.21.0+2080ti"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/setup.py
+++ b/setup.py
@@ -393,6 +393,34 @@ class cmake_build_ext(build_ext):
                     dirs_exist_ok=True,
                 )
 
+    def copy_extensions_to_source(self) -> None:
+        # Editable installs copy built extensions from build_lib back into the
+        # source tree. SM75-only builds intentionally mark vendored FA/FlashMLA
+        # extensions optional because those CMake targets can be no-ops on
+        # 2080 Ti profiles. Setuptools still tries to copy every extension, so
+        # skip missing optional outputs here instead of failing after a
+        # successful build.
+        original_extensions = self.extensions
+        existing_extensions = []
+        build_py = self.get_finalized_command("build_py")
+        for ext in original_extensions:
+            _, build_path = self._get_inplace_equivalent(build_py, ext)
+            build_path = Path(build_path)
+            if build_path.exists() or not getattr(ext, "optional", False):
+                existing_extensions.append(ext)
+            else:
+                logger.info(
+                    "Skipping optional extension copy because build output is "
+                    "missing: %s",
+                    build_path,
+                )
+
+        self.extensions = existing_extensions
+        try:
+            super().copy_extensions_to_source()
+        finally:
+            self.extensions = original_extensions
+
 
 class precompiled_build_ext(build_ext):
     """Disables extension building when using precompiled binaries."""


### PR DESCRIPTION
## Summary

Fixes the source-install failure reported in #12 when the SM75/2080 Ti build intentionally does not produce vendored FlashAttention extension artifacts.

- skip missing optional extension outputs during editable-install copy-back
- add a setuptools-scm fallback version so archive/no-tag builds report `0.21.0+2080ti` instead of falling back to `0.1`

## Validation

- `uv run --no-project --python 3.12 python -m py_compile setup.py`
- `uv run --no-project --python 3.12 --with setuptools==77.0.3 --with setuptools-scm==8.3.1 python - <<PY ... read_configuration("pyproject.toml") ... PY`
- copied `pyproject.toml` into a temporary non-git directory and verified `python -m setuptools_scm` returns `0.21.0+2080ti`
- `git diff --check`
