### PR TITLE
Document KVarN k4v2 SM75 feasibility

### DIFF
--- a/docs/kvarn-k4v2-sm75-feasibility.md
+++ b/docs/kvarn-k4v2-sm75-feasibility.md
@@ -1,0 +1,65 @@
+# KVarN k4v2 SM75 Feasibility Note
+
+Status: on hold. This is an implementation possibility, not a recommended
+profile route.
+
+## Summary
+
+KVarN `kvarn_k4v2_g128` showed strong KV-cache capacity/admission behavior on
+dual RTX 2080 Ti, but the current SM75 runtime does not qualify as a performance
+route. It should not be promoted unless a real fast-attention path is proven for
+Qwen3.6 27B's GQA layout.
+
+## Evidence
+
+Test environment:
+
+- Model: Qwen3.6 27B FP8 family checkpoint
+- GPUs: dual RTX 2080 Ti, TP=2
+- KV cache dtype: `kvarn_k4v2_g128`
+- Standard short throughput probe: `pp4096 / tg128`
+
+Observed short-probe throughput:
+
+| Route | Prefill tok/s | Decode tok/s | Result |
+|---|---:|---:|---|
+| SDPA fallback after FA2 gating | 783.48 | 7.32 | Not viable |
+| Fused verify forced for continuation | 865.81 | 7.38 | Not viable |
+
+The capacity side was promising: the 64K service admitted roughly 500K KV tokens
+under the tested settings. However, the short-probe decode speed is far below
+the existing FP8/INT4 production routes, so longer context tests are not useful
+until the short path is fixed.
+
+## Fast-Path Boundary
+
+The current KVarN attention backend is wired around `flash_attn_varlen` for the
+fast varlen path. On SM75, FA2 is not available, so the backend falls back to
+SDPA or KVarN fused verify paths.
+
+FlashInfer was probed as a possible replacement, but the installed FlashInfer
+path does not directly cover the target Qwen3.6 27B shape on SM75:
+
+- Equal-head small probes can run.
+- Qwen3.6 27B uses GQA: `num_attention_heads=24`,
+  `num_key_value_heads=4`, `head_dim=256`.
+- FlashInfer `single_prefill_with_kv_cache` and
+  `BatchPrefillWithRaggedKVCacheWrapper` both failed on this GQA shape with
+  CUDA invalid-argument errors on RTX 2080 Ti.
+
+FlashQLA is not a direct substitute here. The existing FlashQLA work accelerates
+Qwen GDN / linear-attention prefill, while KVarN's problematic continuation path
+needs a full-attention varlen or paged fast path.
+
+## Promotion Criteria
+
+KVarN k4v2 should only be reconsidered if all of the following are true:
+
+- The Qwen3.6 27B GQA shape runs on SM75 through FlashInfer, FlashQLA, or an
+  equivalent full-attention fast path.
+- `pp4096 / tg128` short-probe throughput is competitive with existing
+  recommended FP8/INT4 routes.
+- Output quality smoke passes before any long-context capacity testing.
+
+Until then, KVarN k4v2 remains an on-hold capacity experiment rather than a
+profile candidate.


### PR DESCRIPTION
## Summary

This draft records KVarN `kvarn_k4v2_g128` as an on-hold implementation possibility for SM75. It does not promote KVarN as a profile route.

The experiment showed strong KV-cache admission/capacity behavior, but the current runtime does not meet the short-probe performance gate on dual RTX 2080 Ti.

## Evidence

- Standard short probe `pp4096 / tg128` with SDPA fallback: `783.48` prefill tok/s, `7.32` decode tok/s.
- Forced fused-verify continuation: `865.81` prefill tok/s, `7.38` decode tok/s.
- Qwen3.6 27B uses GQA: `24` query heads, `4` KV heads, `head_dim=256`.
- FlashInfer probes on RTX 2080 Ti failed for the target GQA shape with CUDA invalid-argument errors. Equal-head probes are not enough evidence for this route.
- FlashQLA is not a direct substitute for this path because the relevant KVarN bottleneck is full-attention varlen/continuation, while the existing FlashQLA path targets Qwen GDN / linear-attention prefill.

## Decision boundary

KVarN k4v2 should only be reconsidered if the target Qwen GQA shape can run on SM75 through FlashInfer, FlashQLA, or an equivalent full-attention fast path, and the `pp4096 / tg128` short probe becomes competitive with the existing FP8/INT4 routes while passing quality smoke.

Until then, this remains an on-hold capacity experiment rather than a recommended profile candidate.

## Changes

- Adds `docs/kvarn-k4v2-sm75-feasibility.md` with the feasibility evidence and promotion criteria.

## Tests

No runtime code was changed in this PR. The note is based on the Miniclaw SM75 probes recorded in the document.