### PR TITLE
Fix build parallelism selection

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -862,6 +862,66 @@ install_torch_from_wheelhouse() {
       "torch==${VALIDATED_TORCH_VERSION}"
 }
 
+install_build_frontend_requirements() {
+  run_uv_pip_with_mirror_fallback "Install build frontend requirements" \
+    install --python .venv/bin/python -U \
+    "pip" \
+    "wheel" \
+    "packaging>=24.2" \
+    "setuptools>=77.0.3,<81.0.0" \
+    "setuptools-scm>=8" \
+    "cmake>=3.26.1" \
+    "ninja"
+}
+
+ensure_build_frontend_tools() {
+  .venv/bin/python - <<'PY'
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import import_module
+from pathlib import Path
+
+try:
+    from packaging.version import Version
+except Exception as exc:  # pragma: no cover - hard fail in build script
+    raise SystemExit(f"packaging import failed: {exc}") from exc
+
+required_modules = {
+    "setuptools": ("77.0.3", "81.0.0"),
+    "setuptools_scm": ("8.0.0", None),
+}
+
+for module_name, (min_version, max_exclusive) in required_modules.items():
+    module = import_module(module_name)
+    version = getattr(module, "__version__", None)
+    if version is None:
+        raise SystemExit(f"{module_name} has no __version__")
+    parsed = Version(version)
+    if parsed < Version(min_version):
+        raise SystemExit(f"{module_name} version too old: {version} < {min_version}")
+    if max_exclusive is not None and parsed >= Version(max_exclusive):
+        raise SystemExit(
+            f"{module_name} version too new: {version} >= {max_exclusive}"
+        )
+
+cmake_path = Path(sys.prefix) / "bin" / "cmake"
+if not cmake_path.is_file():
+    raise SystemExit(f"missing venv cmake: {cmake_path}")
+
+output = subprocess.check_output([str(cmake_path), "--version"], text=True)
+first_line = output.splitlines()[0].strip()
+version_text = first_line.rsplit(" ", 1)[-1]
+if Version(version_text) < Version("3.26.1"):
+    raise SystemExit(f"cmake version too old: {version_text} < 3.26.1")
+
+print(f"build_frontend_ok setuptools={import_module('setuptools').__version__} "
+      f"setuptools_scm={import_module('setuptools_scm').__version__} "
+      f"cmake={version_text}")
+PY
+}
+
 run_step() {
   local title=$1
   shift
@@ -1001,15 +1061,16 @@ fi
 
 install_torch_from_wheelhouse
 
-run_uv_pip_with_mirror_fallback "Upgrade build frontend" install --python .venv/bin/python -U pip setuptools wheel
+install_build_frontend_requirements
+run_with_progress "Validate build frontend tools" ensure_build_frontend_tools
 
-if [[ -f requirements/build/cuda.txt ]]; then
-  run_uv_pip_with_mirror_fallback "Install CUDA build requirements" install --python .venv/bin/python -r requirements/build/cuda.txt
-fi
+[[ -f requirements/build/cuda.txt ]] || fail "Missing requirements/build/cuda.txt. Re-sync the repository before building."
+run_uv_pip_with_mirror_fallback "Install CUDA build requirements" install --python .venv/bin/python -r requirements/build/cuda.txt
+run_with_progress "Re-validate build frontend tools" ensure_build_frontend_tools
 
-if [[ -f requirements/cuda.txt ]]; then
-  run_uv_pip_with_mirror_fallback "Install CUDA runtime requirements" install --python .venv/bin/python -r requirements/cuda.txt
-fi
+[[ -f requirements/cuda.txt ]] || fail "Missing requirements/cuda.txt. Re-sync the repository before building."
+run_uv_pip_with_mirror_fallback "Install CUDA runtime requirements" install --python .venv/bin/python -r requirements/cuda.txt
+run_with_progress "Re-validate build frontend tools after runtime deps" ensure_build_frontend_tools
 
 patch_flashqla_sm75_imports() {
   python - "$FLASHQLA_DIR" "$ROOT/tools/flashqla_sm75_patches" <<'PY'

--- a/build.sh
+++ b/build.sh
@@ -880,6 +880,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from importlib.metadata import version as pkg_version
 from importlib import import_module
 from pathlib import Path
 
@@ -895,9 +896,7 @@ required_modules = {
 
 for module_name, (min_version, max_exclusive) in required_modules.items():
     module = import_module(module_name)
-    version = getattr(module, "__version__", None)
-    if version is None:
-        raise SystemExit(f"{module_name} has no __version__")
+    version = getattr(module, "__version__", None) or pkg_version(module_name.replace("_", "-"))
     parsed = Version(version)
     if parsed < Version(min_version):
         raise SystemExit(f"{module_name} version too old: {version} < {min_version}")
@@ -916,8 +915,8 @@ version_text = first_line.rsplit(" ", 1)[-1]
 if Version(version_text) < Version("3.26.1"):
     raise SystemExit(f"cmake version too old: {version_text} < 3.26.1")
 
-print(f"build_frontend_ok setuptools={import_module('setuptools').__version__} "
-      f"setuptools_scm={import_module('setuptools_scm').__version__} "
+print(f"build_frontend_ok setuptools={pkg_version('setuptools')} "
+      f"setuptools_scm={pkg_version('setuptools-scm')} "
       f"cmake={version_text}")
 PY
 }

--- a/build.sh
+++ b/build.sh
@@ -77,13 +77,66 @@ detect_cpu_threads() {
   echo "$threads"
 }
 
+detect_memory_gb() {
+  local mem_kb mem_gb
+  mem_kb=$(awk '/MemTotal:/ { print $2 }' /proc/meminfo 2>/dev/null || echo 0)
+  mem_gb=$(( mem_kb / 1024 / 1024 ))
+  if (( mem_gb < 1 )); then
+    mem_gb=1
+  fi
+  echo "$mem_gb"
+}
+
 select_max_jobs() {
   local threads=$1
-  if (( threads <= 4 )); then
-    echo "$threads"
-  else
-    echo "$((threads - 2))"
+  local jobs
+  jobs=$((threads / 2))
+  (( jobs >= 1 )) || jobs=1
+  echo "$jobs"
+}
+
+validate_max_jobs_range() {
+  local jobs=$1
+  local threads=$2
+  is_positive_integer "$jobs" || fail "MAX_JOBS must be a positive integer."
+  if (( jobs < 1 || jobs > threads )); then
+    fail "MAX_JOBS must be between 1 and CPU_THREADS ($threads)."
   fi
+}
+
+configure_build_parallelism() {
+  local answer
+
+  if [[ "$MAX_JOBS_SOURCE" != "auto" ]]; then
+    return 0
+  fi
+  if [[ "${ASSUME_YES:-0}" == "1" || "${YES:-0}" == "1" || ! -t 0 ]]; then
+    return 0
+  fi
+
+  cat <<EOF
+
+Build thread selection:
+  CPU threads detected: $CPU_THREADS
+  Recommended build threads: $MAX_JOBS
+  Allowed range: 1-$CPU_THREADS
+
+Press Enter to use the recommended value, or type a build thread count:
+EOF
+
+  while true; do
+    read -r answer
+    if [[ -z "$answer" ]]; then
+      return 0
+    fi
+    if is_positive_integer "$answer" && (( answer >= 1 && answer <= CPU_THREADS )); then
+      MAX_JOBS="$answer"
+      MAX_JOBS_SOURCE=manual-prompt
+      export MAX_JOBS
+      return 0
+    fi
+    echo "Please enter a number from 1 to $CPU_THREADS, or press Enter for $MAX_JOBS:"
+  done
 }
 
 validate_cuda_dev_files() {
@@ -128,6 +181,7 @@ Expected time:
 
 Build parallelism:
   CPU threads: $CPU_THREADS
+  System memory: ${MEMORY_GB}GB
   MAX_JOBS: $MAX_JOBS ($MAX_JOBS_SOURCE)
 
 It will download Python/CUDA dependencies, compile CUDA extensions, and keep
@@ -826,14 +880,19 @@ CPU_THREADS=${CPU_THREADS:-$(detect_cpu_threads)}
 if ! is_positive_integer "$CPU_THREADS"; then
   fail "CPU_THREADS must be a positive integer when set explicitly."
 fi
+MEMORY_GB=${MEMORY_GB:-$(detect_memory_gb)}
+if ! is_positive_integer "$MEMORY_GB"; then
+  fail "MEMORY_GB must be a positive integer when set explicitly."
+fi
 if [[ -z "${MAX_JOBS:-}" ]]; then
   MAX_JOBS=$(select_max_jobs "$CPU_THREADS")
   MAX_JOBS_SOURCE=auto
 else
-  is_positive_integer "$MAX_JOBS" || fail "MAX_JOBS must be a positive integer."
+  validate_max_jobs_range "$MAX_JOBS" "$CPU_THREADS"
   MAX_JOBS_SOURCE=manual
 fi
 export CPU_THREADS
+export MEMORY_GB
 export MAX_JOBS
 
 cd "$ROOT"
@@ -847,6 +906,7 @@ check_memory_headroom
 check_disk_headroom
 check_gpu_hardware
 check_gpu_topology
+configure_build_parallelism
 
 if [[ -z "${CUDA_HOME:-}" ]]; then
   if [[ -x /usr/local/cuda-12.8/bin/nvcc ]]; then
@@ -882,6 +942,8 @@ export CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}
 export FLASHINFER_ENABLE_AOT=${FLASHINFER_ENABLE_AOT:-1}
 export VLLM_CUTLASS_SRC_DIR=${VLLM_CUTLASS_SRC_DIR:-$CUTLASS_DIR}
 export TRITON_KERNELS_SRC_DIR=${TRITON_KERNELS_SRC_DIR:-"$TRITON_KERNELS_DIR/python/triton_kernels/triton_kernels"}
+export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:-$MAX_JOBS}
+export NVCC_THREADS=${NVCC_THREADS:-1}
 
 cat <<EOF | tee -a "$LOG"
 
@@ -898,7 +960,10 @@ Build settings:
   TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST
   UV_TORCH_BACKEND=$UV_TORCH_BACKEND
   CPU_THREADS=$CPU_THREADS
+  MEMORY_GB=$MEMORY_GB
   MAX_JOBS=$MAX_JOBS ($MAX_JOBS_SOURCE)
+  CMAKE_BUILD_PARALLEL_LEVEL=$CMAKE_BUILD_PARALLEL_LEVEL
+  NVCC_THREADS=$NVCC_THREADS
   CMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
   VENV=$ROOT/.venv
   Python package mirror fallback=${BUILD_PYPI_MIRROR_FALLBACK:-1}

--- a/setup.py
+++ b/setup.py
@@ -177,8 +177,9 @@ class cmake_build_ext(build_ext):
                 if nvcc_version >= Version("11.2"):
                     # `nvcc_threads` is either the value of the NVCC_THREADS
                     # environment variable (if defined) or 1.
-                    # when it is set, we reduce `num_jobs` to avoid
-                    # overloading the system.
+                    # It should not silently reduce the outer build parallelism:
+                    # `MAX_JOBS` is the actual build fan-out, while
+                    # `NVCC_THREADS` only controls nvcc's internal threading.
                     nvcc_threads = envs.NVCC_THREADS
                     if nvcc_threads is not None:
                         nvcc_threads = int(nvcc_threads)
@@ -188,7 +189,6 @@ class cmake_build_ext(build_ext):
                         )
                     else:
                         nvcc_threads = 1
-                    num_jobs = max(1, num_jobs // nvcc_threads)
             except Exception as e:
                 logger.warning("Failed to get NVCC version: %s", e)
 


### PR DESCRIPTION
## Summary
- Change the build script's default compile parallelism to use half of detected CPU threads.
- Let interactive builds accept a manual build thread count in the valid range 1..CPU_THREADS.
- Propagate the selected value to MAX_JOBS and CMAKE_BUILD_PARALLEL_LEVEL, with NVCC_THREADS fixed to 1.

## Why
High-core-count hosts could previously default to CPU_THREADS-2 build jobs, which can overrun memory during CUDA/C++ extension compilation and make builds fail or hang.

## Test
- bash -n build.sh
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes build parallelism to avoid OOM on high-core machines and hardens the build bootstrap with pinned, validated tools. `MAX_JOBS` now solely controls build fan-out (propagated to `CMAKE_BUILD_PARALLEL_LEVEL`); NVCC stays single-threaded.

- **Bug Fixes**
  - Default compile jobs to half of CPU threads (min 1); validate manual `MAX_JOBS` is 1..CPU_THREADS.
  - Interactive builds can enter a manual thread count; skipped in non-interactive/YES modes.
  - Export `MAX_JOBS` and `CMAKE_BUILD_PARALLEL_LEVEL`; set `NVCC_THREADS=1` and stop scaling jobs by `NVCC_THREADS` in `setup.py`.
  - Detect and log `MEMORY_GB`; validate when set; include in the build summary.

- **Dependencies**
  - Bootstrap venv build tools and validate versions: `pip`, `wheel`, `packaging>=24.2`, `setuptools>=77,<81`, `setuptools-scm>=8`, `cmake>=3.26.1`, `ninja`.
  - Enforce venv `cmake` presence and version; verify `setuptools`/`setuptools-scm` bounds; probe via `importlib.metadata`; re-validate before and after CUDA deps.
  - Require `requirements/build/cuda.txt` and `requirements/cuda.txt` to exist; fail fast if missing.

<sup>Written for commit 41029896abbe6aba8ca2d409b9d55fdfcfc4b558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

