### PR TITLE
Fix custom all-reduce graph input mode on SM75

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -9,12 +9,14 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 import vllm.envs as envs
+from vllm.config import CUDAGraphMode
 from vllm import _custom_ops as ops
 from vllm.distributed.device_communicators.all_reduce_utils import (
     CUSTOM_ALL_REDUCE_MAX_SIZES,
     gpu_p2p_access_check,
 )
 from vllm.distributed.parallel_state import in_the_same_node_as
+from vllm.forward_context import get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
@@ -263,6 +265,30 @@ class CustomAllreduce:
             )
         return out
 
+    def _use_registered_graph_inputs(self) -> bool:
+        graph_input_mode = envs.VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE
+        if graph_input_mode == "registered":
+            return True
+        if graph_input_mode == "staging":
+            return False
+        if graph_input_mode != "auto":
+            raise ValueError(
+                "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE must be one of "
+                f"auto, registered, or staging. Got {graph_input_mode!r}."
+            )
+
+        # Full decode graphs use stable decode-size graph allocations and keep
+        # the fast registered custom-AR path. Piecewise/prefill graphs may use
+        # graph-private large allocations that cannot be exported with CUDA IPC
+        # on SM75, so they go through the pre-registered staging buffer.
+        if not is_forward_context_available():
+            return False
+        try:
+            forward_context = get_forward_context()
+        except AssertionError:
+            return False
+        return forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
+
     def custom_all_reduce(self, input: torch.Tensor) -> torch.Tensor | None:
         """The main allreduce API that provides support for cuda graph."""
         # When custom allreduce is disabled, this will be None.
@@ -270,7 +296,9 @@ class CustomAllreduce:
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                return self.all_reduce(input, registered=True)
+                return self.all_reduce(
+                    input, registered=self._use_registered_graph_inputs()
+                )
             else:
                 # If warm up, mimic the allocation pattern since custom
                 # allreduce is out-of-place.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1087,6 +1087,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # so that vLLM can verify if p2p is actually working.
     # See https://github.com/vllm-project/vllm/blob/a9b15c606fea67a072416ea0ea115261a2756058/vllm/distributed/device_communicators/custom_all_reduce_utils.py#L101-L108 for details. # noqa
     "VLLM_SKIP_P2P_CHECK": lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "1") == "1",
+    # Custom all-reduce graph input handling. "auto" keeps the registered fast
+    # path for FULL decode graphs and uses the pre-registered staging buffer for
+    # PIECEWISE/prefill graphs, where some SM75 graph-private allocations cannot
+    # be exported through CUDA IPC.
+    "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE": lambda: os.getenv(
+        "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE", "auto"
+    ).lower(),
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection


### PR DESCRIPTION
## Summary

This patch fixes the SM75 custom all-reduce graph-input regression exposed by the Qwen3.6 35B A3B FP8 route under `FULL_AND_PIECEWISE` CUDA graph mode.

The failure mode was not in the decode fast path itself. The crash happened when PIECEWISE / mixed prefill-decode graph capture tried to CUDA-IPC register graph input allocations that are not exportable on this runtime, which caused `cudaIpcGetMemHandle(...): invalid argument` during startup.

## Why this matters

From the user side, the service could fail during engine warmup even though the same model and TP setup were otherwise valid. A simple global fallback to staging buffers avoided the crash, but it also threw away the decode-side custom all-reduce fast path and regressed throughput.

## What changed

- Add `VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE=auto|registered|staging`.
- Default `auto` policy:
  - keep registered custom-AR graph inputs for `CUDAGraphMode.FULL` decode graphs
  - use the pre-registered staging buffer for `PIECEWISE` / prefill graph capture
- This preserves the fast decode custom-AR route while avoiding the SM75 PIECEWISE IPC registration failure.

## Validation

Miniclaw dual RTX 2080 Ti / TP=2, official `Qwen/Qwen3.6-35B-A3B-FP8`, custom all-reduce enabled, `FULL_AND_PIECEWISE`, `compile_ranges_endpoints=[4096]`, `cudagraph_capture_sizes=[1]`:

- Before the patch, startup could fail in `custom_all_reduce.cuh:455` with `cudaIpcGetMemHandle invalid argument`.
- After the patch, startup completes successfully and both PIECEWISE and FULL graph capture complete.
- Unified synthetic `PP4096/TG128` (`pure_filler`, repeated `the`) warm repeat3 averaged about:
  - `6883.84 tok/s` prefill
  - `125.11 tok/s` decode

This restores and exceeds the previous no-custom-AR decode lane while keeping the service stable on SM75.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SM75 crashes in mixed prefill/decode CUDA graph capture by auto-selecting registered vs staging inputs for custom all-reduce. Restores the fast decode path while keeping PIECEWISE prefill stable.

- **New Features**
  - Added `VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE=auto|registered|staging`.
  - Default `auto`: keep registered inputs for `CUDAGraphMode.FULL` decode graphs; use pre-registered staging buffers for `PIECEWISE`/prefill capture.

- **Bug Fixes**
  - Avoids CUDA IPC registration of non-exportable graph-private inputs on SM75, which caused `cudaIpcGetMemHandle(...): invalid argument` during warmup.
  - Prevents startup failures under `FULL_AND_PIECEWISE` while preserving the decode custom all-reduce fast path.

<sup>Written for commit 4c3b4e10392ce3508e89ae8205e2905f95eef6ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

