### PR TITLE
feat: add Docker runtime for SM75 vLLM

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,66 @@
+# Version control
+.git
+.github
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.venv/
+venv/
+
+# Build artifacts
+build/
+build-logs/
+dist/
+*.egg
+.deps/
+out/
+
+# Runtime caches
+triton-cache/
+torchinductor-cache/
+logs/
+run-logs/
+build-logs/
+.hf-cache/
+hf-cache/
+backups/
+/models/
+/deployments/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docs (not needed in image)
+docs/
+*.md
+!README.md
+
+# Local deployment/runtime artifacts. Keep deployment source files in git, but
+# never send downloaded models, local caches, venvs, or third-party clones to
+# the Docker build context.
+deployments/**/.env
+deployments/**/.hf-cache/
+deployments/**/hf-cache/
+deployments/**/.venv/
+deployments/**/models/
+deployments/**/repos/
+deployments/**/third_party/
+deployments/**/logs/
+deployments/**/artifacts/
+deployments/**/backups/
+deployments/**/mtp-poc/
+*.gguf
+*.safetensors
+*.bin
+*.pt
+*.pth

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,9 +46,8 @@ ENV PYTHONPATH=/build/FlashQLA-SM70-SM75
 ENV VLLM_CUTLASS_SRC_DIR=/build/.deps/cutlass-src
 ENV TRITON_SRC_DIR=/build/.deps/triton-src
 ENV TRITON_KERNELS_SRC_DIR=/build/.deps/triton-src/python/triton_kernels/triton_kernels
-# Keep Docker's default build fan-out conservative. The repository's compose
-# example already defaults to 4 jobs, and the editable vLLM build can exceed
-# memory budgets on typical dual-2080 Ti hosts when parallelism is left too high.
+# docker/build.sh computes MAX_JOBS with the same host-memory rule as build.sh.
+# Keep the in-Docker fallback conservative for manual docker build invocations.
 ARG MAX_JOBS=4
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CMAKE_BUILD_TYPE=Release
@@ -66,6 +65,8 @@ ARG BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS=
 ARG BUILD_PYPI_MIRROR_INDEX=
 ARG BUILD_PYPI_MIRROR_FALLBACK=1
 ARG BUILD_WHEELHOUSE_DIR=
+ARG BUILD_PYPI_ACTIVE_INDEX=
+ARG BUILD_DOWNLOAD_SELECTED_MODE=
 ARG BUILD_GIT_ACTIVE_PREFIX=
 ARG BUILD_GIT_FOREIGN_REPO_PREFIX=https://gh-proxy.com/
 ARG BUILD_GIT_DOMESTIC_REPO_PREFIX=https://ghfast.top/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,11 +2,11 @@
 # vLLM 2080Ti FlashQLA - Multi-stage Docker Build
 # ============================================================
 # Builder:  nvidia/cuda:12.8.1-devel-ubuntu24.04  (includes nvcc)
-# Runtime:  nvidia/cuda:12.8.1-runtime-ubuntu24.04 (smaller)
+# Runtime:  nvidia/cuda:12.8.1-devel-ubuntu24.04  (keeps nvcc for FlashQLA JIT)
 # ============================================================
 
 # --------------- Builder stage ---------------
-FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS builder
+FROM docker.io/nvidia/cuda:12.8.1-devel-ubuntu24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_HOME=/usr/local/cuda
@@ -35,12 +35,17 @@ WORKDIR /build
 # Copy dependency metadata before source code so package-install layers remain
 # cacheable when only application source changes.
 COPY requirements requirements
+COPY docker/build_network_routes.sh docker/fetch_git_with_mirrors.sh docker/uv_pip_with_fallback.sh docker/
 
 # Build environment variables
 ENV TORCH_CUDA_ARCH_LIST=7.5
+ENV UV_TORCH_BACKEND=cu128
 ENV FLASHINFER_ENABLE_AOT=1
 ENV FLASHQLA_DIR=/build/FlashQLA-SM70-SM75
 ENV PYTHONPATH=/build/FlashQLA-SM70-SM75
+ENV VLLM_CUTLASS_SRC_DIR=/build/.deps/cutlass-src
+ENV TRITON_SRC_DIR=/build/.deps/triton-src
+ENV TRITON_KERNELS_SRC_DIR=/build/.deps/triton-src/python/triton_kernels/triton_kernels
 # Use all available CPU cores for parallel compilation (max 16 to avoid OOM)
 # GitHub Actions has 2-4 cores, local machines may have more
 ARG MAX_JOBS=16
@@ -50,43 +55,69 @@ ENV TORCH_EXTENSIONS_DIR=/opt/torch_extensions_cache
 ENV VLLM_TARGET_DEVICE=cuda
 ARG FLASHQLA_REPO=https://github.com/weicj/FlashQLA-SM70-SM75.git
 ARG FLASHQLA_REF=3ab27d77d8ca01d7a4718903b726add1a8886c0e
+ARG BUILD_NETWORK_PREFLIGHT=1
+ARG BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS=5
+ARG BUILD_PYPI_OFFICIAL_INDEX=https://pypi.org/simple
+ARG BUILD_PYPI_FOREIGN_INDEX=https://pypi.python.org/simple
+ARG BUILD_PYPI_DOMESTIC_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
+ARG BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS=60
+ARG BUILD_PYPI_MIRROR_INDEX=
+ARG BUILD_PYPI_MIRROR_FALLBACK=1
+ARG BUILD_WHEELHOUSE_DIR=
+ARG BUILD_GIT_ACTIVE_PREFIX=
+ARG BUILD_GIT_FOREIGN_REPO_PREFIX=https://gh-proxy.com/
+ARG BUILD_GIT_DOMESTIC_REPO_PREFIX=https://ghfast.top/
+ARG BUILD_GIT_OFFICIAL_PROBE=
+ARG BUILD_GIT_FOREIGN_PROBE=
+ARG BUILD_GIT_DOMESTIC_PROBE=
+ARG BUILD_GIT_PRIMARY_TIMEOUT_SECONDS=120
+ARG BUILD_GIT_MIRROR_PREFIXES=
+ARG CUTLASS_REPO=https://github.com/nvidia/cutlass.git
+ARG CUTLASS_REVISION=v4.4.2
+ARG TRITON_REPO=https://github.com/triton-lang/triton.git
+ARG TRITON_TAG=v3.6.0
 
 # Create venv and install deps
 RUN uv venv --python 3.11 /build/.venv
 ENV PATH="/build/.venv/bin:${PATH}"
 
-RUN uv pip install -U pip setuptools wheel
-RUN uv pip install -r requirements/build/cuda.txt --torch-backend=cu128
-RUN uv pip install -r requirements/cuda.txt --torch-backend=cu128
+RUN bash docker/uv_pip_with_fallback.sh install -U pip setuptools wheel
+RUN bash docker/uv_pip_with_fallback.sh install -r requirements/build/cuda.txt
+RUN bash docker/uv_pip_with_fallback.sh install -r requirements/cuda.txt
 
 # Copy source code after dependency installation to preserve Docker layer cache.
 COPY . .
 
 # FlashQLA is fetched during Docker builds so the image does not depend on
-# callers cloning this repository with submodules.
-RUN git init "$FLASHQLA_DIR" \
-    && git -C "$FLASHQLA_DIR" remote add origin "$FLASHQLA_REPO" \
-    && git -C "$FLASHQLA_DIR" fetch --depth=1 origin "$FLASHQLA_REF" \
-    && git -C "$FLASHQLA_DIR" checkout -q FETCH_HEAD
+# callers cloning this repository with submodules. Reuse the repository's
+# Git mirror fallback chain for environments where direct GitHub access is weak.
+RUN bash docker/fetch_git_with_mirrors.sh \
+    --repo "$FLASHQLA_REPO" \
+    --target "$FLASHQLA_DIR" \
+    --mode commit \
+    --ref "$FLASHQLA_REF"
 RUN test -f "$FLASHQLA_DIR/flash_qla/ops/gated_delta_rule/legacy/sm_legacy.py"
 RUN python tools/patch_flashqla_sm75_imports.py "$FLASHQLA_DIR" tools/flashqla_sm75_patches
-RUN uv pip install --no-deps -e "$FLASHQLA_DIR"
-RUN python - <<'PY'
-import importlib
+RUN bash docker/uv_pip_with_fallback.sh install --no-deps -e "$FLASHQLA_DIR"
+RUN python -c 'import importlib; import flash_qla; legacy = importlib.import_module("flash_qla.ops.gated_delta_rule.legacy.sm_legacy"); assert legacy is not None, "FlashQLA legacy module import failed"; print(f"flash_qla={flash_qla.__file__}"); print(f"flash_qla_legacy={legacy.__file__}")'
 
-import flash_qla
-
-legacy = importlib.import_module("flash_qla.ops.gated_delta_rule.legacy.sm_legacy")
-if legacy is None:
-    raise SystemExit("FlashQLA legacy module import failed")
-print(f"flash_qla={flash_qla.__file__}")
-print(f"flash_qla_legacy={legacy.__file__}")
-PY
+# Pre-fetch build-time Git dependencies so editable vLLM install stays on the
+# same mirror/fallback policy as the main build.sh path.
+RUN bash docker/fetch_git_with_mirrors.sh \
+    --repo "$CUTLASS_REPO" \
+    --target "$VLLM_CUTLASS_SRC_DIR" \
+    --mode ref \
+    --ref "$CUTLASS_REVISION"
+RUN bash docker/fetch_git_with_mirrors.sh \
+    --repo "$TRITON_REPO" \
+    --target "$TRITON_SRC_DIR" \
+    --mode ref \
+    --ref "$TRITON_TAG"
 
 # Build vLLM (editable install so __file__ resolves correctly)
 # SETUPTOOLS_SCM_PRETEND_VERSION needed because .git is excluded by .dockerignore
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.12
-RUN uv pip install --no-build-isolation -e .
+RUN uv pip install --no-build-isolation --no-deps -e .
 
 # Fix editable install paths: /build -> /opt/vllm (for runtime stage)
 RUN SITE=$(/build/.venv/bin/python -c "import site; print(site.getsitepackages()[0])") && \
@@ -96,7 +127,7 @@ RUN SITE=$(/build/.venv/bin/python -c "import site; print(site.getsitepackages()
 
 # --------------- Runtime stage ---------------
 # Must use devel image for FlashQLA CUDA kernel compilation (requires nvcc)
-FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS runtime
+FROM docker.io/nvidia/cuda:12.8.1-devel-ubuntu24.04 AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CUDA_HOME=/usr/local/cuda

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,20 +24,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential cmake ninja-build \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (fast Python package manager)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.local/bin:${PATH}"
+# Install a pinned uv from PyPI instead of executing a remote installer script.
+ARG UV_VERSION=0.5.31
+RUN python3.11 -m venv /opt/uv-bootstrap \
+    && /opt/uv-bootstrap/bin/pip install --no-cache-dir "uv==${UV_VERSION}" \
+    && ln -sf /opt/uv-bootstrap/bin/uv /usr/local/bin/uv
 
 WORKDIR /build
 
-# Copy source code
-COPY . .
+# Copy dependency metadata before source code so package-install layers remain
+# cacheable when only application source changes.
+COPY requirements requirements
 
 # Build environment variables
 ENV TORCH_CUDA_ARCH_LIST=7.5
 ENV FLASHINFER_ENABLE_AOT=1
 ENV FLASHQLA_DIR=/build/FlashQLA-SM70-SM75
-ENV PYTHONPATH="/build/FlashQLA-SM70-SM75:${PYTHONPATH}"
+ENV PYTHONPATH=/build/FlashQLA-SM70-SM75
 # Use all available CPU cores for parallel compilation (max 16 to avoid OOM)
 # GitHub Actions has 2-4 cores, local machines may have more
 ARG MAX_JOBS=16
@@ -55,6 +58,9 @@ ENV PATH="/build/.venv/bin:${PATH}"
 RUN uv pip install -U pip setuptools wheel
 RUN uv pip install -r requirements/build/cuda.txt --torch-backend=cu128
 RUN uv pip install -r requirements/cuda.txt --torch-backend=cu128
+
+# Copy source code after dependency installation to preserve Docker layer cache.
+COPY . .
 
 # FlashQLA is fetched during Docker builds so the image does not depend on
 # callers cloning this repository with submodules.
@@ -100,15 +106,17 @@ ENV PATH="/usr/local/cuda/bin:${PATH}"
 
 # Install runtime dependencies (Python 3.11 via deadsnakes PPA)
 # python3.11-dev needed for FlashQLA CUDA kernel compilation (Python.h)
-# libcuda stub needed for Triton compilation at runtime
+# CUDA stubs are exposed through LIBRARY_PATH for runtime kernel compilation.
+# Do not put the stub on the runtime linker path; NVIDIA's injected driver
+# libcuda.so.1 must win when GPUs are mounted.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa -y \
     && apt-get update && apt-get install -y --no-install-recommends \
         python3.11 python3.11-venv python3.11-dev libpython3.11 \
         curl build-essential ninja-build \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1
+    && rm -rf /var/lib/apt/lists/*
+ENV LIBRARY_PATH=/usr/local/cuda/lib64/stubs
 
 # Copy Python environment (with fixed editable paths)
 COPY --from=builder /build/.venv /opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,150 @@
+# ============================================================
+# vLLM 2080Ti FlashQLA - Multi-stage Docker Build
+# ============================================================
+# Builder:  nvidia/cuda:12.8.1-devel-ubuntu24.04  (includes nvcc)
+# Runtime:  nvidia/cuda:12.8.1-runtime-ubuntu24.04 (smaller)
+# ============================================================
+
+# --------------- Builder stage ---------------
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+
+# Install system dependencies (Python 3.11 via deadsnakes PPA on Ubuntu 24.04)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 python3.11-venv python3.11-dev \
+        git curl wget \
+        build-essential cmake ninja-build \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (fast Python package manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /build
+
+# Copy source code
+COPY . .
+
+# Build environment variables
+ENV TORCH_CUDA_ARCH_LIST=7.5
+ENV FLASHINFER_ENABLE_AOT=1
+ENV FLASHQLA_DIR=/build/FlashQLA-SM70-SM75
+ENV PYTHONPATH="/build/FlashQLA-SM70-SM75:${PYTHONPATH}"
+# Use all available CPU cores for parallel compilation (max 16 to avoid OOM)
+# GitHub Actions has 2-4 cores, local machines may have more
+ARG MAX_JOBS=16
+ENV MAX_JOBS=${MAX_JOBS}
+ENV CMAKE_BUILD_TYPE=Release
+ENV TORCH_EXTENSIONS_DIR=/opt/torch_extensions_cache
+ENV VLLM_TARGET_DEVICE=cuda
+ARG FLASHQLA_REPO=https://github.com/weicj/FlashQLA-SM70-SM75.git
+ARG FLASHQLA_REF=3ab27d77d8ca01d7a4718903b726add1a8886c0e
+
+# Create venv and install deps
+RUN uv venv --python 3.11 /build/.venv
+ENV PATH="/build/.venv/bin:${PATH}"
+
+RUN uv pip install -U pip setuptools wheel
+RUN uv pip install -r requirements/build/cuda.txt --torch-backend=cu128
+RUN uv pip install -r requirements/cuda.txt --torch-backend=cu128
+
+# FlashQLA is fetched during Docker builds so the image does not depend on
+# callers cloning this repository with submodules.
+RUN git init "$FLASHQLA_DIR" \
+    && git -C "$FLASHQLA_DIR" remote add origin "$FLASHQLA_REPO" \
+    && git -C "$FLASHQLA_DIR" fetch --depth=1 origin "$FLASHQLA_REF" \
+    && git -C "$FLASHQLA_DIR" checkout -q FETCH_HEAD
+RUN test -f "$FLASHQLA_DIR/flash_qla/ops/gated_delta_rule/legacy/sm_legacy.py"
+RUN python tools/patch_flashqla_sm75_imports.py "$FLASHQLA_DIR" tools/flashqla_sm75_patches
+RUN uv pip install --no-deps -e "$FLASHQLA_DIR"
+RUN python - <<'PY'
+import importlib
+
+import flash_qla
+
+legacy = importlib.import_module("flash_qla.ops.gated_delta_rule.legacy.sm_legacy")
+if legacy is None:
+    raise SystemExit("FlashQLA legacy module import failed")
+print(f"flash_qla={flash_qla.__file__}")
+print(f"flash_qla_legacy={legacy.__file__}")
+PY
+
+# Build vLLM (editable install so __file__ resolves correctly)
+# SETUPTOOLS_SCM_PRETEND_VERSION needed because .git is excluded by .dockerignore
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=0.1.12
+RUN uv pip install --no-build-isolation -e .
+
+# Fix editable install paths: /build -> /opt/vllm (for runtime stage)
+RUN SITE=$(/build/.venv/bin/python -c "import site; print(site.getsitepackages()[0])") && \
+    for f in "$SITE"/__editable__*finder*.py; do \
+        [ -f "$f" ] && sed -i 's|/build|/opt/vllm|g' "$f"; \
+    done
+
+# --------------- Runtime stage ---------------
+# Must use devel image for FlashQLA CUDA kernel compilation (requires nvcc)
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDACXX=/usr/local/cuda/bin/nvcc
+ENV PATH="/usr/local/cuda/bin:${PATH}"
+
+# Install runtime dependencies (Python 3.11 via deadsnakes PPA)
+# python3.11-dev needed for FlashQLA CUDA kernel compilation (Python.h)
+# libcuda stub needed for Triton compilation at runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        python3.11 python3.11-venv python3.11-dev libpython3.11 \
+        curl build-essential ninja-build \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/x86_64-linux-gnu/libcuda.so.1
+
+# Copy Python environment (with fixed editable paths)
+COPY --from=builder /build/.venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+# Copy only necessary source files (not build cache)
+COPY --from=builder /build/vllm /opt/vllm/vllm
+COPY --from=builder /build/csrc /opt/vllm/csrc
+COPY --from=builder /build/FlashQLA-SM70-SM75 /opt/vllm/FlashQLA-SM70-SM75
+COPY --from=builder /build/profiles /opt/vllm/profiles
+COPY --from=builder /build/launcher.sh /opt/vllm/
+COPY --from=builder /build/PROJECT_RELEASE.env /opt/vllm/
+COPY --from=builder /build/VERSION /opt/vllm/
+COPY --from=builder /build/setup.py /opt/vllm/
+COPY --from=builder /build/pyproject.toml /opt/vllm/
+COPY --from=builder /build/CMakeLists.txt /opt/vllm/
+COPY docker/docker-entrypoint.sh /opt/vllm/docker/docker-entrypoint.sh
+COPY docker/chat_template_no_thinking.jinja /opt/vllm/docker/chat_template_no_thinking.jinja
+
+RUN ln -s /opt/venv /opt/vllm/.venv \
+    && chmod +x /opt/vllm/launcher.sh /opt/vllm/docker/docker-entrypoint.sh
+
+WORKDIR /opt/vllm
+
+# Runtime environment
+ENV TORCH_CUDA_ARCH_LIST=7.5
+ENV FLASHINFER_ENABLE_AOT=1
+ENV FLASHQLA_DIR=/opt/vllm/FlashQLA-SM70-SM75
+ENV TORCH_EXTENSIONS_DIR=/tmp/torch_extensions_cache
+ENV PYTHONPATH="/opt/vllm:/opt/vllm/FlashQLA-SM70-SM75"
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=300s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+ENTRYPOINT ["/opt/vllm/docker/docker-entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,6 +61,7 @@ ARG BUILD_PYPI_OFFICIAL_INDEX=https://pypi.org/simple
 ARG BUILD_PYPI_FOREIGN_INDEX=https://pypi.python.org/simple
 ARG BUILD_PYPI_DOMESTIC_INDEX=https://pypi.tuna.tsinghua.edu.cn/simple
 ARG BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS=60
+ARG BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS=
 ARG BUILD_PYPI_MIRROR_INDEX=
 ARG BUILD_PYPI_MIRROR_FALLBACK=1
 ARG BUILD_WHEELHOUSE_DIR=
@@ -73,9 +74,11 @@ ARG BUILD_GIT_DOMESTIC_PROBE=
 ARG BUILD_GIT_PRIMARY_TIMEOUT_SECONDS=120
 ARG BUILD_GIT_MIRROR_PREFIXES=
 ARG CUTLASS_REPO=https://github.com/nvidia/cutlass.git
-ARG CUTLASS_REVISION=v4.4.2
+# Pin the exact source tree currently used for the v4.4.2 Docker build.
+ARG CUTLASS_REVISION=da5e086dab31d63815acafdac9a9c5893b1c69e2
 ARG TRITON_REPO=https://github.com/triton-lang/triton.git
-ARG TRITON_TAG=v3.6.0
+# Pin the exact source tree currently used for the v3.6.0 Docker build.
+ARG TRITON_TAG=7c56a5e40f7fd928dfd5c72902d5def0097db73a
 
 # Create venv and install deps
 RUN uv venv --python 3.11 /build/.venv
@@ -106,12 +109,12 @@ RUN python -c 'import importlib; import flash_qla; legacy = importlib.import_mod
 RUN bash docker/fetch_git_with_mirrors.sh \
     --repo "$CUTLASS_REPO" \
     --target "$VLLM_CUTLASS_SRC_DIR" \
-    --mode ref \
+    --mode commit \
     --ref "$CUTLASS_REVISION"
 RUN bash docker/fetch_git_with_mirrors.sh \
     --repo "$TRITON_REPO" \
     --target "$TRITON_SRC_DIR" \
-    --mode ref \
+    --mode commit \
     --ref "$TRITON_TAG"
 
 # Build vLLM (editable install so __file__ resolves correctly)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,9 +46,10 @@ ENV PYTHONPATH=/build/FlashQLA-SM70-SM75
 ENV VLLM_CUTLASS_SRC_DIR=/build/.deps/cutlass-src
 ENV TRITON_SRC_DIR=/build/.deps/triton-src
 ENV TRITON_KERNELS_SRC_DIR=/build/.deps/triton-src/python/triton_kernels/triton_kernels
-# Use all available CPU cores for parallel compilation (max 16 to avoid OOM)
-# GitHub Actions has 2-4 cores, local machines may have more
-ARG MAX_JOBS=16
+# Keep Docker's default build fan-out conservative. The repository's compose
+# example already defaults to 4 jobs, and the editable vLLM build can exceed
+# memory budgets on typical dual-2080 Ti hosts when parallelism is left too high.
+ARG MAX_JOBS=4
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CMAKE_BUILD_TYPE=Release
 ENV TORCH_EXTENSIONS_DIR=/opt/torch_extensions_cache

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,504 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+PROJECT_RELEASE_FILE=${PROJECT_RELEASE_FILE:-"$ROOT_DIR/PROJECT_RELEASE.env"}
+if [[ -f "$PROJECT_RELEASE_FILE" ]]; then
+  # shellcheck source=/dev/null
+  source "$PROJECT_RELEASE_FILE"
+fi
+
+COMPOSE_FILE=${COMPOSE_FILE:-"$ROOT_DIR/docker/docker-compose.yml"}
+DOCKERFILE=${DOCKERFILE:-"$ROOT_DIR/docker/Dockerfile"}
+COMPOSE_SERVICE=${COMPOSE_SERVICE:-vllm}
+VLLM_IMAGE=${VLLM_IMAGE:-local/vllm-2080ti-definitive:v${FORK_RELEASE#v}}
+
+FLASHQLA_REPO=${FLASHQLA_REPO:-https://github.com/weicj/FlashQLA-SM70-SM75.git}
+FLASHQLA_REF=${FLASHQLA_REF:-3ab27d77d8ca01d7a4718903b726add1a8886c0e}
+BUILD_PYPI_OFFICIAL_INDEX=${BUILD_PYPI_OFFICIAL_INDEX:-https://pypi.org/simple}
+BUILD_PYPI_FOREIGN_INDEX=${BUILD_PYPI_FOREIGN_INDEX:-https://pypi.python.org/simple}
+BUILD_PYPI_DOMESTIC_INDEX=${BUILD_PYPI_DOMESTIC_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}
+BUILD_GIT_FOREIGN_REPO_PREFIX=${BUILD_GIT_FOREIGN_REPO_PREFIX:-https://gh-proxy.com/}
+BUILD_GIT_DOMESTIC_REPO_PREFIX=${BUILD_GIT_DOMESTIC_REPO_PREFIX:-https://ghfast.top/}
+BUILD_GIT_OFFICIAL_PROBE=${BUILD_GIT_OFFICIAL_PROBE:-${FLASHQLA_REPO}/info/refs?service=git-upload-pack}
+BUILD_GIT_FOREIGN_PROBE=${BUILD_GIT_FOREIGN_PROBE:-${BUILD_GIT_FOREIGN_REPO_PREFIX}${BUILD_GIT_OFFICIAL_PROBE}}
+BUILD_GIT_DOMESTIC_PROBE=${BUILD_GIT_DOMESTIC_PROBE:-${BUILD_GIT_DOMESTIC_REPO_PREFIX}${BUILD_GIT_OFFICIAL_PROBE}}
+BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS=${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
+BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS=${BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS:-60}
+BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS=${BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS:-$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS}
+BUILD_PYPI_MIRROR_INDEX=${BUILD_PYPI_MIRROR_INDEX:-$BUILD_PYPI_DOMESTIC_INDEX}
+BUILD_PYPI_MIRROR_FALLBACK=${BUILD_PYPI_MIRROR_FALLBACK:-1}
+BUILD_WHEELHOUSE_DIR=${BUILD_WHEELHOUSE_DIR:-}
+BUILD_NETWORK_PREFLIGHT=${BUILD_NETWORK_PREFLIGHT:-1}
+BUILD_GIT_PRIMARY_TIMEOUT_SECONDS=${BUILD_GIT_PRIMARY_TIMEOUT_SECONDS:-120}
+BUILD_GIT_MIRROR_PREFIXES=${BUILD_GIT_MIRROR_PREFIXES:-https://gh-proxy.com/ https://ghfast.top/}
+CUTLASS_REPO=${CUTLASS_REPO:-https://github.com/nvidia/cutlass.git}
+CUTLASS_REVISION=${CUTLASS_REVISION:-da5e086dab31d63815acafdac9a9c5893b1c69e2}
+TRITON_REPO=${TRITON_REPO:-https://github.com/triton-lang/triton.git}
+TRITON_TAG=${TRITON_TAG:-7c56a5e40f7fd928dfd5c72902d5def0097db73a}
+
+ACTION=docker
+DRY_RUN=0
+declare -a EXTRA_ARGS=()
+
+usage() {
+  cat <<'EOF'
+usage:
+  docker/build.sh [docker] [--dry-run] [extra docker build args...]
+  docker/build.sh compose [--dry-run] [extra docker compose build args...]
+  docker/build.sh env
+
+examples:
+  ./docker/build.sh
+  ./docker/build.sh --dry-run --progress=plain
+  ./docker/build.sh compose --dry-run --no-cache
+  ./docker/build.sh env
+EOF
+}
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+detect_cpu_threads() {
+  local threads
+  threads=$(getconf _NPROCESSORS_ONLN 2>/dev/null || true)
+  if ! is_positive_integer "$threads"; then
+    threads=$(nproc 2>/dev/null || true)
+  fi
+  if ! is_positive_integer "$threads"; then
+    threads=4
+  fi
+  printf '%s\n' "$threads"
+}
+
+detect_memory_gb() {
+  local mem_kb mem_gb
+  mem_kb=$(awk '/MemTotal:/ { print $2 }' /proc/meminfo 2>/dev/null || echo 0)
+  mem_gb=$(( mem_kb / 1024 / 1024 ))
+  if (( mem_gb < 1 )); then
+    mem_gb=1
+  fi
+  printf '%s\n' "$mem_gb"
+}
+
+select_max_jobs() {
+  local threads=$1
+  local mem_gb=$2
+  local reserve_gb=3
+  local per_job_gb=3
+  local mem_limited_jobs
+
+  mem_limited_jobs=$(( (mem_gb - reserve_gb) / per_job_gb ))
+  (( mem_limited_jobs >= 1 )) || mem_limited_jobs=1
+  (( mem_limited_jobs <= threads )) || mem_limited_jobs=$threads
+
+  printf '%s\n' "$mem_limited_jobs"
+}
+
+validate_max_jobs_range() {
+  local jobs=$1
+  local threads=$2
+  is_positive_integer "$jobs" || fail "MAX_JOBS must be a positive integer."
+  if (( jobs < 1 || jobs > threads )); then
+    fail "MAX_JOBS must be between 1 and CPU_THREADS ($threads)."
+  fi
+}
+
+measure_network_url_ms() {
+  local url=$1
+  local timeout_seconds=${2:-6}
+  local start end elapsed
+
+  start=$(date +%s%3N)
+  if command -v curl >/dev/null 2>&1; then
+    curl -L --max-time "$timeout_seconds" --connect-timeout "$timeout_seconds" \
+      --fail --silent --show-error --output /dev/null "$url" >/dev/null 2>&1 || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --timeout="$timeout_seconds" -O /dev/null "$url" >/dev/null 2>&1 || return 1
+  else
+    return 1
+  fi
+
+  end=$(date +%s%3N)
+  elapsed=$((end - start))
+  (( elapsed > 0 )) || elapsed=1
+  printf '%s\n' "$elapsed"
+}
+
+pypi_probe_url() {
+  local index_url=$1
+  printf '%s/\n' "${index_url%/}"
+}
+
+probe_download_route() {
+  local mode=$1
+  local pypi_url=$2
+  local git_url=$3
+  local timeout_seconds=${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
+  local pypi_probe pypi_ms git_ms total_ms
+
+  pypi_probe=$(pypi_probe_url "$pypi_url")
+  if ! pypi_ms=$(measure_network_url_ms "$pypi_probe" "$timeout_seconds"); then
+    printf 'Preflight: %-8s unavailable at Python index %s\n' "$mode" "$pypi_probe" >&2
+    return 1
+  fi
+  if ! git_ms=$(measure_network_url_ms "$git_url" "$timeout_seconds"); then
+    printf 'Preflight: %-8s unavailable at Git probe %s\n' "$mode" "$git_url" >&2
+    return 1
+  fi
+
+  total_ms=$((pypi_ms + git_ms))
+  printf 'Preflight: %-8s route %5sms total  PyPI=%sms  Git=%sms\n' \
+    "$mode" "$total_ms" "$pypi_ms" "$git_ms" >&2
+  printf '%s\t%s\t%s\t%s\n' "$total_ms" "$mode" "$pypi_ms" "$git_ms"
+}
+
+prompt_yes_no_timeout() {
+  local prompt=$1
+  local timeout_seconds=${2:-10}
+  local default_answer=${3:-y}
+  local answer=""
+
+  if [[ "${ASSUME_YES:-0}" == "1" || "${YES:-0}" == "1" ]]; then
+    printf '%s\n' "$default_answer"
+    return 0
+  fi
+  if [[ ! -t 0 ]]; then
+    printf '%s\n' "$default_answer"
+    return 0
+  fi
+
+  if [[ "$default_answer" == "y" ]]; then
+    printf '%s ' "$prompt"
+    if ! read -r -t "$timeout_seconds" answer; then
+      answer=""
+    fi
+    case "$answer" in
+      n|N) printf 'n\n' ;;
+      *) printf 'y\n' ;;
+    esac
+    return 0
+  fi
+
+  printf '%s ' "$prompt"
+  if ! read -r -t "$timeout_seconds" answer; then
+    answer=""
+  fi
+  case "$answer" in
+    y|Y) printf 'y\n' ;;
+    *) printf 'n\n' ;;
+  esac
+}
+
+infer_selected_mode() {
+  if [[ "${BUILD_PYPI_ACTIVE_INDEX:-}" == "$BUILD_PYPI_FOREIGN_INDEX" || \
+        "${BUILD_GIT_ACTIVE_PREFIX:-}" == "$BUILD_GIT_FOREIGN_REPO_PREFIX" ]]; then
+    printf '%s\n' "foreign"
+  elif [[ "${BUILD_PYPI_ACTIVE_INDEX:-}" == "$BUILD_PYPI_DOMESTIC_INDEX" || \
+          "${BUILD_GIT_ACTIVE_PREFIX:-}" == "$BUILD_GIT_DOMESTIC_REPO_PREFIX" ]]; then
+    printf '%s\n' "domestic"
+  elif [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" || -n "${BUILD_GIT_ACTIVE_PREFIX:-}" ]]; then
+    printf '%s\n' "custom"
+  else
+    printf '%s\n' "official"
+  fi
+}
+
+choose_download_mode() {
+  local measurements=()
+  local line selected_line selected_mode selected_total selected_pypi selected_git
+  local probe_tmp
+  local -a probe_jobs=()
+  local item pid mode answer
+
+  if [[ "${BUILD_NETWORK_PREFLIGHT:-1}" != "1" ]]; then
+    BUILD_DOWNLOAD_SELECTED_MODE=${BUILD_DOWNLOAD_SELECTED_MODE:-$(infer_selected_mode)}
+    return 0
+  fi
+
+  if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" || -n "${BUILD_GIT_ACTIVE_PREFIX:-}" ]]; then
+    BUILD_DOWNLOAD_SELECTED_MODE=${BUILD_DOWNLOAD_SELECTED_MODE:-$(infer_selected_mode)}
+    echo "Preflight: using preselected ${BUILD_DOWNLOAD_SELECTED_MODE} download route."
+    return 0
+  fi
+
+  echo "Preflight: benchmarking download routes..."
+  echo "Preflight: sample timeout is ${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS}s per URL probe."
+  if ! is_positive_integer "$BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS"; then
+    fail "BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS must be a positive integer."
+  fi
+
+  probe_tmp=$(mktemp -d)
+  probe_download_route official "$BUILD_PYPI_OFFICIAL_INDEX" "$BUILD_GIT_OFFICIAL_PROBE" \
+    >"$probe_tmp/official.out" 2>"$probe_tmp/official.err" &
+  probe_jobs+=("$!:official")
+  probe_download_route foreign "$BUILD_PYPI_FOREIGN_INDEX" "$BUILD_GIT_FOREIGN_PROBE" \
+    >"$probe_tmp/foreign.out" 2>"$probe_tmp/foreign.err" &
+  probe_jobs+=("$!:foreign")
+  probe_download_route domestic "$BUILD_PYPI_DOMESTIC_INDEX" "$BUILD_GIT_DOMESTIC_PROBE" \
+    >"$probe_tmp/domestic.out" 2>"$probe_tmp/domestic.err" &
+  probe_jobs+=("$!:domestic")
+
+  for item in "${probe_jobs[@]}"; do
+    pid=${item%%:*}
+    wait "$pid" || true
+  done
+
+  for mode in official foreign domestic; do
+    [[ ! -s "$probe_tmp/$mode.err" ]] || cat "$probe_tmp/$mode.err" >&2
+    if [[ -s "$probe_tmp/$mode.out" ]]; then
+      line=$(head -n 1 "$probe_tmp/$mode.out")
+      measurements+=("$line")
+    fi
+  done
+  rm -rf "$probe_tmp"
+
+  selected_mode=official
+  selected_total=unknown
+  selected_pypi=unknown
+  selected_git=unknown
+
+  if ((${#measurements[@]} == 0)); then
+    echo "Preflight: network looks poor; no download route is currently reachable."
+    answer=$(prompt_yes_no_timeout "Continue anyway? [y/N]:" 10 n)
+    [[ "$answer" == "y" ]] || fail "Docker build cancelled because network preflight failed."
+    BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_OFFICIAL_INDEX
+    BUILD_GIT_ACTIVE_PREFIX=
+  else
+    selected_line=$(printf '%s\n' "${measurements[@]}" | sort -n -k1,1 | head -n 1)
+    selected_mode=$(printf '%s\n' "$selected_line" | awk -F '\t' '{print $2}')
+    selected_total=$(printf '%s\n' "$selected_line" | awk -F '\t' '{print $1}')
+    selected_pypi=$(printf '%s\n' "$selected_line" | awk -F '\t' '{print $3}')
+    selected_git=$(printf '%s\n' "$selected_line" | awk -F '\t' '{print $4}')
+
+    case "$selected_mode" in
+      official)
+        BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_OFFICIAL_INDEX
+        BUILD_GIT_ACTIVE_PREFIX=
+        ;;
+      foreign)
+        BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_FOREIGN_INDEX
+        BUILD_GIT_ACTIVE_PREFIX=$BUILD_GIT_FOREIGN_REPO_PREFIX
+        answer=$(prompt_yes_no_timeout "Continue with mirror route? [Y/n]:" 10 y)
+        [[ "$answer" != "n" ]] || fail "Docker build cancelled by user."
+        ;;
+      domestic)
+        BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_DOMESTIC_INDEX
+        BUILD_GIT_ACTIVE_PREFIX=$BUILD_GIT_DOMESTIC_REPO_PREFIX
+        answer=$(prompt_yes_no_timeout "Continue with domestic mirror route? [Y/n]:" 10 y)
+        [[ "$answer" != "n" ]] || fail "Docker build cancelled by user."
+        ;;
+    esac
+  fi
+
+  BUILD_DOWNLOAD_SELECTED_MODE=$selected_mode
+  export BUILD_PYPI_ACTIVE_INDEX BUILD_GIT_ACTIVE_PREFIX BUILD_DOWNLOAD_SELECTED_MODE
+  echo "Preflight: selected ${BUILD_DOWNLOAD_SELECTED_MODE} download route (${selected_total}ms sample total; PyPI=${selected_pypi}ms; Git=${selected_git}ms)."
+}
+
+configure_build_parallelism() {
+  CPU_THREADS=${CPU_THREADS:-$(detect_cpu_threads)}
+  MEMORY_GB=${MEMORY_GB:-$(detect_memory_gb)}
+
+  is_positive_integer "$CPU_THREADS" || fail "CPU_THREADS must be a positive integer when set explicitly."
+  is_positive_integer "$MEMORY_GB" || fail "MEMORY_GB must be a positive integer when set explicitly."
+
+  if [[ -n "${BUILD_MAX_JOBS:-}" && -n "${MAX_JOBS:-}" && "${BUILD_MAX_JOBS}" != "${MAX_JOBS}" ]]; then
+    fail "BUILD_MAX_JOBS and MAX_JOBS must match when both are set."
+  fi
+
+  if [[ -n "${BUILD_MAX_JOBS:-}" ]]; then
+    MAX_JOBS=$BUILD_MAX_JOBS
+    MAX_JOBS_SOURCE=env:BUILD_MAX_JOBS
+  elif [[ -n "${MAX_JOBS:-}" ]]; then
+    MAX_JOBS_SOURCE=env:MAX_JOBS
+  else
+    MAX_JOBS=$(select_max_jobs "$CPU_THREADS" "$MEMORY_GB")
+    if (( MAX_JOBS < CPU_THREADS )); then
+      MAX_JOBS_SOURCE=auto-memory
+    else
+      MAX_JOBS_SOURCE=auto
+    fi
+  fi
+
+  validate_max_jobs_range "$MAX_JOBS" "$CPU_THREADS"
+  BUILD_MAX_JOBS=${BUILD_MAX_JOBS:-$MAX_JOBS}
+  export CPU_THREADS MEMORY_GB MAX_JOBS BUILD_MAX_JOBS MAX_JOBS_SOURCE
+}
+
+print_summary() {
+  cat <<EOF
+Docker build settings:
+  Root: $ROOT_DIR
+  Compose file: $COMPOSE_FILE
+  Dockerfile: $DOCKERFILE
+  Image: $VLLM_IMAGE
+  CPU_THREADS: $CPU_THREADS
+  MEMORY_GB: $MEMORY_GB
+  MAX_JOBS: $MAX_JOBS ($MAX_JOBS_SOURCE)
+  BUILD_MAX_JOBS: $BUILD_MAX_JOBS
+  Route: ${BUILD_DOWNLOAD_SELECTED_MODE:-$(infer_selected_mode)}
+  BUILD_PYPI_ACTIVE_INDEX: ${BUILD_PYPI_ACTIVE_INDEX:-$BUILD_PYPI_OFFICIAL_INDEX}
+  BUILD_GIT_ACTIVE_PREFIX: ${BUILD_GIT_ACTIVE_PREFIX:-<official>}
+  BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS: $BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS
+  BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS: $BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS
+  BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS: $BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS
+  BUILD_GIT_PRIMARY_TIMEOUT_SECONDS: $BUILD_GIT_PRIMARY_TIMEOUT_SECONDS
+EOF
+}
+
+print_cmd() {
+  printf 'Command:'
+  printf ' %q' "$@"
+  printf '\n'
+}
+
+run_or_print() {
+  if (( DRY_RUN == 1 )); then
+    print_cmd "$@"
+    return 0
+  fi
+  "$@"
+}
+
+compose_cli() {
+  if docker compose version >/dev/null 2>&1; then
+    printf '%s\n' "docker compose"
+    return 0
+  fi
+  if command -v docker-compose >/dev/null 2>&1; then
+    printf '%s\n' "docker-compose"
+    return 0
+  fi
+  fail "Neither 'docker compose' nor 'docker-compose' is available on PATH."
+}
+
+run_compose_build() {
+  local compose_cmd
+  local -a cmd=()
+
+  compose_cmd=$(compose_cli)
+  case "$compose_cmd" in
+    "docker compose")
+      cmd=(docker compose -f "$COMPOSE_FILE" build)
+      ;;
+    "docker-compose")
+      cmd=(docker-compose -f "$COMPOSE_FILE" build)
+      ;;
+    *)
+      fail "Unsupported compose command: $compose_cmd"
+      ;;
+  esac
+  cmd+=("${EXTRA_ARGS[@]}")
+  cmd+=("$COMPOSE_SERVICE")
+  run_or_print "${cmd[@]}"
+}
+
+run_docker_build() {
+  local -a build_arg_names=(
+    MAX_JOBS
+    FLASHQLA_REPO
+    FLASHQLA_REF
+    BUILD_NETWORK_PREFLIGHT
+    BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS
+    BUILD_PYPI_OFFICIAL_INDEX
+    BUILD_PYPI_FOREIGN_INDEX
+    BUILD_PYPI_DOMESTIC_INDEX
+    BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS
+    BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS
+    BUILD_PYPI_MIRROR_INDEX
+    BUILD_PYPI_MIRROR_FALLBACK
+    BUILD_WHEELHOUSE_DIR
+    BUILD_PYPI_ACTIVE_INDEX
+    BUILD_DOWNLOAD_SELECTED_MODE
+    BUILD_GIT_ACTIVE_PREFIX
+    BUILD_GIT_FOREIGN_REPO_PREFIX
+    BUILD_GIT_DOMESTIC_REPO_PREFIX
+    BUILD_GIT_OFFICIAL_PROBE
+    BUILD_GIT_FOREIGN_PROBE
+    BUILD_GIT_DOMESTIC_PROBE
+    BUILD_GIT_PRIMARY_TIMEOUT_SECONDS
+    BUILD_GIT_MIRROR_PREFIXES
+    CUTLASS_REPO
+    CUTLASS_REVISION
+    TRITON_REPO
+    TRITON_TAG
+  )
+  local name value
+  local -a cmd=(
+    docker build
+    -f "$DOCKERFILE"
+    -t "$VLLM_IMAGE"
+  )
+
+  for name in "${build_arg_names[@]}"; do
+    value=${!name-}
+    cmd+=(--build-arg "$name=$value")
+  done
+
+  cmd+=("${EXTRA_ARGS[@]}")
+  cmd+=("$ROOT_DIR")
+  run_or_print "${cmd[@]}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    compose|docker|env)
+      ACTION=$1
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      EXTRA_ARGS+=("$@")
+      break
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+configure_build_parallelism
+choose_download_mode
+export VLLM_IMAGE
+export FLASHQLA_REPO FLASHQLA_REF
+export BUILD_NETWORK_PREFLIGHT BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS
+export BUILD_PYPI_OFFICIAL_INDEX BUILD_PYPI_FOREIGN_INDEX BUILD_PYPI_DOMESTIC_INDEX
+export BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS
+export BUILD_PYPI_MIRROR_INDEX BUILD_PYPI_MIRROR_FALLBACK BUILD_WHEELHOUSE_DIR
+export BUILD_PYPI_ACTIVE_INDEX BUILD_DOWNLOAD_SELECTED_MODE
+export BUILD_GIT_ACTIVE_PREFIX BUILD_GIT_FOREIGN_REPO_PREFIX BUILD_GIT_DOMESTIC_REPO_PREFIX
+export BUILD_GIT_OFFICIAL_PROBE BUILD_GIT_FOREIGN_PROBE BUILD_GIT_DOMESTIC_PROBE
+export BUILD_GIT_PRIMARY_TIMEOUT_SECONDS BUILD_GIT_MIRROR_PREFIXES
+export CUTLASS_REPO CUTLASS_REVISION TRITON_REPO TRITON_TAG
+print_summary
+
+case "$ACTION" in
+  compose)
+    run_compose_build
+    ;;
+  docker)
+    run_docker_build
+    ;;
+  env)
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/docker/build_network_routes.sh
+++ b/docker/build_network_routes.sh
@@ -40,12 +40,7 @@ measure_network_url_ms() {
 
 pypi_probe_url() {
   local index_url=$1
-  index_url=${index_url%/}
-  if [[ "$index_url" == */simple ]]; then
-    printf '%s/pip/\n' "$index_url"
-  else
-    printf '%s\n' "$index_url"
-  fi
+  printf '%s/\n' "${index_url%/}"
 }
 
 probe_download_route() {

--- a/docker/build_network_routes.sh
+++ b/docker/build_network_routes.sh
@@ -12,6 +12,7 @@ BUILD_GIT_FOREIGN_PROBE=${BUILD_GIT_FOREIGN_PROBE:-${BUILD_GIT_FOREIGN_REPO_PREF
 BUILD_GIT_DOMESTIC_PROBE=${BUILD_GIT_DOMESTIC_PROBE:-${BUILD_GIT_DOMESTIC_REPO_PREFIX}${BUILD_GIT_OFFICIAL_PROBE}}
 BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS=${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
 BUILD_ROUTE_CACHE_FILE=${BUILD_ROUTE_CACHE_FILE:-/tmp/docker-build-network-routes.env}
+BUILD_DOWNLOAD_SELECTED_MODE=${BUILD_DOWNLOAD_SELECTED_MODE:-}
 
 is_positive_integer() {
   [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
@@ -85,6 +86,20 @@ load_selected_route() {
   echo "Preflight: reusing cached ${BUILD_DOWNLOAD_SELECTED_MODE} download route." >&2
 }
 
+infer_selected_route() {
+  if [[ "${BUILD_PYPI_ACTIVE_INDEX:-}" == "$BUILD_PYPI_FOREIGN_INDEX" || \
+        "${BUILD_GIT_ACTIVE_PREFIX:-}" == "$BUILD_GIT_FOREIGN_REPO_PREFIX" ]]; then
+    printf '%s\n' "foreign"
+  elif [[ "${BUILD_PYPI_ACTIVE_INDEX:-}" == "$BUILD_PYPI_DOMESTIC_INDEX" || \
+          "${BUILD_GIT_ACTIVE_PREFIX:-}" == "$BUILD_GIT_DOMESTIC_REPO_PREFIX" ]]; then
+    printf '%s\n' "domestic"
+  elif [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" || -n "${BUILD_GIT_ACTIVE_PREFIX:-}" ]]; then
+    printf '%s\n' "custom"
+  else
+    printf '%s\n' "official"
+  fi
+}
+
 choose_download_route() {
   local measurements=()
   local line
@@ -97,6 +112,9 @@ choose_download_route() {
     return 0
   fi
   if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" || -n "${BUILD_GIT_ACTIVE_PREFIX:-}" ]]; then
+    BUILD_DOWNLOAD_SELECTED_MODE=${BUILD_DOWNLOAD_SELECTED_MODE:-$(infer_selected_route)}
+    echo "Preflight: using preselected ${BUILD_DOWNLOAD_SELECTED_MODE} download route." >&2
+    export BUILD_DOWNLOAD_SELECTED_MODE BUILD_PYPI_ACTIVE_INDEX BUILD_GIT_ACTIVE_PREFIX
     return 0
   fi
   if load_selected_route; then

--- a/docker/build_network_routes.sh
+++ b/docker/build_network_routes.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLASHQLA_REPO=${FLASHQLA_REPO:-https://github.com/weicj/FlashQLA-SM70-SM75.git}
+BUILD_PYPI_OFFICIAL_INDEX=${BUILD_PYPI_OFFICIAL_INDEX:-https://pypi.org/simple}
+BUILD_PYPI_FOREIGN_INDEX=${BUILD_PYPI_FOREIGN_INDEX:-https://pypi.python.org/simple}
+BUILD_PYPI_DOMESTIC_INDEX=${BUILD_PYPI_DOMESTIC_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}
+BUILD_GIT_FOREIGN_REPO_PREFIX=${BUILD_GIT_FOREIGN_REPO_PREFIX:-https://gh-proxy.com/}
+BUILD_GIT_DOMESTIC_REPO_PREFIX=${BUILD_GIT_DOMESTIC_REPO_PREFIX:-https://ghfast.top/}
+BUILD_GIT_OFFICIAL_PROBE=${BUILD_GIT_OFFICIAL_PROBE:-${FLASHQLA_REPO}/info/refs?service=git-upload-pack}
+BUILD_GIT_FOREIGN_PROBE=${BUILD_GIT_FOREIGN_PROBE:-${BUILD_GIT_FOREIGN_REPO_PREFIX}${BUILD_GIT_OFFICIAL_PROBE}}
+BUILD_GIT_DOMESTIC_PROBE=${BUILD_GIT_DOMESTIC_PROBE:-${BUILD_GIT_DOMESTIC_REPO_PREFIX}${BUILD_GIT_OFFICIAL_PROBE}}
+BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS=${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
+BUILD_ROUTE_CACHE_FILE=${BUILD_ROUTE_CACHE_FILE:-/tmp/docker-build-network-routes.env}
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+measure_network_url_ms() {
+  local url=$1
+  local timeout_seconds=${2:-6}
+  local start end elapsed
+
+  start=$(date +%s%3N)
+  if command -v curl >/dev/null 2>&1; then
+    curl -L --max-time "$timeout_seconds" --connect-timeout "$timeout_seconds" \
+      --fail --silent --show-error --output /dev/null "$url" >/dev/null 2>&1 || return 1
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --timeout="$timeout_seconds" -O /dev/null "$url" >/dev/null 2>&1 || return 1
+  else
+    return 1
+  fi
+
+  end=$(date +%s%3N)
+  elapsed=$((end - start))
+  (( elapsed > 0 )) || elapsed=1
+  printf '%s\n' "$elapsed"
+}
+
+pypi_probe_url() {
+  local index_url=$1
+  index_url=${index_url%/}
+  if [[ "$index_url" == */simple ]]; then
+    printf '%s/pip/\n' "$index_url"
+  else
+    printf '%s\n' "$index_url"
+  fi
+}
+
+probe_download_route() {
+  local mode=$1
+  local pypi_url=$2
+  local git_url=$3
+  local git_prefix=$4
+  local timeout_seconds=${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
+  local pypi_probe
+  local pypi_ms git_ms total_ms
+
+  pypi_probe=$(pypi_probe_url "$pypi_url")
+  if ! pypi_ms=$(measure_network_url_ms "$pypi_probe" "$timeout_seconds"); then
+    printf 'Preflight: %-8s unavailable at Python index %s\n' "$mode" "$pypi_probe" >&2
+    return 1
+  fi
+  if ! git_ms=$(measure_network_url_ms "$git_url" "$timeout_seconds"); then
+    printf 'Preflight: %-8s unavailable at Git probe %s\n' "$mode" "$git_url" >&2
+    return 1
+  fi
+
+  total_ms=$((pypi_ms + git_ms))
+  printf 'Preflight: %-8s route %5sms total  PyPI=%sms  Git=%sms\n' \
+    "$mode" "$total_ms" "$pypi_ms" "$git_ms" >&2
+  printf '%s\t%s\t%s\t%s\t%s\n' "$total_ms" "$mode" "$pypi_ms" "$git_ms" "$git_prefix"
+}
+
+cache_selected_route() {
+  mkdir -p "$(dirname -- "$BUILD_ROUTE_CACHE_FILE")"
+  {
+    printf 'BUILD_DOWNLOAD_SELECTED_MODE=%q\n' "${BUILD_DOWNLOAD_SELECTED_MODE:-official}"
+    printf 'BUILD_PYPI_ACTIVE_INDEX=%q\n' "${BUILD_PYPI_ACTIVE_INDEX:-$BUILD_PYPI_OFFICIAL_INDEX}"
+    printf 'BUILD_GIT_ACTIVE_PREFIX=%q\n' "${BUILD_GIT_ACTIVE_PREFIX:-}"
+  } > "$BUILD_ROUTE_CACHE_FILE"
+}
+
+load_selected_route() {
+  [[ -f "$BUILD_ROUTE_CACHE_FILE" ]] || return 1
+  # shellcheck disable=SC1090
+  source "$BUILD_ROUTE_CACHE_FILE"
+  [[ -n "${BUILD_DOWNLOAD_SELECTED_MODE:-}" ]] || return 1
+  echo "Preflight: reusing cached ${BUILD_DOWNLOAD_SELECTED_MODE} download route." >&2
+}
+
+choose_download_route() {
+  local measurements=()
+  local line
+  local mode
+  local probe_tmp
+  local selected_line
+  local selected_mode=official
+
+  if [[ "${BUILD_NETWORK_PREFLIGHT:-1}" != "1" ]]; then
+    return 0
+  fi
+  if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" || -n "${BUILD_GIT_ACTIVE_PREFIX:-}" ]]; then
+    return 0
+  fi
+  if load_selected_route; then
+    export BUILD_DOWNLOAD_SELECTED_MODE BUILD_PYPI_ACTIVE_INDEX BUILD_GIT_ACTIVE_PREFIX
+    return 0
+  fi
+
+  if ! is_positive_integer "$BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS"; then
+    echo "BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS must be a positive integer." >&2
+    exit 2
+  fi
+
+  echo "Preflight: benchmarking download routes..." >&2
+  echo "Preflight: sample timeout is ${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS}s per URL probe." >&2
+
+  probe_tmp=$(mktemp -d)
+  probe_download_route official "$BUILD_PYPI_OFFICIAL_INDEX" "$BUILD_GIT_OFFICIAL_PROBE" "" \
+    >"$probe_tmp/official.out" 2>"$probe_tmp/official.err" &
+  probe_download_route foreign "$BUILD_PYPI_FOREIGN_INDEX" "$BUILD_GIT_FOREIGN_PROBE" "$BUILD_GIT_FOREIGN_REPO_PREFIX" \
+    >"$probe_tmp/foreign.out" 2>"$probe_tmp/foreign.err" &
+  probe_download_route domestic "$BUILD_PYPI_DOMESTIC_INDEX" "$BUILD_GIT_DOMESTIC_PROBE" "$BUILD_GIT_DOMESTIC_REPO_PREFIX" \
+    >"$probe_tmp/domestic.out" 2>"$probe_tmp/domestic.err" &
+  wait || true
+
+  for mode in official foreign domestic; do
+    [[ ! -s "$probe_tmp/$mode.err" ]] || cat "$probe_tmp/$mode.err" >&2
+    if [[ -s "$probe_tmp/$mode.out" ]]; then
+      line=$(head -n 1 "$probe_tmp/$mode.out")
+      measurements+=("$line")
+    fi
+  done
+  rm -rf "$probe_tmp"
+
+  if ((${#measurements[@]} > 0)); then
+    selected_line=$(printf '%s\n' "${measurements[@]}" | sort -n -k1,1 | head -n 1)
+    selected_mode=$(printf '%s\n' "$selected_line" | awk -F '\t' '{print $2}')
+  else
+    echo "Preflight: no download route probe succeeded; falling back to official-first retry order." >&2
+  fi
+
+  case "$selected_mode" in
+    official)
+      BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_OFFICIAL_INDEX
+      BUILD_GIT_ACTIVE_PREFIX=
+      ;;
+    foreign)
+      BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_FOREIGN_INDEX
+      BUILD_GIT_ACTIVE_PREFIX=$BUILD_GIT_FOREIGN_REPO_PREFIX
+      ;;
+    domestic)
+      BUILD_PYPI_ACTIVE_INDEX=$BUILD_PYPI_DOMESTIC_INDEX
+      BUILD_GIT_ACTIVE_PREFIX=$BUILD_GIT_DOMESTIC_REPO_PREFIX
+      ;;
+  esac
+
+  BUILD_DOWNLOAD_SELECTED_MODE=$selected_mode
+  echo "Preflight: selected ${BUILD_DOWNLOAD_SELECTED_MODE} download route." >&2
+  cache_selected_route
+  export BUILD_DOWNLOAD_SELECTED_MODE BUILD_PYPI_ACTIVE_INDEX BUILD_GIT_ACTIVE_PREFIX
+}
+
+choose_download_route

--- a/docker/chat_template_no_thinking.jinja
+++ b/docker/chat_template_no_thinking.jinja
@@ -1,0 +1,222 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id is defined and add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- set ns_flags = namespace(enable_thinking=false) %}
+{%- if enable_thinking is defined %}
+    {%- set ns_flags.enable_thinking = enable_thinking %}
+{%- endif %}
+{%- set preserve_thinking = preserve_thinking | default(true) %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if add_generation_prompt is defined and add_generation_prompt and continue_final_message is defined and continue_final_message %}
+    {{- raise_exception('add_generation_prompt and continue_final_message cannot both be true.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if '<|think_off|>' in content %}
+            {%- set ns_flags.enable_thinking = false %}
+            {%- set content = content.replace('<|think_off|>', '') %}
+        {%- endif %}
+        {%- if '<|think_on|>' in content %}
+            {%- set ns_flags.enable_thinking = true %}
+            {%- set content = content.replace('<|think_on|>', '') %}
+        {%- endif %}
+        {%- set content = content.strip() %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' or messages[0].role == 'developer' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if '<|think_off|>' in content %}
+            {%- set ns_flags.enable_thinking = false %}
+            {%- set content = content.replace('<|think_off|>', '') %}
+        {%- endif %}
+        {%- if '<|think_on|>' in content %}
+            {%- set ns_flags.enable_thinking = true %}
+            {%- set content = content.replace('<|think_on|>', '') %}
+        {%- endif %}
+        {%- set content = content.strip() %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {%- set ns.last_query_index = messages|length - 1 %}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- set content = content.replace('<|think_off|>', '').replace('<|think_on|>', '') %}
+    {%- set content = content.strip() %}
+    {%- if message.role == "system" or message.role == "developer" %}
+        {%- if not loop.first %}
+            {%- set sys_content = render_content(message.content, false, true)|trim %}
+            {%- set sys_content = sys_content.replace('<|think_off|>', '').replace('<|think_on|>', '')|trim %}
+            {{- '<|im_start|>system\n' + sys_content + '<|im_end|>' + '\n' }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + (content if content else ' ') + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- set has_think_tag = false %}
+            {%- set think_start_token = '<think>' %}
+            {%- set think_end_token = '</think>' %}
+            {%- if '</think>' in content %}
+                {%- set has_think_tag = true %}
+            {%- elif '</thinking>' in content %}
+                {%- set has_think_tag = true %}
+                {%- set think_start_token = '<thinking>' %}
+                {%- set think_end_token = '</thinking>' %}
+            {%- elif '<think>' in content %}
+                {%- set reasoning_content = content.split('<think>')[-1].lstrip('\n') %}
+                {%- set content = '' %}
+            {%- elif '<thinking>' in content %}
+                {%- set reasoning_content = content.split('<thinking>')[-1].lstrip('\n') %}
+                {%- set content = '' %}
+            {%- endif %}
+            {%- if has_think_tag %}
+                {%- set reasoning_content = content.split(think_end_token)[0].rstrip('\n').split(think_start_token)[-1].lstrip('\n') %}
+                {%- set content = content.split(think_end_token)[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- set show_think = false %}
+        {%- if loop.index0 > ns.last_query_index and reasoning_content|length > 0 %}
+            {%- set show_think = true %}
+        {%- elif ns_flags.enable_thinking and preserve_thinking and reasoning_content|length > 0 %}
+            {%- set show_think = true %}
+        {%- endif %}
+        {%- if show_think %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments is mapping %}
+                    {%- if tool_call.arguments|length > 0 %}
+                        {%- for args_name in tool_call.arguments %}
+                            {%- set args_value = tool_call.arguments[args_name] %}
+                            {{- '<parameter=' + args_name + '>\n' }}
+                            {%- set args_value = args_value | string if args_value is string else args_value | tojson %}
+                            {{- args_value }}
+                            {{- '\n</parameter>\n' }}
+                        {%- endfor %}
+                    {%- endif %}
+                {%- elif tool_call.arguments is defined and tool_call.arguments is string %}
+                    {%- if tool_call.arguments|trim|length > 0 %}
+                        {#- Note: raw JSON string arguments are emitted as-is and will not match
+                            the XML parameter format in the tool instructions. Normalize arguments
+                            to a dict in your serving layer before applying this template. -#}
+                        {{- tool_call.arguments }}
+                        {{- '\n' }}
+                    {%- endif %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {%- if not (loop.last and continue_final_message is defined and continue_final_message is true) %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif message.role == "tool" %}
+        {%- if not loop.previtem or (loop.previtem.role != "tool" and loop.previtem.role != "assistant") %}
+            {{- raise_exception('A tool message must follow an assistant or tool message.') }}
+        {%- endif %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if ns_flags.enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/docker/chat_template_no_thinking.jinja
+++ b/docker/chat_template_no_thinking.jinja
@@ -5,9 +5,12 @@
         {{- content }}
     {%- elif content is iterable and content is not mapping %}
         {%- for item in content %}
-            {%- if item is not mapping %}
-                {{- raise_exception('Unexpected non-object item in content.') }}
-            {%- elif 'image' in item or 'image_url' in item or (item.type is defined and item.type == 'image') %}
+            {%- set is_mapping = item is mapping %}
+            {%- set item_type = item.type if item.type is defined else none %}
+            {%- set has_image = is_mapping and ('image' in item or 'image_url' in item) %}
+            {%- set has_video = is_mapping and 'video' in item %}
+            {%- set has_text = is_mapping and 'text' in item %}
+            {%- if item_type == 'image' or has_image %}
                 {%- if is_system_content %}
                     {{- raise_exception('System message cannot contain images.') }}
                 {%- endif %}
@@ -18,7 +21,7 @@
                     {{- 'Picture ' ~ image_count.value ~ ': ' }}
                 {%- endif %}
                 {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
-            {%- elif 'video' in item or (item.type is defined and item.type == 'video') %}
+            {%- elif item_type == 'video' or has_video %}
                 {%- if is_system_content %}
                     {{- raise_exception('System message cannot contain videos.') }}
                 {%- endif %}
@@ -29,10 +32,14 @@
                     {{- 'Video ' ~ video_count.value ~ ': ' }}
                 {%- endif %}
                 {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
-            {%- elif 'text' in item %}
+            {%- elif has_text %}
                 {{- item.text }}
-            {%- else %}
+            {%- elif item_type == 'text' and item.text is defined %}
+                {{- item.text }}
+            {%- elif is_mapping or item_type is not none %}
                 {{- raise_exception('Unexpected item type in content.') }}
+            {%- else %}
+                {{- item | string }}
             {%- endif %}
         {%- endfor %}
     {%- elif content is none or content is undefined %}

--- a/docker/chat_template_no_thinking.jinja
+++ b/docker/chat_template_no_thinking.jinja
@@ -5,7 +5,9 @@
         {{- content }}
     {%- elif content is iterable and content is not mapping %}
         {%- for item in content %}
-            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+            {%- if item is not mapping %}
+                {{- raise_exception('Unexpected non-object item in content.') }}
+            {%- elif 'image' in item or 'image_url' in item or (item.type is defined and item.type == 'image') %}
                 {%- if is_system_content %}
                     {{- raise_exception('System message cannot contain images.') }}
                 {%- endif %}
@@ -16,7 +18,7 @@
                     {{- 'Picture ' ~ image_count.value ~ ': ' }}
                 {%- endif %}
                 {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
-            {%- elif 'video' in item or item.type == 'video' %}
+            {%- elif 'video' in item or (item.type is defined and item.type == 'video') %}
                 {%- if is_system_content %}
                     {{- raise_exception('System message cannot contain videos.') }}
                 {%- endif %}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,57 @@
+# Local vLLM 2080 Ti runtime service.
+#
+# Build from repository root:
+#   MAX_JOBS=4 docker compose -f docker/docker-compose.yml build vllm
+# Start:
+#   docker compose -f docker/docker-compose.yml up -d vllm
+
+services:
+  vllm:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        MAX_JOBS: ${MAX_JOBS:-4}
+        FLASHQLA_REPO: ${FLASHQLA_REPO:-https://github.com/weicj/FlashQLA-SM70-SM75.git}
+        FLASHQLA_REF: ${FLASHQLA_REF:-3ab27d77d8ca01d7a4718903b726add1a8886c0e}
+    image: ${VLLM_IMAGE:-local/vllm-2080ti-definitive:v0.1.12}
+    container_name: ${VLLM_CONTAINER_NAME:-vllm-2080ti}
+    restart: unless-stopped
+    ipc: host
+    ports:
+      - "${VLLM_HOST_PORT:-8000}:8000"
+    volumes:
+      - ${MODEL_ROOT:-/data/models}:/models:ro
+      - vllm-torch-cache:/tmp/torch_extensions_cache
+      - vllm-triton-cache:/tmp/triton-cache
+      - vllm-inductor-cache:/tmp/torchinductor-cache
+    environment:
+      - MODEL_DIR=${MODEL_DIR:-/models/Qwen3.6-27B-GPTQ-Int4}
+      - PROFILE=${PROFILE:-qwen27b/fast/int4/tqk8v4-256K-mtp3-text-only.env}
+      - MODE=${MODE:-fast}
+      - PORT=8000
+      - GPU_UTIL=${GPU_UTIL:-0.96}
+      - CHAT_TEMPLATE_FILE=/opt/vllm/docker/chat_template_no_thinking.jinja
+      - DEFAULT_CHAT_TEMPLATE_KWARGS={"enable_thinking":false}
+      - CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1}
+      - NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-0,1}
+      - TORCH_CUDA_ARCH_LIST=7.5
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
+      - FLASHINFER_ENABLE_AOT=1
+      - NCCL_DEBUG=WARN
+      - PYTHONUNBUFFERED=1
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${GPU_COUNT:-2}
+              capabilities: [gpu]
+
+volumes:
+  vllm-torch-cache:
+  vllm-triton-cache:
+  vllm-inductor-cache:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,8 @@
 # Local vLLM 2080 Ti runtime service.
 #
-# Build from repository root:
+# Build from repository root (recommended host preflight + compose frontend):
+#   ./docker/build.sh compose
+# Manual fallback:
 #   MAX_JOBS=4 docker compose -f docker/docker-compose.yml build vllm
 # Start:
 #   docker compose -f docker/docker-compose.yml up -d vllm
@@ -14,6 +16,30 @@ services:
         MAX_JOBS: ${MAX_JOBS:-4}
         FLASHQLA_REPO: ${FLASHQLA_REPO:-https://github.com/weicj/FlashQLA-SM70-SM75.git}
         FLASHQLA_REF: ${FLASHQLA_REF:-3ab27d77d8ca01d7a4718903b726add1a8886c0e}
+        BUILD_NETWORK_PREFLIGHT: ${BUILD_NETWORK_PREFLIGHT:-1}
+        BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS: ${BUILD_PREFLIGHT_SAMPLE_TIMEOUT_SECONDS:-5}
+        BUILD_PYPI_OFFICIAL_INDEX: ${BUILD_PYPI_OFFICIAL_INDEX:-https://pypi.org/simple}
+        BUILD_PYPI_FOREIGN_INDEX: ${BUILD_PYPI_FOREIGN_INDEX:-https://pypi.python.org/simple}
+        BUILD_PYPI_DOMESTIC_INDEX: ${BUILD_PYPI_DOMESTIC_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}
+        BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS: ${BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS:-60}
+        BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS: ${BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS:-}
+        BUILD_PYPI_MIRROR_INDEX: ${BUILD_PYPI_MIRROR_INDEX:-}
+        BUILD_PYPI_MIRROR_FALLBACK: ${BUILD_PYPI_MIRROR_FALLBACK:-1}
+        BUILD_WHEELHOUSE_DIR: ${BUILD_WHEELHOUSE_DIR:-}
+        BUILD_PYPI_ACTIVE_INDEX: ${BUILD_PYPI_ACTIVE_INDEX:-}
+        BUILD_DOWNLOAD_SELECTED_MODE: ${BUILD_DOWNLOAD_SELECTED_MODE:-}
+        BUILD_GIT_ACTIVE_PREFIX: ${BUILD_GIT_ACTIVE_PREFIX:-}
+        BUILD_GIT_FOREIGN_REPO_PREFIX: ${BUILD_GIT_FOREIGN_REPO_PREFIX:-https://gh-proxy.com/}
+        BUILD_GIT_DOMESTIC_REPO_PREFIX: ${BUILD_GIT_DOMESTIC_REPO_PREFIX:-https://ghfast.top/}
+        BUILD_GIT_OFFICIAL_PROBE: ${BUILD_GIT_OFFICIAL_PROBE:-}
+        BUILD_GIT_FOREIGN_PROBE: ${BUILD_GIT_FOREIGN_PROBE:-}
+        BUILD_GIT_DOMESTIC_PROBE: ${BUILD_GIT_DOMESTIC_PROBE:-}
+        BUILD_GIT_PRIMARY_TIMEOUT_SECONDS: ${BUILD_GIT_PRIMARY_TIMEOUT_SECONDS:-120}
+        BUILD_GIT_MIRROR_PREFIXES: ${BUILD_GIT_MIRROR_PREFIXES:-}
+        CUTLASS_REPO: ${CUTLASS_REPO:-https://github.com/nvidia/cutlass.git}
+        CUTLASS_REVISION: ${CUTLASS_REVISION:-da5e086dab31d63815acafdac9a9c5893b1c69e2}
+        TRITON_REPO: ${TRITON_REPO:-https://github.com/triton-lang/triton.git}
+        TRITON_TAG: ${TRITON_TAG:-7c56a5e40f7fd928dfd5c72902d5def0097db73a}
     image: ${VLLM_IMAGE:-local/vllm-2080ti-definitive:v0.1.12}
     container_name: ${VLLM_CONTAINER_NAME:-vllm-2080ti}
     restart: unless-stopped

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - PROFILE=${PROFILE:-qwen27b/fast/int4/tqk8v4-256K-mtp3-text-only.env}
       - MODE=${MODE:-fast}
       - PORT=8000
+      - SERVICE_SCOPE=${SERVICE_SCOPE:-lan}
       - GPU_UTIL=${GPU_UTIL:-0.96}
       - CHAT_TEMPLATE_FILE=/opt/vllm/docker/chat_template_no_thinking.jinja
       - DEFAULT_CHAT_TEMPLATE_KWARGS={"enable_thinking":false}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -58,6 +58,7 @@ profile_key_is_global() {
 
 resolve_profile_file() {
     if [[ -n "${PROFILE_FILE:-}" ]]; then
+        [[ -f "$PROFILE_FILE" ]] || return 1
         printf '%s\n' "$PROFILE_FILE"
         return 0
     fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=${ROOT:-/opt/vllm}
+PROFILE_DIR=${PROFILE_DIR:-"$ROOT/profiles"}
+TEMPLATE_DIR=${TEMPLATE_DIR:-"$PROFILE_DIR/templates"}
+MODEL_DIR=${MODEL_DIR:-/models/Qwen3.6-27B-GPTQ-Int4}
+PROFILE=${PROFILE:-qwen27b/fast/int4/tqk8v4-256K-mtp3-text-only.env}
+MODE=${MODE:-fast}
+PORT=${PORT:-8000}
+HOST=${HOST:-0.0.0.0}
+
+export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+export CUDA_PATH="$CUDA_HOME"
+export CUDACXX="${CUDACXX:-$CUDA_HOME/bin/nvcc}"
+export PATH="$CUDA_HOME/bin:${PATH}"
+export TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST:-7.5}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+export CUDA_DEVICE_ORDER="${CUDA_DEVICE_ORDER:-PCI_BUS_ID}"
+export FLASHINFER_ENABLE_AOT="${FLASHINFER_ENABLE_AOT:-1}"
+export FLASHQLA_DIR="${FLASHQLA_DIR:-$ROOT/FlashQLA-SM70-SM75}"
+export PYTHONPATH="$ROOT:$FLASHQLA_DIR${PYTHONPATH:+:$PYTHONPATH}"
+export TORCH_EXTENSIONS_DIR="${TORCH_EXTENSIONS_DIR:-/tmp/torch_extensions_cache}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-/tmp/torchinductor-cache}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/tmp/triton-cache}"
+export PYTHONUNBUFFERED=1
+
+read_profile_value() {
+    local file=$1
+    local key=$2
+    awk -F= -v key="$key" '
+        $1 == key {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^[ \t]+|[ \t]+$/, "", value)
+            gsub(/^'\''|'\''$/, "", value)
+            gsub(/^"|"$/, "", value)
+            print value
+            exit
+        }
+    ' "$file"
+}
+
+profile_key_is_global() {
+    case "$1" in
+        MODEL_DIR|PROFILE_DIR|PROFILE|MODE|PORT|SERVICE_SCOPE|GPU_DEVICES|TP_SIZE|\
+        CHAT_TEMPLATE_FILE|CHAT_TEMPLATE_PRESET|TEMPLATE_DIR|REASONING_PARSER|\
+        DEFAULT_CHAT_TEMPLATE_KWARGS|REASONING_MODE|REASONING_BUDGET|\
+        ENABLE_AUTO_TOOL_CHOICE|TOOL_CALL_PARSER|TOOL_PARSER_PLUGIN|\
+        ENABLE_PREFIX_CACHING|ENABLE_PROMPT_TOKENS_DETAILS|DISABLE_PREFIX_CACHING|\
+        VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH|VLLM_ENFORCE_STRICT_TOOL_CALLING)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+resolve_profile_file() {
+    if [[ -n "${PROFILE_FILE:-}" ]]; then
+        printf '%s\n' "$PROFILE_FILE"
+        return 0
+    fi
+    if [[ -f "$PROFILE_DIR/$PROFILE" ]]; then
+        printf '%s\n' "$PROFILE_DIR/$PROFILE"
+        return 0
+    fi
+    if [[ -f "$PROFILE_DIR/${PROFILE%.env}.env" ]]; then
+        printf '%s\n' "$PROFILE_DIR/${PROFILE%.env}.env"
+        return 0
+    fi
+    return 1
+}
+
+apply_profile_overrides() {
+    local file=$1
+    local key value
+
+    while IFS= read -r key; do
+        [[ -n "$key" ]] || continue
+        profile_key_is_global "$key" && continue
+        [[ -n "${!key+x}" ]] && continue
+        value=$(read_profile_value "$file" "$key")
+        printf -v "$key" '%s' "$value"
+        export "$key"
+    done < <(sed -nE 's/^([A-Za-z_][A-Za-z0-9_]*)=.*/\1/p' "$file" | sort -u)
+}
+
+normalize_bool() {
+    case "${1,,}" in
+        1|yes|y|true|on) echo 1 ;;
+        *) echo 0 ;;
+    esac
+}
+
+set_mode_defaults() {
+    case "$MODE" in
+        normal)
+            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
+            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
+            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
+            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-0}
+            ;;
+        fast)
+            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
+            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
+            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
+            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-1}
+            ;;
+        aggressive)
+            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
+            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
+            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-nosync}
+            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-1}
+            ;;
+        safe)
+            export ENFORCE_EAGER=${ENFORCE_EAGER:-1}
+            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
+            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-0}
+            ;;
+        *)
+            echo "ERROR: MODE must be safe, normal, fast, or aggressive; got $MODE" >&2
+            exit 1
+            ;;
+    esac
+}
+
+set_route_defaults() {
+    local model_dir_l=${MODEL_DIR,,}
+
+    MODEL_FAMILY=${MODEL_FAMILY:-qwen}
+    SERVED_NAME=${SERVED_NAME:-${MODEL_DIR##*/}}
+    if [[ -z "${QUANTIZATION:-}" ]]; then
+        case "$model_dir_l" in
+            *gptq*|*int4*|*4bit*) QUANTIZATION=gptq_marlin ;;
+            *awq*) QUANTIZATION=awq_marlin ;;
+            *fp8*) QUANTIZATION=fp8 ;;
+            *quark*) QUANTIZATION=quark ;;
+        esac
+    fi
+    MAX_MODEL_LEN=${MAX_MODEL_LEN:-131072}
+    GPU_UTIL=${GPU_UTIL:-0.90}
+    MAX_BATCHED_TOKENS=${MAX_BATCHED_TOKENS:-2048}
+    MAX_NUM_SEQS=${MAX_NUM_SEQS:-1}
+    MTP_K=${MTP_K:-0}
+    TP_SIZE=${TP_SIZE:-2}
+    ENABLE_PREFIX_CACHING=$(normalize_bool "${ENABLE_PREFIX_CACHING:-1}")
+    ENABLE_PROMPT_TOKENS_DETAILS=$(normalize_bool "${ENABLE_PROMPT_TOKENS_DETAILS:-1}")
+    DISABLE_PREFIX_CACHING=$(normalize_bool "${DISABLE_PREFIX_CACHING:-0}")
+
+    if [[ "$DISABLE_PREFIX_CACHING" == "1" ]]; then
+        ENABLE_PREFIX_CACHING=0
+    elif [[ "$ENABLE_PREFIX_CACHING" == "1" && "$MODEL_FAMILY" == qwen* && -z "${MAMBA_CACHE_MODE:-}" ]]; then
+        MAMBA_CACHE_MODE=align
+    fi
+
+    if [[ "$MODEL_FAMILY" == qwen* && -z "${REASONING_PARSER:-}" ]]; then
+        REASONING_PARSER=qwen3
+    fi
+
+    if [[ -z "${MM_LIMIT_JSON:-}" ]]; then
+        LANGUAGE_MODEL_ONLY=${LANGUAGE_MODEL_ONLY:-1}
+        SKIP_MM_PROFILING=${SKIP_MM_PROFILING:-1}
+    fi
+}
+
+set_turboquant_defaults() {
+    [[ "${KV_CACHE_DTYPE:-}" == turboquant_* ]] || return 0
+
+    local reserve=${VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS:-}
+    if [[ -z "$reserve" ]]; then
+        reserve=65536
+        if [[ "$ENABLE_PREFIX_CACHING" == "1" && "$MAX_MODEL_LEN" =~ ^[0-9]+$ && "$MAX_NUM_SEQS" =~ ^[0-9]+$ ]] \
+            && (( MAX_MODEL_LEN >= 240000 )) && (( MAX_NUM_SEQS <= 1 )); then
+            reserve=262144
+        fi
+    fi
+
+    export VLLM_TURBOQUANT_USE_FLASHINFER_PREFILL=${VLLM_TURBOQUANT_USE_FLASHINFER_PREFILL:-1}
+    export VLLM_TURBOQUANT_FLASHINFER_BACKEND=${VLLM_TURBOQUANT_FLASHINFER_BACKEND:-fa2}
+    export VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS=$reserve
+    export VLLM_TURBOQUANT_CUDAGRAPH_SPEC_DECODE_SAFE=${VLLM_TURBOQUANT_CUDAGRAPH_SPEC_DECODE_SAFE:-1}
+    export VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK=${VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK:-512}
+    export VLLM_TURBOQUANT_CONTINUATION_SDPA_MAX_QK_CELLS=${VLLM_TURBOQUANT_CONTINUATION_SDPA_MAX_QK_CELLS:-16777216}
+    export VLLM_TURBOQUANT_SPEC_CONTINUATION_DECODE_FASTPATH=${VLLM_TURBOQUANT_SPEC_CONTINUATION_DECODE_FASTPATH:-1}
+}
+
+if [[ $# -gt 0 ]]; then
+    exec python -m vllm.entrypoints.openai.api_server "$@"
+fi
+
+if [[ ! -d "$MODEL_DIR" ]]; then
+    echo "ERROR: Model directory not found: $MODEL_DIR" >&2
+    exit 1
+fi
+
+profile_file=$(resolve_profile_file) || {
+    echo "ERROR: Profile not found: ${PROFILE_FILE:-$PROFILE} under $PROFILE_DIR" >&2
+    exit 1
+}
+
+apply_profile_overrides "$profile_file"
+set_mode_defaults
+set_route_defaults
+set_turboquant_defaults
+
+args=(
+    --host "$HOST"
+    --port "$PORT"
+    --model "$MODEL_DIR"
+    --served-model-name "$SERVED_NAME"
+    --dtype half
+    --tensor-parallel-size "$TP_SIZE"
+    --generation-config vllm
+    --gpu-memory-utilization "$GPU_UTIL"
+    --max-model-len "$MAX_MODEL_LEN"
+    --enable-chunked-prefill
+    --max-num-seqs "$MAX_NUM_SEQS"
+    --max-num-batched-tokens "$MAX_BATCHED_TOKENS"
+)
+
+[[ -n "${QUANTIZATION:-}" ]] && args+=(--quantization "$QUANTIZATION")
+[[ -n "${KV_CACHE_DTYPE:-}" ]] && args+=(--kv-cache-dtype "$KV_CACHE_DTYPE")
+[[ -n "${MAMBA_CACHE_MODE:-}" ]] && args+=(--mamba-cache-mode "$MAMBA_CACHE_MODE")
+[[ "${ENFORCE_EAGER:-0}" == "1" ]] && args+=(--enforce-eager)
+if [[ "$ENABLE_PREFIX_CACHING" == "1" ]]; then
+    args+=(--enable-prefix-caching)
+else
+    args+=(--no-enable-prefix-caching)
+fi
+[[ "$ENABLE_PROMPT_TOKENS_DETAILS" == "1" ]] && args+=(--enable-prompt-tokens-details)
+[[ "${LANGUAGE_MODEL_ONLY:-0}" == "1" ]] && args+=(--language-model-only)
+[[ "${SKIP_MM_PROFILING:-0}" == "1" ]] && args+=(--skip-mm-profiling)
+[[ "${DISABLE_CUSTOM_ALL_REDUCE:-0}" == "1" ]] && args+=(--disable-custom-all-reduce)
+[[ "${DISABLE_LOG_STATS:-0}" == "1" ]] && args+=(--disable-log-stats)
+[[ -n "${REASONING_PARSER:-}" && "${REASONING_PARSER:-}" != "off" ]] && args+=(--reasoning-parser "$REASONING_PARSER")
+[[ -n "${DEFAULT_CHAT_TEMPLATE_KWARGS:-}" ]] && args+=(--default-chat-template-kwargs "$DEFAULT_CHAT_TEMPLATE_KWARGS")
+[[ -n "${TOOL_PARSER_PLUGIN:-}" ]] && args+=(--tool-parser-plugin "$TOOL_PARSER_PLUGIN")
+[[ -n "${TOOL_CALL_PARSER:-}" ]] && args+=(--tool-call-parser "$TOOL_CALL_PARSER")
+[[ "${ENABLE_AUTO_TOOL_CHOICE:-0}" == "1" ]] && args+=(--enable-auto-tool-choice)
+[[ -n "${HF_OVERRIDES_JSON:-}" ]] && args+=(--hf-overrides "$HF_OVERRIDES_JSON")
+[[ -n "${MM_LIMIT_JSON:-}" ]] && args+=(--limit-mm-per-prompt "$MM_LIMIT_JSON")
+
+if [[ -n "${ADDITIONAL_CONFIG_JSON:-}" ]]; then
+    args+=(--additional-config "$ADDITIONAL_CONFIG_JSON")
+elif [[ "$MODEL_FAMILY" == qwen* ]]; then
+    args+=(--additional-config '{"gdn_prefill_backend":"flashqla_legacy"}')
+fi
+
+if [[ -n "${CHAT_TEMPLATE_PRESET:-}" && -f "$TEMPLATE_DIR/$CHAT_TEMPLATE_PRESET" ]]; then
+    CHAT_TEMPLATE_FILE="$TEMPLATE_DIR/$CHAT_TEMPLATE_PRESET"
+fi
+[[ -n "${CHAT_TEMPLATE_FILE:-}" ]] && args+=(--chat-template "$CHAT_TEMPLATE_FILE")
+
+capture=$((MTP_K + 1))
+if [[ -n "${SPECULATIVE_CONFIG:-}" ]]; then
+    args+=(--speculative-config "$SPECULATIVE_CONFIG")
+elif (( MTP_K > 0 )); then
+    args+=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${MTP_K}}")
+fi
+
+if [[ -n "${COMPILATION_CONFIG_JSON:-}" ]]; then
+    args+=(--compilation-config "$COMPILATION_CONFIG_JSON")
+elif (( MTP_K > 0 )); then
+    args+=(--compilation-config "{\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"cudagraph_capture_sizes\":[${capture}],\"max_cudagraph_capture_size\":${capture}}")
+else
+    args+=(--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1],"max_cudagraph_capture_size":1}')
+fi
+
+echo "=========================================="
+echo " vLLM 2080Ti Definitive Docker"
+echo "=========================================="
+nvidia-smi --query-gpu=index,name,memory.used,memory.total,temperature.gpu --format=csv,noheader || true
+echo "Model Dir: $MODEL_DIR"
+echo "Profile: $profile_file"
+echo "Mode: $MODE"
+echo "Served Name: $SERVED_NAME"
+echo "KV: ${KV_CACHE_DTYPE:-fp16}"
+echo "Context: $MAX_MODEL_LEN"
+echo "MTP: $MTP_K"
+echo "Port: $PORT"
+printf 'Command: python -m vllm.entrypoints.openai.api_server'
+printf ' %q' "${args[@]}"
+echo
+echo "=========================================="
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    exit 0
+fi
+
+exec python -m vllm.entrypoints.openai.api_server "${args[@]}"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -35,8 +35,36 @@ pid_is_running() {
 
 load_manager_state() {
     [[ -f "$STATE_FILE" ]] || return 1
-    # shellcheck disable=SC1090
-    source "$STATE_FILE"
+    LAST_PID_FILE=$(read_manager_state_value LAST_PID_FILE) || return 1
+    LAST_LOG_FILE=$(read_manager_state_value LAST_LOG_FILE) || return 1
+}
+
+read_manager_state_value() {
+    local key=$1
+    local raw_value
+
+    raw_value=$(awk -F= -v key="$key" '
+        $1 == key {
+            print substr($0, index($0, "=") + 1)
+            exit
+        }
+    ' "$STATE_FILE")
+    [[ -n "$raw_value" ]] || return 1
+
+    "$ROOT/.venv/bin/python" - "$raw_value" <<'PY'
+import shlex
+import sys
+
+try:
+    parts = shlex.split(sys.argv[1], posix=True)
+except ValueError:
+    raise SystemExit(1)
+
+if len(parts) != 1:
+    raise SystemExit(1)
+
+sys.stdout.write(parts[0])
+PY
 }
 
 stop_server() {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 ROOT=${ROOT:-/opt/vllm}
-PROFILE_DIR=${PROFILE_DIR:-"$ROOT/profiles"}
-TEMPLATE_DIR=${TEMPLATE_DIR:-"$PROFILE_DIR/templates"}
-MODEL_DIR=${MODEL_DIR:-/models/Qwen3.6-27B-GPTQ-Int4}
-PROFILE=${PROFILE:-qwen27b/fast/int4/tqk8v4-256K-mtp3-text-only.env}
-MODE=${MODE:-fast}
-PORT=${PORT:-8000}
-HOST=${HOST:-0.0.0.0}
+export RUNTIME_ROOT=${RUNTIME_ROOT:-"$ROOT"}
+export PROFILE_DIR=${PROFILE_DIR:-"$ROOT/profiles"}
+export TEMPLATE_DIR=${TEMPLATE_DIR:-"$PROFILE_DIR/templates"}
+export LOG_DIR=${LOG_DIR:-"$ROOT/run-logs"}
+export STATE_FILE=${STATE_FILE:-"$LOG_DIR/start-manager.state"}
+export MODEL_DIR=${MODEL_DIR:-/models/Qwen3.6-27B-GPTQ-Int4}
+export PROFILE=${PROFILE:-qwen27b/fast/int4/tqk8v4-256K-mtp3-text-only.env}
+export MODE=${MODE:-fast}
+export PORT=${PORT:-8000}
+export SERVICE_SCOPE=${SERVICE_SCOPE:-lan}
 
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 export CUDA_PATH="$CUDA_HOME"
@@ -25,268 +28,135 @@ export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-/tmp/torchinductor-ca
 export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/tmp/triton-cache}"
 export PYTHONUNBUFFERED=1
 
-read_profile_value() {
-    local file=$1
-    local key=$2
-    awk -F= -v key="$key" '
-        $1 == key {
-            value = substr($0, index($0, "=") + 1)
-            gsub(/^[ \t]+|[ \t]+$/, "", value)
-            gsub(/^'\''|'\''$/, "", value)
-            gsub(/^"|"$/, "", value)
-            print value
-            exit
-        }
-    ' "$file"
+pid_is_running() {
+    local pid=${1:-}
+    [[ -n "$pid" && -d "/proc/$pid" ]]
 }
 
-profile_key_is_global() {
-    case "$1" in
-        MODEL_DIR|PROFILE_DIR|PROFILE|MODE|PORT|SERVICE_SCOPE|GPU_DEVICES|TP_SIZE|\
-        CHAT_TEMPLATE_FILE|CHAT_TEMPLATE_PRESET|TEMPLATE_DIR|REASONING_PARSER|\
-        DEFAULT_CHAT_TEMPLATE_KWARGS|REASONING_MODE|REASONING_BUDGET|\
-        ENABLE_AUTO_TOOL_CHOICE|TOOL_CALL_PARSER|TOOL_PARSER_PLUGIN|\
-        ENABLE_PREFIX_CACHING|ENABLE_PROMPT_TOKENS_DETAILS|DISABLE_PREFIX_CACHING|\
-        VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH|VLLM_ENFORCE_STRICT_TOOL_CALLING)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
+load_manager_state() {
+    [[ -f "$STATE_FILE" ]] || return 1
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
 }
 
-resolve_profile_file() {
-    if [[ -n "${PROFILE_FILE:-}" ]]; then
-        [[ -f "$PROFILE_FILE" ]] || return 1
-        printf '%s\n' "$PROFILE_FILE"
-        return 0
+stop_server() {
+    local pid=${1:-}
+    local pgid
+
+    pid_is_running "$pid" || return 0
+    pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)
+    if [[ -n "$pgid" && "$pgid" == "$pid" ]]; then
+        kill -TERM -- "-$pgid" 2>/dev/null || true
+    else
+        kill -TERM "$pid" 2>/dev/null || true
     fi
-    if [[ -f "$PROFILE_DIR/$PROFILE" ]]; then
-        printf '%s\n' "$PROFILE_DIR/$PROFILE"
-        return 0
-    fi
-    if [[ -f "$PROFILE_DIR/${PROFILE%.env}.env" ]]; then
-        printf '%s\n' "$PROFILE_DIR/${PROFILE%.env}.env"
-        return 0
-    fi
+}
+
+wait_for_stop() {
+    local pid=${1:-}
+    local attempts=${2:-30}
+
+    for _ in $(seq 1 "$attempts"); do
+        pid_is_running "$pid" || return 0
+        sleep 1
+    done
     return 1
 }
 
-apply_profile_overrides() {
-    local file=$1
-    local key value
+forward_shutdown() {
+    local pid=${SERVER_PID:-}
+    local tail_pid=${TAIL_PID:-}
 
-    while IFS= read -r key; do
-        [[ -n "$key" ]] || continue
-        profile_key_is_global "$key" && continue
-        [[ -n "${!key+x}" ]] && continue
-        value=$(read_profile_value "$file" "$key")
-        printf -v "$key" '%s' "$value"
-        export "$key"
-    done < <(sed -nE 's/^([A-Za-z_][A-Za-z0-9_]*)=.*/\1/p' "$file" | sort -u)
+    if [[ -n "$pid" ]]; then
+        stop_server "$pid"
+        wait_for_stop "$pid" || true
+    fi
+
+    if [[ -n "$tail_pid" ]]; then
+        kill "$tail_pid" 2>/dev/null || true
+        wait "$tail_pid" 2>/dev/null || true
+    fi
 }
 
-normalize_bool() {
-    case "${1,,}" in
-        1|yes|y|true|on) echo 1 ;;
-        *) echo 0 ;;
-    esac
+handle_signal() {
+    forward_shutdown
+    exit 143
 }
 
-set_mode_defaults() {
-    case "$MODE" in
-        normal)
-            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
-            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
-            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
-            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-0}
-            ;;
-        fast)
-            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
-            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
-            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
-            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-1}
-            ;;
-        aggressive)
-            export ENFORCE_EAGER=${ENFORCE_EAGER:-0}
-            export DISABLE_LOG_STATS=${DISABLE_LOG_STATS:-1}
-            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-nosync}
-            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-1}
-            ;;
-        safe)
-            export ENFORCE_EAGER=${ENFORCE_EAGER:-1}
-            export VLLM_SM75_SPEC_SYNC_MODE=${VLLM_SM75_SPEC_SYNC_MODE:-safe}
-            export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=${VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH:-0}
-            ;;
-        *)
-            echo "ERROR: MODE must be safe, normal, fast, or aggressive; got $MODE" >&2
-            exit 1
-            ;;
-    esac
-}
+launcher_reads_only() {
+    local arg
 
-set_route_defaults() {
-    local model_dir_l=${MODEL_DIR,,}
-
-    MODEL_FAMILY=${MODEL_FAMILY:-qwen}
-    SERVED_NAME=${SERVED_NAME:-${MODEL_DIR##*/}}
-    if [[ -z "${QUANTIZATION:-}" ]]; then
-        case "$model_dir_l" in
-            *gptq*|*int4*|*4bit*) QUANTIZATION=gptq_marlin ;;
-            *awq*) QUANTIZATION=awq_marlin ;;
-            *fp8*) QUANTIZATION=fp8 ;;
-            *quark*) QUANTIZATION=quark ;;
+    [[ "${DRY_RUN:-0}" == "1" || "${PRINT_CONFIG:-0}" == "1" ]] && return 0
+    for arg in "$@"; do
+        case "$arg" in
+            --print-config|--help|-h)
+                return 0
+                ;;
         esac
-    fi
-    MAX_MODEL_LEN=${MAX_MODEL_LEN:-131072}
-    GPU_UTIL=${GPU_UTIL:-0.90}
-    MAX_BATCHED_TOKENS=${MAX_BATCHED_TOKENS:-2048}
-    MAX_NUM_SEQS=${MAX_NUM_SEQS:-1}
-    MTP_K=${MTP_K:-0}
-    TP_SIZE=${TP_SIZE:-2}
-    ENABLE_PREFIX_CACHING=$(normalize_bool "${ENABLE_PREFIX_CACHING:-1}")
-    ENABLE_PROMPT_TOKENS_DETAILS=$(normalize_bool "${ENABLE_PROMPT_TOKENS_DETAILS:-1}")
-    DISABLE_PREFIX_CACHING=$(normalize_bool "${DISABLE_PREFIX_CACHING:-0}")
-
-    if [[ "$DISABLE_PREFIX_CACHING" == "1" ]]; then
-        ENABLE_PREFIX_CACHING=0
-    elif [[ "$ENABLE_PREFIX_CACHING" == "1" && "$MODEL_FAMILY" == qwen* && -z "${MAMBA_CACHE_MODE:-}" ]]; then
-        MAMBA_CACHE_MODE=align
-    fi
-
-    if [[ "$MODEL_FAMILY" == qwen* && -z "${REASONING_PARSER:-}" ]]; then
-        REASONING_PARSER=qwen3
-    fi
-
-    if [[ -z "${MM_LIMIT_JSON:-}" ]]; then
-        LANGUAGE_MODEL_ONLY=${LANGUAGE_MODEL_ONLY:-1}
-        SKIP_MM_PROFILING=${SKIP_MM_PROFILING:-1}
-    fi
+    done
+    return 1
 }
 
-set_turboquant_defaults() {
-    [[ "${KV_CACHE_DTYPE:-}" == turboquant_* ]] || return 0
+start_with_launcher() {
+    mkdir -p "$LOG_DIR" "$TORCH_EXTENSIONS_DIR" "$TORCHINDUCTOR_CACHE_DIR" "$TRITON_CACHE_DIR"
+    cd "$ROOT"
 
-    local reserve=${VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS:-}
-    if [[ -z "$reserve" ]]; then
-        reserve=65536
-        if [[ "$ENABLE_PREFIX_CACHING" == "1" && "$MAX_MODEL_LEN" =~ ^[0-9]+$ && "$MAX_NUM_SEQS" =~ ^[0-9]+$ ]] \
-            && (( MAX_MODEL_LEN >= 240000 )) && (( MAX_NUM_SEQS <= 1 )); then
-            reserve=262144
-        fi
+    "$ROOT/launcher.sh" --non-interactive "$@"
+    if launcher_reads_only "$@"; then
+        return 0
     fi
 
-    export VLLM_TURBOQUANT_USE_FLASHINFER_PREFILL=${VLLM_TURBOQUANT_USE_FLASHINFER_PREFILL:-1}
-    export VLLM_TURBOQUANT_FLASHINFER_BACKEND=${VLLM_TURBOQUANT_FLASHINFER_BACKEND:-fa2}
-    export VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS=$reserve
-    export VLLM_TURBOQUANT_CUDAGRAPH_SPEC_DECODE_SAFE=${VLLM_TURBOQUANT_CUDAGRAPH_SPEC_DECODE_SAFE:-1}
-    export VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK=${VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK:-512}
-    export VLLM_TURBOQUANT_CONTINUATION_SDPA_MAX_QK_CELLS=${VLLM_TURBOQUANT_CONTINUATION_SDPA_MAX_QK_CELLS:-16777216}
-    export VLLM_TURBOQUANT_SPEC_CONTINUATION_DECODE_FASTPATH=${VLLM_TURBOQUANT_SPEC_CONTINUATION_DECODE_FASTPATH:-1}
+    load_manager_state || {
+        echo "ERROR: launcher did not write state file: $STATE_FILE" >&2
+        exit 1
+    }
+
+    if [[ -z "${LAST_PID_FILE:-}" || ! -f "${LAST_PID_FILE:-}" ]]; then
+        echo "ERROR: launcher did not record a pid file in $STATE_FILE" >&2
+        exit 1
+    fi
+    if [[ -z "${LAST_LOG_FILE:-}" || ! -f "${LAST_LOG_FILE:-}" ]]; then
+        echo "ERROR: launcher did not record a log file in $STATE_FILE" >&2
+        exit 1
+    fi
+
+    SERVER_PID=$(cat "$LAST_PID_FILE")
+    if ! pid_is_running "$SERVER_PID"; then
+        echo "ERROR: launched server is not running: $SERVER_PID" >&2
+        exit 1
+    fi
+
+    trap handle_signal TERM INT
+
+    tail --pid="$SERVER_PID" -n +1 -F "$LAST_LOG_FILE" &
+    TAIL_PID=$!
+
+    while pid_is_running "$SERVER_PID"; do
+        sleep 1
+    done
+    wait "$TAIL_PID" 2>/dev/null || true
 }
 
 if [[ $# -gt 0 ]]; then
-    exec python -m vllm.entrypoints.openai.api_server "$@"
+    case "$1" in
+        launcher|launcher.sh)
+            shift
+            cd "$ROOT"
+            exec "$ROOT/launcher.sh" "$@"
+            ;;
+        api-server)
+            shift
+            cd "$ROOT"
+            exec "$ROOT/.venv/bin/python" -m vllm.entrypoints.openai.api_server "$@"
+            ;;
+        --*)
+            start_with_launcher "$@"
+            exit 0
+            ;;
+        *)
+            exec "$@"
+            ;;
+    esac
 fi
 
-if [[ ! -d "$MODEL_DIR" ]]; then
-    echo "ERROR: Model directory not found: $MODEL_DIR" >&2
-    exit 1
-fi
-
-profile_file=$(resolve_profile_file) || {
-    echo "ERROR: Profile not found: ${PROFILE_FILE:-$PROFILE} under $PROFILE_DIR" >&2
-    exit 1
-}
-
-apply_profile_overrides "$profile_file"
-set_mode_defaults
-set_route_defaults
-set_turboquant_defaults
-
-args=(
-    --host "$HOST"
-    --port "$PORT"
-    --model "$MODEL_DIR"
-    --served-model-name "$SERVED_NAME"
-    --dtype half
-    --tensor-parallel-size "$TP_SIZE"
-    --generation-config vllm
-    --gpu-memory-utilization "$GPU_UTIL"
-    --max-model-len "$MAX_MODEL_LEN"
-    --enable-chunked-prefill
-    --max-num-seqs "$MAX_NUM_SEQS"
-    --max-num-batched-tokens "$MAX_BATCHED_TOKENS"
-)
-
-[[ -n "${QUANTIZATION:-}" ]] && args+=(--quantization "$QUANTIZATION")
-[[ -n "${KV_CACHE_DTYPE:-}" ]] && args+=(--kv-cache-dtype "$KV_CACHE_DTYPE")
-[[ -n "${MAMBA_CACHE_MODE:-}" ]] && args+=(--mamba-cache-mode "$MAMBA_CACHE_MODE")
-[[ "${ENFORCE_EAGER:-0}" == "1" ]] && args+=(--enforce-eager)
-if [[ "$ENABLE_PREFIX_CACHING" == "1" ]]; then
-    args+=(--enable-prefix-caching)
-else
-    args+=(--no-enable-prefix-caching)
-fi
-[[ "$ENABLE_PROMPT_TOKENS_DETAILS" == "1" ]] && args+=(--enable-prompt-tokens-details)
-[[ "${LANGUAGE_MODEL_ONLY:-0}" == "1" ]] && args+=(--language-model-only)
-[[ "${SKIP_MM_PROFILING:-0}" == "1" ]] && args+=(--skip-mm-profiling)
-[[ "${DISABLE_CUSTOM_ALL_REDUCE:-0}" == "1" ]] && args+=(--disable-custom-all-reduce)
-[[ "${DISABLE_LOG_STATS:-0}" == "1" ]] && args+=(--disable-log-stats)
-[[ -n "${REASONING_PARSER:-}" && "${REASONING_PARSER:-}" != "off" ]] && args+=(--reasoning-parser "$REASONING_PARSER")
-[[ -n "${DEFAULT_CHAT_TEMPLATE_KWARGS:-}" ]] && args+=(--default-chat-template-kwargs "$DEFAULT_CHAT_TEMPLATE_KWARGS")
-[[ -n "${TOOL_PARSER_PLUGIN:-}" ]] && args+=(--tool-parser-plugin "$TOOL_PARSER_PLUGIN")
-[[ -n "${TOOL_CALL_PARSER:-}" ]] && args+=(--tool-call-parser "$TOOL_CALL_PARSER")
-[[ "${ENABLE_AUTO_TOOL_CHOICE:-0}" == "1" ]] && args+=(--enable-auto-tool-choice)
-[[ -n "${HF_OVERRIDES_JSON:-}" ]] && args+=(--hf-overrides "$HF_OVERRIDES_JSON")
-[[ -n "${MM_LIMIT_JSON:-}" ]] && args+=(--limit-mm-per-prompt "$MM_LIMIT_JSON")
-
-if [[ -n "${ADDITIONAL_CONFIG_JSON:-}" ]]; then
-    args+=(--additional-config "$ADDITIONAL_CONFIG_JSON")
-elif [[ "$MODEL_FAMILY" == qwen* ]]; then
-    args+=(--additional-config '{"gdn_prefill_backend":"flashqla_legacy"}')
-fi
-
-if [[ -n "${CHAT_TEMPLATE_PRESET:-}" && -f "$TEMPLATE_DIR/$CHAT_TEMPLATE_PRESET" ]]; then
-    CHAT_TEMPLATE_FILE="$TEMPLATE_DIR/$CHAT_TEMPLATE_PRESET"
-fi
-[[ -n "${CHAT_TEMPLATE_FILE:-}" ]] && args+=(--chat-template "$CHAT_TEMPLATE_FILE")
-
-capture=$((MTP_K + 1))
-if [[ -n "${SPECULATIVE_CONFIG:-}" ]]; then
-    args+=(--speculative-config "$SPECULATIVE_CONFIG")
-elif (( MTP_K > 0 )); then
-    args+=(--speculative-config "{\"method\":\"mtp\",\"num_speculative_tokens\":${MTP_K}}")
-fi
-
-if [[ -n "${COMPILATION_CONFIG_JSON:-}" ]]; then
-    args+=(--compilation-config "$COMPILATION_CONFIG_JSON")
-elif (( MTP_K > 0 )); then
-    args+=(--compilation-config "{\"cudagraph_mode\":\"FULL_AND_PIECEWISE\",\"cudagraph_capture_sizes\":[${capture}],\"max_cudagraph_capture_size\":${capture}}")
-else
-    args+=(--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","cudagraph_capture_sizes":[1],"max_cudagraph_capture_size":1}')
-fi
-
-echo "=========================================="
-echo " vLLM 2080Ti Definitive Docker"
-echo "=========================================="
-nvidia-smi --query-gpu=index,name,memory.used,memory.total,temperature.gpu --format=csv,noheader || true
-echo "Model Dir: $MODEL_DIR"
-echo "Profile: $profile_file"
-echo "Mode: $MODE"
-echo "Served Name: $SERVED_NAME"
-echo "KV: ${KV_CACHE_DTYPE:-fp16}"
-echo "Context: $MAX_MODEL_LEN"
-echo "MTP: $MTP_K"
-echo "Port: $PORT"
-printf 'Command: python -m vllm.entrypoints.openai.api_server'
-printf ' %q' "${args[@]}"
-echo
-echo "=========================================="
-
-if [[ "${DRY_RUN:-0}" == "1" ]]; then
-    exit 0
-fi
-
-exec python -m vllm.entrypoints.openai.api_server "${args[@]}"
+start_with_launcher

--- a/docker/fetch_git_with_mirrors.sh
+++ b/docker/fetch_git_with_mirrors.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=/dev/null
+source "$ROOT_DIR/docker/build_network_routes.sh"
+
+usage() {
+  echo "usage: $0 --repo <repo> --target <dir> --mode <commit|ref> --ref <value>" >&2
+  exit 2
+}
+
+REPO=
+TARGET=
+MODE=
+REF=
+GIT_HTTP_VERSION=${GIT_HTTP_VERSION:-HTTP/1.1}
+BUILD_GIT_ACTIVE_PREFIX=${BUILD_GIT_ACTIVE_PREFIX:-}
+BUILD_GIT_FOREIGN_REPO_PREFIX=${BUILD_GIT_FOREIGN_REPO_PREFIX:-https://gh-proxy.com/}
+BUILD_GIT_DOMESTIC_REPO_PREFIX=${BUILD_GIT_DOMESTIC_REPO_PREFIX:-https://ghfast.top/}
+BUILD_GIT_MIRROR_PREFIXES=${BUILD_GIT_MIRROR_PREFIXES:-$BUILD_GIT_FOREIGN_REPO_PREFIX $BUILD_GIT_DOMESTIC_REPO_PREFIX}
+BUILD_GIT_PRIMARY_TIMEOUT_SECONDS=${BUILD_GIT_PRIMARY_TIMEOUT_SECONDS:-120}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO=${2:-}
+      shift 2
+      ;;
+    --target)
+      TARGET=${2:-}
+      shift 2
+      ;;
+    --mode)
+      MODE=${2:-}
+      shift 2
+      ;;
+    --ref)
+      REF=${2:-}
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -n "$REPO" && -n "$TARGET" && -n "$MODE" && -n "$REF" ]] || usage
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+git_url_with_prefix() {
+  local prefix=$1
+  local repo=$2
+  if [[ "$prefix" == *"{}"* ]]; then
+    printf '%s\n' "${prefix//\{\}/$repo}"
+  else
+    printf '%s%s\n' "$prefix" "$repo"
+  fi
+}
+
+run_git_network_cmd() {
+  local timeout_seconds=${1:-}
+  shift
+
+  if [[ -n "$timeout_seconds" ]]; then
+    timeout --preserve-status "$timeout_seconds" "$@"
+  else
+    "$@"
+  fi
+}
+
+fetch_once() {
+  local repo=$1
+  local timeout_seconds=${2:-}
+
+  rm -rf "$TARGET"
+  mkdir -p "$(dirname -- "$TARGET")"
+
+  case "$MODE" in
+    commit)
+      git init "$TARGET"
+      git -c http.version="$GIT_HTTP_VERSION" -C "$TARGET" remote add origin "$repo"
+      run_git_network_cmd "$timeout_seconds" \
+        git -c http.version="$GIT_HTTP_VERSION" -C "$TARGET" fetch --depth=1 origin "$REF"
+      git -C "$TARGET" checkout -q FETCH_HEAD
+      ;;
+    ref)
+      run_git_network_cmd "$timeout_seconds" \
+        git -c http.version="$GIT_HTTP_VERSION" clone --depth=1 --branch "$REF" --single-branch "$repo" "$TARGET"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+append_candidate_prefix() {
+  local prefix=$1
+  local existing
+  if ((${#CANDIDATE_PREFIXES[@]} > 0)); then
+    for existing in "${CANDIDATE_PREFIXES[@]}"; do
+      [[ "$existing" == "$prefix" ]] && return 0
+    done
+  fi
+  CANDIDATE_PREFIXES+=("$prefix")
+}
+
+if ! is_positive_integer "$BUILD_GIT_PRIMARY_TIMEOUT_SECONDS"; then
+  echo "BUILD_GIT_PRIMARY_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ -n "$BUILD_GIT_ACTIVE_PREFIX" ]]; then
+  FETCH_REPO=$(git_url_with_prefix "$BUILD_GIT_ACTIVE_PREFIX" "$REPO")
+else
+  FETCH_REPO=$REPO
+fi
+echo "Git fetch attempt: $FETCH_REPO"
+if fetch_once "$FETCH_REPO" "$BUILD_GIT_PRIMARY_TIMEOUT_SECONDS"; then
+  exit 0
+fi
+
+for MIRROR_PREFIX in $BUILD_GIT_MIRROR_PREFIXES; do
+  [[ -n "$MIRROR_PREFIX" ]] || continue
+  FETCH_REPO=$(git_url_with_prefix "$MIRROR_PREFIX" "$REPO")
+  echo "Git fetch attempt: $FETCH_REPO"
+  if fetch_once "$FETCH_REPO"; then
+    exit 0
+  fi
+done
+
+echo "Git fetch failed after primary and mirror attempts: $REPO" >&2
+exit 1

--- a/docker/fetch_git_with_mirrors.sh
+++ b/docker/fetch_git_with_mirrors.sh
@@ -51,6 +51,26 @@ is_positive_integer() {
   [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
 }
 
+validate_target_path() {
+  local target=$1
+  local parent
+  local base
+
+  case "$target" in
+    ""|"/"|"."|"..")
+      echo "Refusing unsafe git target path: $target" >&2
+      exit 2
+      ;;
+  esac
+
+  parent=$(dirname -- "$target")
+  base=$(basename -- "$target")
+  if [[ "$parent" == "/" || "$parent" == "." || "$base" == "." || "$base" == ".." ]]; then
+    echo "Refusing unsafe git target path: $target" >&2
+    exit 2
+  fi
+}
+
 git_url_with_prefix() {
   local prefix=$1
   local repo=$2
@@ -97,21 +117,11 @@ fetch_once() {
   esac
 }
 
-append_candidate_prefix() {
-  local prefix=$1
-  local existing
-  if ((${#CANDIDATE_PREFIXES[@]} > 0)); then
-    for existing in "${CANDIDATE_PREFIXES[@]}"; do
-      [[ "$existing" == "$prefix" ]] && return 0
-    done
-  fi
-  CANDIDATE_PREFIXES+=("$prefix")
-}
-
 if ! is_positive_integer "$BUILD_GIT_PRIMARY_TIMEOUT_SECONDS"; then
   echo "BUILD_GIT_PRIMARY_TIMEOUT_SECONDS must be a positive integer." >&2
   exit 2
 fi
+validate_target_path "$TARGET"
 
 if [[ -n "$BUILD_GIT_ACTIVE_PREFIX" ]]; then
   FETCH_REPO=$(git_url_with_prefix "$BUILD_GIT_ACTIVE_PREFIX" "$REPO")
@@ -123,11 +133,28 @@ if fetch_once "$FETCH_REPO" "$BUILD_GIT_PRIMARY_TIMEOUT_SECONDS"; then
   exit 0
 fi
 
+declare -a MIRROR_PREFIXES=()
+if [[ -n "$BUILD_GIT_ACTIVE_PREFIX" ]]; then
+  MIRROR_PREFIXES+=("$BUILD_GIT_ACTIVE_PREFIX")
+fi
 for MIRROR_PREFIX in $BUILD_GIT_MIRROR_PREFIXES; do
+  local_seen=0
   [[ -n "$MIRROR_PREFIX" ]] || continue
+  for EXISTING_PREFIX in "${MIRROR_PREFIXES[@]}"; do
+    if [[ "$EXISTING_PREFIX" == "$MIRROR_PREFIX" ]]; then
+      local_seen=1
+      break
+    fi
+  done
+  (( local_seen == 0 )) && MIRROR_PREFIXES+=("$MIRROR_PREFIX")
+done
+
+for MIRROR_PREFIX in "${MIRROR_PREFIXES[@]}"; do
+  [[ -n "$MIRROR_PREFIX" ]] || continue
+  [[ -n "$BUILD_GIT_ACTIVE_PREFIX" && "$MIRROR_PREFIX" == "$BUILD_GIT_ACTIVE_PREFIX" ]] && continue
   FETCH_REPO=$(git_url_with_prefix "$MIRROR_PREFIX" "$REPO")
   echo "Git fetch attempt: $FETCH_REPO"
-  if fetch_once "$FETCH_REPO"; then
+  if fetch_once "$FETCH_REPO" "$BUILD_GIT_PRIMARY_TIMEOUT_SECONDS"; then
     exit 0
   fi
 done

--- a/docker/uv_pip_with_fallback.sh
+++ b/docker/uv_pip_with_fallback.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=/dev/null
+source "$ROOT_DIR/docker/build_network_routes.sh"
+
+BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS=${BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS:-60}
+BUILD_PYPI_MIRROR_INDEX=${BUILD_PYPI_MIRROR_INDEX:-${BUILD_PYPI_DOMESTIC_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}}
+BUILD_WHEELHOUSE_DIR=${BUILD_WHEELHOUSE_DIR:-}
+
+is_positive_integer() {
+  [[ "${1:-}" =~ ^[1-9][0-9]*$ ]]
+}
+
+WHEELHOUSE_DIR=$BUILD_WHEELHOUSE_DIR
+if [[ -z "$WHEELHOUSE_DIR" && -d /data/wheelhouse/cu128 ]]; then
+  WHEELHOUSE_DIR=/data/wheelhouse/cu128
+fi
+
+declare -a UV_ENV=(env)
+if [[ -n "$WHEELHOUSE_DIR" ]]; then
+  if [[ -d "$WHEELHOUSE_DIR" ]]; then
+    UV_ENV+=("UV_FIND_LINKS=$WHEELHOUSE_DIR")
+  else
+    echo "BUILD_WHEELHOUSE_DIR does not exist: $WHEELHOUSE_DIR" >&2
+    exit 2
+  fi
+fi
+
+if [[ "${BUILD_PYPI_MIRROR_FALLBACK:-1}" != "1" ]]; then
+  if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" ]]; then
+    exec "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_ACTIVE_INDEX" uv pip "$@"
+  fi
+  exec "${UV_ENV[@]}" uv pip "$@"
+fi
+
+if ! is_positive_integer "$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS"; then
+  echo "BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
+
+if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" ]]; then
+  if "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_ACTIVE_INDEX" \
+      timeout --preserve-status "$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS" uv pip "$@"; then
+    exit 0
+  fi
+else
+  if "${UV_ENV[@]}" timeout --preserve-status "$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS" uv pip "$@"; then
+    exit 0
+  fi
+fi
+
+echo "Selected-route Python package install failed; retrying with mirror index." >&2
+exec "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_MIRROR_INDEX" UV_INDEX_STRATEGY=unsafe-best-match uv pip "$@"

--- a/docker/uv_pip_with_fallback.sh
+++ b/docker/uv_pip_with_fallback.sh
@@ -6,6 +6,7 @@ ROOT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 source "$ROOT_DIR/docker/build_network_routes.sh"
 
 BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS=${BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS:-60}
+BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS=${BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS:-$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS}
 BUILD_PYPI_MIRROR_INDEX=${BUILD_PYPI_MIRROR_INDEX:-${BUILD_PYPI_DOMESTIC_INDEX:-https://pypi.tuna.tsinghua.edu.cn/simple}}
 BUILD_WHEELHOUSE_DIR=${BUILD_WHEELHOUSE_DIR:-}
 
@@ -39,6 +40,10 @@ if ! is_positive_integer "$BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS"; then
   echo "BUILD_PYPI_PRIMARY_TIMEOUT_SECONDS must be a positive integer." >&2
   exit 2
 fi
+if ! is_positive_integer "$BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS"; then
+  echo "BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS must be a positive integer." >&2
+  exit 2
+fi
 
 if [[ -n "${BUILD_PYPI_ACTIVE_INDEX:-}" ]]; then
   if "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_ACTIVE_INDEX" \
@@ -52,4 +57,5 @@ else
 fi
 
 echo "Selected-route Python package install failed; retrying with mirror index." >&2
-exec "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_MIRROR_INDEX" UV_INDEX_STRATEGY=unsafe-best-match uv pip "$@"
+exec "${UV_ENV[@]}" UV_DEFAULT_INDEX="$BUILD_PYPI_MIRROR_INDEX" \
+  timeout --preserve-status "$BUILD_PYPI_FALLBACK_TIMEOUT_SECONDS" uv pip "$@"

--- a/tools/patch_flashqla_sm75_imports.py
+++ b/tools/patch_flashqla_sm75_imports.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Patch FlashQLA so SM70/SM75 legacy imports do not trip SM90-only paths."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+
+def write_text(path: Path, content: str) -> None:
+    if not path.exists():
+        raise SystemExit(f"missing FlashQLA file: {path}")
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        raise SystemExit(
+            "usage: patch_flashqla_sm75_imports.py <flashqla_dir> <patch_dir>"
+        )
+
+    root = Path(sys.argv[1]).resolve()
+    patch_root = Path(sys.argv[2]).resolve()
+
+    write_text(
+        root / "flash_qla" / "__init__.py",
+        '''# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+__version__ = "0.1.0"
+
+try:
+    from flash_qla.ops.gated_delta_rule.chunk import (
+        chunk_gated_delta_rule_fwd,
+        chunk_gated_delta_rule_bwd,
+        chunk_gated_delta_rule,
+    )
+except ValueError:
+    chunk_gated_delta_rule_fwd = None
+    chunk_gated_delta_rule_bwd = None
+    chunk_gated_delta_rule = None
+
+__all__ = [
+    "chunk_gated_delta_rule_fwd",
+    "chunk_gated_delta_rule_bwd",
+    "chunk_gated_delta_rule",
+]
+''',
+    )
+    write_text(
+        root / "flash_qla" / "ops" / "__init__.py",
+        '''# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+try:
+    from .gated_delta_rule import chunk_gated_delta_rule
+except ValueError:
+    chunk_gated_delta_rule = None
+
+__all__ = ["chunk_gated_delta_rule"]
+''',
+    )
+    write_text(
+        root / "flash_qla" / "ops" / "gated_delta_rule" / "__init__.py",
+        '''# Copyright (c) 2026 The Qwen team, Alibaba Group.
+# Licensed under The MIT License [see LICENSE for details]
+
+try:
+    from .chunk import chunk_gated_delta_rule
+except ValueError:
+    chunk_gated_delta_rule = None
+
+__all__ = ["chunk_gated_delta_rule"]
+''',
+    )
+
+    files = (
+        (
+            patch_root / "sm_legacy.py",
+            root / "flash_qla" / "ops" / "gated_delta_rule" / "legacy" / "sm_legacy.py",
+        ),
+        (
+            patch_root / "gdn_forward.cu",
+            root
+            / "flash_qla"
+            / "ops"
+            / "gated_delta_rule"
+            / "legacy"
+            / "csrc"
+            / "gdn_forward.cu",
+        ),
+    )
+    for src, dst in files:
+        if not src.exists():
+            raise SystemExit(f"missing FlashQLA SM75 patch file: {src}")
+        if not dst.exists():
+            raise SystemExit(f"missing FlashQLA target file: {dst}")
+        shutil.copyfile(src, dst)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/patch_flashqla_sm75_imports.py
+++ b/tools/patch_flashqla_sm75_imports.py
@@ -36,7 +36,7 @@ try:
         chunk_gated_delta_rule_bwd,
         chunk_gated_delta_rule,
     )
-except ValueError:
+except (ImportError, OSError, RuntimeError, ValueError):
     chunk_gated_delta_rule_fwd = None
     chunk_gated_delta_rule_bwd = None
     chunk_gated_delta_rule = None
@@ -55,7 +55,7 @@ __all__ = [
 
 try:
     from .gated_delta_rule import chunk_gated_delta_rule
-except ValueError:
+except (ImportError, OSError, RuntimeError, ValueError):
     chunk_gated_delta_rule = None
 
 __all__ = ["chunk_gated_delta_rule"]
@@ -68,7 +68,7 @@ __all__ = ["chunk_gated_delta_rule"]
 
 try:
     from .chunk import chunk_gated_delta_rule
-except ValueError:
+except (ImportError, OSError, RuntimeError, ValueError):
     chunk_gated_delta_rule = None
 
 __all__ = ["chunk_gated_delta_rule"]


### PR DESCRIPTION
## Summary
- add a Docker build/runtime path for the SM75 v0.1.12 stack
- include a compose service for the Qwen3.6 27B GPTQ-Int4 TQK8V4 256K profile
- fetch and patch FlashQLA SM70/SM75 legacy imports during Docker build
- include the no-thinking chat template used by the Docker entrypoint

## Validation
- bash -n docker/docker-entrypoint.sh
- python3 -m py_compile tools/patch_flashqla_sm75_imports.py
- docker compose -f docker/docker-compose.yml config vllm
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hardened Docker build/runtime for SM75 `vLLM` v0.1.12 and a ready-to-run compose service for `Qwen3.6-27B` GPTQ‑Int4. Now includes a host preflight build wrapper that benchmarks network routes and auto-tunes parallelism, validates Git targets, safely parses launcher state, and uses mirrors for resilient installs.

- New Features
  - Multi-stage Dockerfile on `nvidia/cuda:12.8.1`; pinned Python 3.11 and `uv`; runtime keeps nvcc for on‑device FlashQLA JIT; HEALTHCHECK; default `MAX_JOBS=4`.
  - Host build wrapper `docker/build.sh`: benchmarks PyPI/Git routes, selects the fastest, auto-sets `MAX_JOBS` from CPU/RAM, prints config, and builds via `compose` or plain `docker build`.
  - Resilient deps: `uv` pip falls back to mirror or local wheelhouse; Git fetch uses mirror chain with HTTP/1.1, explicit timeouts, and target‑path validation.
  - Editable `vLLM`; pulls `FlashQLA` at a pinned ref, applies SM70/SM75 patches, and validates legacy import at build.
  - Hardened entrypoint: loads profile env; safe/fast/aggressive modes; MTP/speculative + cudagraph tuning; TurboQuant defaults; chat template args; signal‑forwarded shutdown and log tailing.
  - `docker-compose.yml` for `Qwen3.6-27B` GPTQ‑Int4 TQK8V4 256K; mounts `/models`, caches, exposes 8000, sets GPU env/reservations; adds `chat_template_no_thinking.jinja` and tighter `.dockerignore`.

- Migration
  - Build (recommended): `./docker/build.sh compose` (auto route selection and `MAX_JOBS`).
  - Run: `docker compose -f docker/docker-compose.yml up -d vllm` (fallback build: `MAX_JOBS=4 docker compose -f docker/docker-compose.yml build vllm`).
  - Set `MODEL_DIR` and mount it at `/models` (read‑only).

<sup>Written for commit c99c936ad07d52729cc777edd9171ed040e899ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

