### PR TITLE
Fix Qwen-VL rotary fallback when flash-attn extension is unavailable

### DIFF
--- a/tests/kernels/core/test_apply_rotary_emb.py
+++ b/tests/kernels/core/test_apply_rotary_emb.py
@@ -11,6 +11,7 @@ ApplyRotaryEmb methods based on the calling context:
 3. RotaryEmbedding.forward_hip() -> ApplyRotaryEmb.forward() (auto-dispatch)
 """
 
+import builtins
 from dataclasses import dataclass
 
 import pytest
@@ -201,3 +202,31 @@ def test_rotary_embedding_dispatch(
     - forward_cuda/forward methods should call ApplyRotaryEmb.forward()
     """
     run_dispatch_test(test_case, device)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required.")
+def test_apply_rotary_emb_cuda_falls_back_without_vllm_flash_attn(monkeypatch):
+    from vllm.model_executor.layers.rotary_embedding.common import ApplyRotaryEmb
+
+    original_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "vllm.vllm_flash_attn.layers.rotary":
+            raise ImportError("missing vllm_flash_attn rotary extension")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    op = object.__new__(ApplyRotaryEmb)
+    op.is_neox_style = True
+    op.enable_fp32_compute = False
+
+    x = torch.randn(2, 4, 3, 8, dtype=torch.float16, device="cuda")
+    cos = torch.randn(4, 4, dtype=torch.float16, device="cuda")
+    sin = torch.randn(4, 4, dtype=torch.float16, device="cuda")
+
+    output = ApplyRotaryEmb.forward_cuda(op, x, cos, sin)
+
+    assert output.shape == x.shape
+    assert output.dtype == x.dtype
+    assert torch.isfinite(output).all()

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -229,7 +229,14 @@ class ApplyRotaryEmb(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        try:
+            from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        except (ImportError, ModuleNotFoundError):
+            logger.warning_once(
+                "vllm_flash_attn rotary extension is unavailable; "
+                "falling back to native rotary embedding."
+            )
+            return self.forward_native(x, cos, sin)
 
         x, cos, sin, origin_shape, origin_dtype = self._pre_process(x, cos, sin)
 


### PR DESCRIPTION
## Summary

- Handle missing `vllm_flash_attn` rotary CUDA extensions in `ApplyRotaryEmb.forward_cuda`.
- Fall back to the native rotary implementation instead of crashing Qwen3-VL image requests.
- Add a CUDA regression test that simulates the missing `vllm.vllm_flash_attn.layers.rotary` import.

## Why

Issue #19 reports image requests failing inside the Qwen3-VL visual encoder when the runtime package has the `vllm.vllm_flash_attn` Python module but does not have the `_vllm_fa2_C` / `_vllm_fa3_C` CUDA extensions available. In that case, the fast rotary import raises `ImportError` and the worker exits.

The fallback keeps the fast path unchanged when the extension exists, while allowing multimodal requests to continue through the existing native rotary path when the optional extension is unavailable.

## Validation

- `python -m py_compile vllm/model_executor/layers/rotary_embedding/common.py tests/kernels/core/test_apply_rotary_emb.py` passed.
- `git diff --check` passed.
- Remote CUDA smoke on the validated SM75 runtime: monkeypatched the flash-attn rotary import to fail, called `ApplyRotaryEmb.forward_cuda` on CUDA, and confirmed finite FP16 output.
- Local pytest collection could not run in this temporary worktree because the local test environment is missing `tblib` from `tests/conftest.py`.

Closes #19
