### PR TITLE
feat: add initial DFlash support for Qwen speculative decode

### DIFF
--- a/docs/model-profile-routes.md
+++ b/docs/model-profile-routes.md
@@ -32,7 +32,9 @@ are not capacity evidence.
 
 ## Notes
 
-- Profiles are organized as `profiles/<model>/<mode>/<weight>/<route>.env`.
+- Validated profiles are organized as `profiles/<model>/<mode>/<weight>/<route>.env`.
+  Experimental launch-only presets may also live under
+  `profiles/<model>/experimental/<weight>/`.
 - `normal` is the current recommended production route. `fast` keeps only
   high-performance routes that passed quality smoke. `safe` is the launcher
   eager fallback mode, not the current shipped profile directory.

--- a/launcher.sh
+++ b/launcher.sh
@@ -281,6 +281,55 @@ read_profile_value() {
   ' "$file"
 }
 
+json_config_field() {
+  local payload=$1
+  local field=$2
+
+  python3 - "$field" "$payload" <<'PY'
+import json
+import sys
+
+field = sys.argv[1]
+payload = sys.argv[2]
+
+try:
+    data = json.loads(payload)
+except json.JSONDecodeError as exc:
+    print(f"invalid speculative JSON: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+value = data.get(field)
+if value is None:
+    raise SystemExit(0)
+if isinstance(value, bool):
+    print("1" if value else "0")
+else:
+    print(value)
+PY
+}
+
+effective_speculative_tokens() {
+  local tokens
+
+  if [[ -n "${SPECULATIVE_CONFIG:-}" ]]; then
+    tokens=$(json_config_field "$SPECULATIVE_CONFIG" num_speculative_tokens 2>/dev/null || true)
+    if [[ "$tokens" =~ ^[0-9]+$ ]] && (( tokens > 0 )); then
+      printf '%s\n' "$tokens"
+      return 0
+    fi
+    printf '0\n'
+    return 0
+  fi
+
+  tokens=${MTP_K:-0}
+  if [[ "$tokens" =~ ^[0-9]+$ ]] && (( tokens > 0 )); then
+    printf '%s\n' "$tokens"
+    return 0
+  fi
+
+  printf '0\n'
+}
+
 ROUTE_PROFILE_KEYS=(
   SERVED_NAME
   COMPATIBLE_MODES
@@ -2924,7 +2973,9 @@ build_args() {
   fi
   [[ -n "${CHAT_TEMPLATE_FILE:-}" ]] && VLLM_ARGS+=(--chat-template "$CHAT_TEMPLATE_FILE")
 
-  local capture=$((MTP_K + 1))
+  local spec_tokens capture
+  spec_tokens=$(effective_speculative_tokens)
+  capture=$((spec_tokens + 1))
   if [[ -n "${SPECULATIVE_CONFIG:-}" ]]; then
     VLLM_ARGS+=(--speculative-config "$SPECULATIVE_CONFIG")
   elif (( MTP_K > 0 )); then
@@ -2953,7 +3004,7 @@ build_args() {
 
   if [[ -n "${COMPILATION_CONFIG_JSON:-}" ]]; then
     VLLM_ARGS+=(--compilation-config "$COMPILATION_CONFIG_JSON")
-  elif [[ -n "${SPECULATIVE_CONFIG:-}" || "$MTP_K" -gt 0 ]]; then
+  elif [[ -n "${SPECULATIVE_CONFIG:-}" || "$spec_tokens" -gt 0 ]]; then
     VLLM_ARGS+=(--compilation-config "{\"cudagraph_mode\":\"${cudagraph_mode}\",\"cudagraph_capture_sizes\":[${capture}],\"max_cudagraph_capture_size\":${capture}}")
   else
     VLLM_ARGS+=(--compilation-config "{\"cudagraph_mode\":\"${cudagraph_mode}\",\"cudagraph_capture_sizes\":[1],\"max_cudagraph_capture_size\":1}")

--- a/launcher.sh
+++ b/launcher.sh
@@ -310,9 +310,16 @@ PY
 
 effective_speculative_tokens() {
   local tokens
+  local status
 
   if [[ -n "${SPECULATIVE_CONFIG:-}" ]]; then
-    tokens=$(json_config_field "$SPECULATIVE_CONFIG" num_speculative_tokens 2>/dev/null || true)
+    set +e
+    tokens=$(json_config_field "$SPECULATIVE_CONFIG" num_speculative_tokens 2>/dev/null)
+    status=$?
+    set -e
+    if (( status == 2 )); then
+      die "SPECULATIVE_CONFIG contains invalid JSON."
+    fi
     if [[ "$tokens" =~ ^[0-9]+$ ]] && (( tokens > 0 )); then
       printf '%s\n' "$tokens"
       return 0
@@ -328,6 +335,20 @@ effective_speculative_tokens() {
   fi
 
   printf '0\n'
+}
+
+validate_speculative_config() {
+  local status
+
+  [[ -n "${SPECULATIVE_CONFIG:-}" ]] || return 0
+
+  set +e
+  json_config_field "$SPECULATIVE_CONFIG" num_speculative_tokens >/dev/null 2>&1
+  status=$?
+  set -e
+  if (( status == 2 )); then
+    die "SPECULATIVE_CONFIG contains invalid JSON."
+  fi
 }
 
 ROUTE_PROFILE_KEYS=(
@@ -3656,6 +3677,7 @@ prepare_runtime_defaults() {
   SERVICE_SCOPE=${SERVICE_SCOPE:-local}
   normalize_message_type_defaults
   apply_prefix_cache_defaults
+  validate_speculative_config
   ENABLE_AUTO_TOOL_CHOICE=$(normalize_bool "${ENABLE_AUTO_TOOL_CHOICE:-0}")
   apply_family_reasoning_defaults
   if [[ "$ENABLE_AUTO_TOOL_CHOICE" == "1" ]]; then

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -16,6 +16,8 @@ Profile layout:
 profiles/
   templates/
   qwen27b/
+    experimental/
+      int4/
     normal/
       fp8/
       int4/
@@ -51,8 +53,11 @@ if you need to run without a reasoning parser for diagnostics.
 File names describe the intended route:
 
 ```text
-<kv-precision>-<context>-<mtp>-<message-type>.env
+<kv-precision>-<context>-<speculative>-<message-type>.env
 ```
+
+The speculative slot is typically `nomtp`, `mtp3`, or an experimental draft
+lane such as `dflash8`.
 
 KV positioning:
 
@@ -67,6 +72,10 @@ KV positioning:
 The shipped TQK8V4 profiles use `MAX_BATCHED_TOKENS=2560`, which is the
 validated setting for the prefix-cache path with aligned Qwen hybrid cache
 blocks.
+
+Experimental profiles may exist outside the validated tables below. They are
+kept as launchable presets only and are not promoted deployment routes until
+capacity and throughput evidence is published.
 
 ## Validated Profiles
 

--- a/profiles/README.zh-CN.md
+++ b/profiles/README.zh-CN.md
@@ -15,6 +15,8 @@ parallel size 2。
 profiles/
   templates/
   qwen27b/
+    experimental/
+      int4/
     normal/
       fp8/
       int4/
@@ -49,8 +51,11 @@ reasoning parser，让启动 smoke 和聊天解析都跟模型默认 reasoning �
 文件名描述路线：
 
 ```text
-<kv-precision>-<context>-<mtp>-<message-type>.env
+<kv-precision>-<context>-<speculative>-<message-type>.env
 ```
+
+其中 speculative 这一段通常写成 `nomtp`、`mtp3`，或 `dflash8`
+这类实验性 draft 路线名。
 
 KV 精度定位：
 
@@ -61,6 +66,9 @@ KV 精度定位：
 
 内置 TQK8V4 profile 使用 `MAX_BATCHED_TOKENS=2560`，这是 Qwen hybrid cache
 block 对齐后的 prefix-cache 路径已验证设置。
+
+实验性 profile 可能不会列入下面的已验证表格。它们只作为可启动预设保留，在补齐
+容量和吞吐证据前不作为正式推荐部署路线。
 
 ## 已验证 Profile
 

--- a/profiles/qwen27b/experimental/int4/fp16kv-96K-dflash8-text-only.env
+++ b/profiles/qwen27b/experimental/int4/fp16kv-96K-dflash8-text-only.env
@@ -1,0 +1,13 @@
+SERVED_NAME=qwen27b-int4-fp16kv-96K-dflash8-text-only-cu128
+COMPATIBLE_MODES=aggressive
+MODEL_FAMILY=qwen
+PROFILE_GROUP=qwen36-27b-int4
+MODEL_VARIANT=int4
+MAX_MODEL_LEN=98304
+GPU_UTIL=0.90
+MAX_BATCHED_TOKENS=2048
+MAX_NUM_SEQS=1
+MTP_K=0
+LANGUAGE_MODEL_ONLY=1
+SKIP_MM_PROFILING=1
+SPECULATIVE_CONFIG='{"method":"dflash","model":"z-lab/Qwen3.6-27B-DFlash","num_speculative_tokens":8,"use_local_argmax_reduction":true}'

--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -108,6 +108,7 @@ class LogitsProcessor(PluggableLayer):
         lm_head: VocabParallelEmbedding,
         hidden_states: torch.Tensor,
         embedding_bias: torch.Tensor | None = None,
+        disallowed_token_ids_mask: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Vocab-parallel argmax without all-gathering full logits.
 
@@ -127,6 +128,26 @@ class LogitsProcessor(PluggableLayer):
             logits = torch.tanh(logits / self.soft_cap) * self.soft_cap
         if self.scale != 1.0:
             logits = logits * self.scale
+
+        if disallowed_token_ids_mask is not None:
+            if disallowed_token_ids_mask.shape[0] != hidden_states.shape[0]:
+                raise ValueError(
+                    "disallowed_token_ids_mask batch does not match hidden states."
+                )
+            shard_indices = lm_head.shard_indices
+            shard_mask = disallowed_token_ids_mask[
+                :,
+                shard_indices.org_vocab_start_index : shard_indices.org_vocab_end_index,
+            ]
+            if shard_mask.shape[1] != logits.shape[-1]:
+                padded_mask = torch.ones(
+                    (shard_mask.shape[0], logits.shape[-1]),
+                    dtype=torch.bool,
+                    device=logits.device,
+                )
+                padded_mask[:, : shard_mask.shape[1]] = shard_mask
+                shard_mask = padded_mask
+            logits.masked_fill_(shard_mask, float("-inf"))
 
         # Mask out padding entries beyond org_vocab_size on this shard.
         num_pad = lm_head.shard_indices.num_org_vocab_padding

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -34,6 +34,11 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.multimodal.inputs import NestedTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 
 from .qwen2 import Qwen2MLP as Qwen3MLP
 from .qwen3 import Qwen3ForCausalLM
@@ -45,6 +50,53 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+_DFLASH_VALID_LAYER_TYPES = frozenset({"full_attention", "sliding_attention"})
+
+
+def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types is None:
+        return ("full_attention",) * config.num_hidden_layers
+    if len(layer_types) != config.num_hidden_layers:
+        raise ValueError(
+            f"DFlash layer_types length {len(layer_types)} does not match "
+            f"num_hidden_layers {config.num_hidden_layers}."
+        )
+    invalid = set(layer_types) - _DFLASH_VALID_LAYER_TYPES
+    if invalid:
+        raise ValueError(f"Invalid DFlash layer_type(s): {sorted(invalid)}.")
+    if "sliding_attention" in layer_types and not getattr(
+        config, "sliding_window", None
+    ):
+        raise ValueError(
+            "DFlash sliding_attention layers require `sliding_window` in config."
+        )
+    return tuple(layer_types)
+
+
+class DFlashAttention(Attention):
+    """Attention with DFlash-specific KV allocation semantics.
+
+    The compute path keeps the layer's configured sliding window. The KV cache
+    spec is widened to full attention because DFlash writes every context KV
+    before drafting and cannot evict old context blocks from draft layers.
+    """
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        spec = super().get_kv_cache_spec(vllm_config)
+        if isinstance(spec, SlidingWindowSpec):
+            return FullAttentionSpec(
+                block_size=spec.block_size,
+                num_kv_heads=spec.num_kv_heads,
+                head_size=spec.head_size,
+                head_size_v=getattr(spec, "head_size_v", spec.head_size),
+                dtype=spec.dtype,
+                kv_quant_mode=spec.kv_quant_mode,
+                page_size_padded=spec.page_size_padded,
+            )
+        return spec
 
 
 class DFlashQwen3Attention(nn.Module):
@@ -66,6 +118,7 @@ class DFlashQwen3Attention(nn.Module):
         attention_bias: bool = False,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        sliding_window: int | None = None,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
     ) -> None:
@@ -109,13 +162,14 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
-        self.attn = Attention(
+        self.attn = DFlashAttention(
             self.num_heads,
             self.head_dim,
             self.scaling,
             num_kv_heads=self.num_kv_heads,
             cache_config=cache_config,
             quant_config=quant_config,
+            per_layer_sliding_window=sliding_window,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
         )
@@ -158,12 +212,17 @@ class DFlashQwen3DecoderLayer(nn.Module):
         config: Qwen3Config,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        layer_type: str = "full_attention",
         prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
+        self.layer_type = layer_type
         set_default_rope_theta(config, default_theta=1000000)
         attn_type = AttentionType.DECODER
+        sliding_window = (
+            config.sliding_window if layer_type == "sliding_attention" else None
+        )
 
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
@@ -175,6 +234,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
+            sliding_window=sliding_window,
             rope_parameters=config.rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
@@ -243,12 +303,14 @@ class DFlashQwen3Model(nn.Module):
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
+        self.layer_types = _get_dflash_layer_types(self.config)
         self.layers = nn.ModuleList(
             [
                 DFlashQwen3DecoderLayer(
                     current_vllm_config,
                     prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                     config=self.config,
+                    layer_type=self.layer_types[layer_idx],
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
@@ -565,6 +627,47 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         logits_new[:, targets] = logits
         return logits_new
 
+    def _map_draft_ids_to_target_ids(
+        self,
+        draft_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.draft_id_to_target_id is None:
+            return draft_token_ids
+        target_offsets = self.draft_id_to_target_id[draft_token_ids]
+        return draft_token_ids + target_offsets
+
+    def get_top_tokens(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return target token ids without gathering the full vocab when possible."""
+        draft_token_ids = self.logits_processor.get_top_tokens(
+            self.lm_head, hidden_states
+        )
+        return self._map_draft_ids_to_target_ids(draft_token_ids)
+
+    def get_top_tokens_with_mask(
+        self,
+        hidden_states: torch.Tensor,
+        allowed_token_ids_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply target-vocab token constraints during draft argmax."""
+        draft_mask = allowed_token_ids_mask
+        if self.draft_id_to_target_id is not None:
+            draft_token_ids = torch.arange(
+                self.config.draft_vocab_size,
+                device=allowed_token_ids_mask.device,
+                dtype=torch.long,
+            )
+            target_token_ids = draft_token_ids + self.draft_id_to_target_id
+            draft_mask = allowed_token_ids_mask[:, target_token_ids]
+        draft_token_ids = self.logits_processor.get_top_tokens(
+            self.lm_head,
+            hidden_states,
+            disallowed_token_ids_mask=draft_mask,
+        )
+        return self._map_draft_ids_to_target_ids(draft_token_ids)
+
     def precompute_and_store_context_kv(
         self,
         context_states: torch.Tensor,
@@ -585,6 +688,11 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         needs_squeeze = hidden_states.dim() == 1
         if needs_squeeze:
             hidden_states = hidden_states.unsqueeze(0)
+        fc_weight = getattr(self.model.fc, "weight", None)
+        fc_dtype = fc_weight.dtype if fc_weight is not None else hidden_states.dtype
+        if hidden_states.dtype != fc_dtype:
+            # RMSNorm/native paths can upcast aux hidden states to fp32.
+            hidden_states = hidden_states.to(dtype=fc_dtype)
         result = self.model.fc(hidden_states)
         if needs_squeeze:
             result = result.squeeze(0)

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -92,6 +92,7 @@ class DFlashAttention(Attention):
                 num_kv_heads=spec.num_kv_heads,
                 head_size=spec.head_size,
                 head_size_v=getattr(spec, "head_size_v", spec.head_size),
+                sliding_window=spec.sliding_window,
                 dtype=spec.dtype,
                 kv_quant_mode=spec.kv_quant_mode,
                 page_size_padded=spec.page_size_padded,

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -4,7 +4,7 @@
 
 import math
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import ClassVar, NamedTuple
 
@@ -37,6 +37,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
     MultipleOf,
 )
+from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.kv_cache_interface import AttentionSpec, EncoderOnlyAttentionSpec
 
 logger = init_logger(__name__)
@@ -46,6 +47,10 @@ create_block_mask_compiled = torch.compile(
     create_block_mask, fullgraph=True, mode="reduce-overhead"
 )
 flex_attention_compiled = torch.compile(flex_attention, fullgraph=True)
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
 
 
 def _offsets_to_doc_ids_tensor(
@@ -125,7 +130,26 @@ class FlexAttentionBackend(AttentionBackend):
         head_size: int,
         cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
-        return (2, num_blocks, block_size, num_kv_heads, head_size)
+        return (num_blocks, 2, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        cache_layout = get_kv_cache_layout()
+        if cache_layout == "NHD" and include_num_layers_dimension:
+            return (1, 0, 2, 3, 4, 5)
+        if cache_layout == "NHD":
+            # Keep the logical view as [num_blocks, 2, block_size, ...] while
+            # placing the K/V selector first in physical memory. This makes
+            # kv_cache.unbind(1) produce contiguous per-token K/V pages for the
+            # decoder fast-path and avoids correctness-only compaction on NHD.
+            return (1, 0, 2, 3, 4)
+        if cache_layout == "HND" and include_num_layers_dimension:
+            return (1, 2, 4, 0, 3, 5)
+        if cache_layout == "HND":
+            return (0, 1, 3, 2, 4)
+        raise ValueError(f"Unknown cache layout: {cache_layout}")
 
     @staticmethod
     def get_builder_cls() -> type["FlexAttentionMetadataBuilder"]:
@@ -251,6 +275,79 @@ def physical_to_logical_mapping(
     # NB - Seems like block 0 is always empty so we reset it manually
     physical_to_logical[:, 0] = -1
     return physical_to_logical
+
+
+def compact_interleaved_paged_kv(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    attn_metadata: "FlexAttentionMetadata",
+    num_kv_heads: int,
+    head_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, "FlexAttentionMetadata"]:
+    """Compact only the live physical KV pages for interleaved KV layouts.
+
+    Some runtimes allocate paged KV as [num_blocks, 2, block_size, ...], which
+    makes the K/V views non-contiguous after unbinding the KV axis. Flex
+    attention still needs token-major K/V tensors, so for correctness we gather
+    the live physical pages for the current batch into a dense page space and
+    rebuild the metadata to match that dense layout.
+    """
+    block_table = attn_metadata.block_table[: attn_metadata.num_reqs]
+    max_blocks_per_req = block_table.shape[1]
+    device = block_table.device
+    valid_block_mask = (
+        torch.arange(max_blocks_per_req, device=device).unsqueeze(0)
+        < attn_metadata.num_blocks_per_seq.unsqueeze(1)
+    )
+    live_physical_blocks = torch.unique(
+        block_table.masked_select(valid_block_mask).to(torch.long), sorted=True
+    )
+    if live_physical_blocks.numel() == 0:
+        return (
+            key_cache.reshape(-1, num_kv_heads, head_size),
+            value_cache.reshape(-1, num_kv_heads, head_size),
+            attn_metadata,
+        )
+
+    dense_lookup = torch.full(
+        (key_cache.shape[0],), -1, dtype=torch.long, device=device
+    )
+    dense_lookup[live_physical_blocks] = torch.arange(
+        live_physical_blocks.numel(), device=device, dtype=torch.long
+    )
+
+    dense_block_table = torch.zeros_like(block_table)
+    dense_block_table[valid_block_mask] = dense_lookup[
+        block_table[valid_block_mask].to(torch.long)
+    ].to(block_table.dtype)
+
+    dense_physical_to_logical = physical_to_logical_mapping(
+        dense_block_table,
+        attn_metadata.seq_lens,
+        attn_metadata.block_size,
+        int(live_physical_blocks.numel()),
+    )
+    dense_total_cache_tokens = (
+        int(live_physical_blocks.numel()) * attn_metadata.block_size
+    )
+    dense_metadata = replace(
+        attn_metadata,
+        block_table=dense_block_table,
+        physical_to_logical=dense_physical_to_logical,
+        total_cache_tokens=dense_total_cache_tokens,
+        block_mask=None,
+        direct_build=False,
+        q_block_size=128,
+        kv_block_size=128,
+    )
+
+    key_cache = key_cache.index_select(0, live_physical_blocks).reshape(
+        -1, num_kv_heads, head_size
+    )
+    value_cache = value_cache.index_select(0, live_physical_blocks).reshape(
+        -1, num_kv_heads, head_size
+    )
+    return key_cache, value_cache, dense_metadata
 
 
 def unique_static_unsorted(
@@ -768,9 +865,15 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         self.block_size = kv_cache_spec.block_size
         self.kv_cache_spec = kv_cache_spec
         supports_small_blocks = is_torch_equal_or_newer("2.9.0.dev0")
-        self.direct_build: bool = supports_small_blocks
-        self.q_block_size: int = 16 if supports_small_blocks else 128
-        self.kv_block_size: int = self.block_size if supports_small_blocks else 128
+        # Direct BlockMask lowering feeds kv_block_size into Triton arange(),
+        # which currently requires a power-of-two span. Hybrid Mamba/GDN
+        # routes can align attention blocks to values like 800, so keep those
+        # on the generic 128x128 block-mask path instead of crashing at smoke.
+        self.direct_build: bool = supports_small_blocks and _is_power_of_two(
+            self.block_size
+        )
+        self.q_block_size: int = 16 if self.direct_build else 128
+        self.kv_block_size: int = self.block_size if self.direct_build else 128
 
         self.max_model_len = self.model_config.max_model_len
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
@@ -1005,7 +1108,7 @@ class FlexAttentionImpl(AttentionImpl):
         if self.attn_type == AttentionType.ENCODER_ONLY:
             return
 
-        key_cache, value_cache = kv_cache.unbind(0)
+        key_cache, value_cache = kv_cache.unbind(1)
         torch.ops._C_cache_ops.reshape_and_cache_flash(
             key,
             value,
@@ -1036,7 +1139,7 @@ class FlexAttentionImpl(AttentionImpl):
             key: shape = [num_tokens, num_kv_heads, head_size]
             value: shape = [num_tokens, num_kv_heads, head_size]
             kv_cache: shape =
-                [2, num_blocks, block_size, num_kv_heads, head_size]
+                [num_blocks, 2, block_size, num_kv_heads, head_size]
             attn_metadata: Metadata for attention.
         Returns:
             shape = [num_tokens, num_heads * head_size]
@@ -1055,6 +1158,28 @@ class FlexAttentionImpl(AttentionImpl):
             # return torch.empty_like(query)
 
         num_actual_tokens = attn_metadata.num_actual_tokens
+
+        decoder_key_cache: torch.Tensor | None = None
+        decoder_value_cache: torch.Tensor | None = None
+        if self.attn_type == AttentionType.DECODER:
+            key_cache, value_cache = kv_cache.unbind(1)
+            if key_cache.is_contiguous() and value_cache.is_contiguous():
+                decoder_key_cache = key_cache.view(
+                    -1, self.num_kv_heads, self.head_size
+                )
+                decoder_value_cache = value_cache.view(
+                    -1, self.num_kv_heads, self.head_size
+                )
+            else:
+                decoder_key_cache, decoder_value_cache, attn_metadata = (
+                    compact_interleaved_paged_kv(
+                        key_cache,
+                        value_cache,
+                        attn_metadata,
+                        self.num_kv_heads,
+                        self.head_size,
+                    )
+                )
 
         needs_rebuild_block_mask = False
         if attn_metadata.sliding_window != self.sliding_window:
@@ -1110,14 +1235,11 @@ class FlexAttentionImpl(AttentionImpl):
 
         else:
             assert self.attn_type == AttentionType.DECODER
-            key_cache, value_cache = kv_cache.unbind(0)
-
-            # View out the block_size dim
-            key_cache = key_cache.view(-1, self.num_kv_heads, self.head_size)
-            value_cache = value_cache.view(-1, self.num_kv_heads, self.head_size)
+            assert decoder_key_cache is not None
+            assert decoder_value_cache is not None
             query, key_tensor, value_tensor = map(
                 lambda x: self.view_as_4d(x).permute(0, 2, 1, 3),
-                (query, key_cache, value_cache),
+                (query, decoder_key_cache, decoder_value_cache),
             )
 
             query = query[:, :, :num_actual_tokens, :]

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -174,6 +174,8 @@ def physical_to_logical_mapping(
     seq_lens: torch.Tensor,
     block_size: int,
     total_blocks: int,
+    *,
+    reset_block_zero: bool = True,
 ) -> torch.Tensor:
     """
     Creates an inverse mapping from physical block locations to logical indices.
@@ -272,8 +274,9 @@ def physical_to_logical_mapping(
     physical_to_logical.scatter_reduce_(
         -1, valid_block_table.to(torch.int64), valid_logical_indices, reduce="amax"
     )
-    # NB - Seems like block 0 is always empty so we reset it manually
-    physical_to_logical[:, 0] = -1
+    if reset_block_zero:
+        # Some paged-KV layouts reserve physical block 0 as empty.
+        physical_to_logical[:, 0] = -1
     return physical_to_logical
 
 
@@ -326,6 +329,7 @@ def compact_interleaved_paged_kv(
         attn_metadata.seq_lens,
         attn_metadata.block_size,
         int(live_physical_blocks.numel()),
+        reset_block_zero=False,
     )
     dense_total_cache_tokens = (
         int(live_physical_blocks.numel()) * attn_metadata.block_size

--- a/vllm/v1/spec_decode/gemma4.py
+++ b/vllm/v1/spec_decode/gemma4.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -96,8 +97,18 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                 per_layer_attn_metadata[layer_name] = attn_metadata
         return per_group_attn_metadata, per_layer_attn_metadata
 
-    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        if self._centroids_sizes:
+    def _greedy_sample(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None = None,
+    ) -> torch.Tensor:
+        if (
+            self._centroids_sizes
+            and (
+                sampling_metadata is None
+                or sampling_metadata.allowed_token_ids_mask is None
+            )
+        ):
             T = hidden_states.shape[0]
             for size in self._centroids_sizes:
                 if size >= T:
@@ -105,7 +116,7 @@ class Gemma4Proposer(SpecDecodeBaseProposer):
                     self._centroids_graphs[size].replay()
                     return self._centroids_outputs[size][:T].clone()
             return self.model.get_top_tokens(hidden_states)
-        return super()._greedy_sample(hidden_states)
+        return super()._greedy_sample(hidden_states, sampling_metadata)
 
     def _setup_centroids_cuda_graphs(self) -> None:
         """Capture CUDA graphs for centroids get_top_tokens at key sizes."""

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -383,11 +383,54 @@ class SpecDecodeBaseProposer:
 
         self.cudagraph_dispatcher.initialize_cudagraph_keys(eagle_cudagraph_mode)
 
-    def _greedy_sample(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def _expand_allowed_token_ids_mask(
+        self,
+        num_hidden_state_rows: int,
+        sampling_metadata: SamplingMetadata | None,
+    ) -> torch.Tensor | None:
+        if (
+            sampling_metadata is None
+            or sampling_metadata.allowed_token_ids_mask is None
+        ):
+            return None
+
+        allowed_token_ids_mask = sampling_metadata.allowed_token_ids_mask
+        num_requests = allowed_token_ids_mask.shape[0]
+        if num_hidden_state_rows == num_requests:
+            return allowed_token_ids_mask
+        if num_requests == 0 or num_hidden_state_rows % num_requests != 0:
+            raise ValueError(
+                "Draft sampling rows do not align with allowed_token_ids_mask."
+            )
+        repeat_factor = num_hidden_state_rows // num_requests
+        return allowed_token_ids_mask.repeat_interleave(repeat_factor, dim=0)
+
+    def _greedy_sample(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None = None,
+    ) -> torch.Tensor:
         """Greedy-sample draft tokens from hidden states."""
+        allowed_token_ids_mask = self._expand_allowed_token_ids_mask(
+            hidden_states.shape[0], sampling_metadata
+        )
+        if allowed_token_ids_mask is not None:
+            if self.use_local_argmax_reduction and hasattr(
+                self.model, "get_top_tokens_with_mask"
+            ):
+                return self.model.get_top_tokens_with_mask(
+                    hidden_states, allowed_token_ids_mask
+                )
+            logits = self.model.compute_logits(hidden_states)
+            assert logits is not None
+            logits.masked_fill_(allowed_token_ids_mask, float("-inf"))
+            return logits.argmax(dim=-1)
+
         if self.use_local_argmax_reduction:
             return self.model.get_top_tokens(hidden_states)
-        return self.model.compute_logits(hidden_states).argmax(dim=-1)
+        logits = self.model.compute_logits(hidden_states)
+        assert logits is not None
+        return logits.argmax(dim=-1)
 
     def propose(
         self,
@@ -469,7 +512,9 @@ class SpecDecodeBaseProposer:
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
-            draft_token_ids = self._greedy_sample(sample_hidden_states)
+            draft_token_ids = self._greedy_sample(
+                sample_hidden_states, sampling_metadata
+            )
             return draft_token_ids.view(-1, self.num_speculative_tokens)
 
         if self.uses_mrope:
@@ -484,7 +529,7 @@ class SpecDecodeBaseProposer:
             # (which read via _get_positions) use the correct values.
             self.positions[:batch_size] = positions
 
-        draft_token_ids = self._greedy_sample(sample_hidden_states)
+        draft_token_ids = self._greedy_sample(sample_hidden_states, sampling_metadata)
 
         if self.allowed_attn_types is not None:
             for group_md in per_group_attn_metadata:
@@ -584,7 +629,9 @@ class SpecDecodeBaseProposer:
                     last_hidden_states, hidden_states = ret_hidden_states
 
             hidden_states = hidden_states[:batch_size]
-            draft_token_ids = self._greedy_sample(last_hidden_states[:batch_size])
+            draft_token_ids = self._greedy_sample(
+                last_hidden_states[:batch_size], sampling_metadata
+            )
             draft_token_ids_list.append(draft_token_ids)
 
         # [batch_size, num_speculative_tokens]
@@ -1373,11 +1420,15 @@ class SpecDecodeBaseProposer:
                     f"{self.model.__class__.__name__} does not implement "
                     "get_top_tokens()."
                 )
-            # Warn if draft model has vocab remapping, which forces fallback
-            # to the full-logits path (negating the optimization).
+            supports_vocab_remap_local_argmax = getattr(
+                self.model,
+                "_map_draft_ids_to_target_ids",
+                None,
+            ) is not None
             if (
                 hasattr(self.model, "draft_id_to_target_id")
                 and self.model.draft_id_to_target_id is not None
+                and not supports_vocab_remap_local_argmax
             ):
                 logger.warning(
                     "use_local_argmax_reduction is enabled but draft model "
@@ -1387,8 +1438,14 @@ class SpecDecodeBaseProposer:
                 )
             else:
                 logger.info(
-                    "Using local argmax reduction for draft token generation "
-                    "(communication: O(2*tp_size) vs O(vocab_size))."
+                    "Using local argmax reduction for draft token generation%s "
+                    "(communication: O(2*tp_size) vs O(vocab_size)).",
+                    " with vocab remapping support"
+                    if (
+                        hasattr(self.model, "draft_id_to_target_id")
+                        and self.model.draft_id_to_target_id is not None
+                    )
+                    else "",
                 )
 
     @torch.inference_mode()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -869,7 +869,7 @@ class GPUModelRunner(
         self.execute_model_state: ExecuteModelState | None = None
         self.kv_connector_output: KVConnectorOutput | None = None
         self.mamba_state_idx: dict[str, int] = {}
-        self._mamba_copy_bufs: mamba_utils.MambaCopyBuffers | None = None
+        self._mamba_bufs: mamba_utils.MambaBuffers | None = None
         self.layerwise_nvtx_hooks_registered = False
 
     def update_max_model_len(self, max_model_len: int) -> None:
@@ -969,15 +969,20 @@ class GPUModelRunner(
             with_numpy=numpy,
         )
 
-    def _get_mamba_copy_bufs(self) -> mamba_utils.MambaCopyBuffers:
-        if self._mamba_copy_bufs is None:
-            self._mamba_copy_bufs = mamba_utils.MambaCopyBuffers.create(
-                self.max_num_reqs,
-                self.kv_cache_config,
-                self.model.get_mamba_state_copy_func(),
-                self._make_buffer,
+    def _get_mamba_bufs(self) -> mamba_utils.MambaBuffers:
+        assert self.cache_config.mamba_cache_mode == "align"
+        if self._mamba_bufs is None:
+            self._mamba_bufs = mamba_utils.MambaBuffers.create(
+                max_num_reqs=self.max_num_reqs,
+                kv_cache_config=self.kv_cache_config,
+                copy_funcs=self.model.get_mamba_state_copy_func(),
+                make_buffer=self._make_buffer,
+                device=self.device,
+                with_postprocess_align=(
+                    self.speculative_config is not None and self.model_config.is_hybrid
+                ),
             )
-        return self._mamba_copy_bufs
+        return self._mamba_bufs
 
     def _init_model_kwargs(self):
         model_kwargs = dict[str, Any]()
@@ -1475,20 +1480,38 @@ class GPUModelRunner(
         self.num_accepted_tokens.gpu[:num_reqs] = (output_token_ids != -1).sum(dim=1)
 
         if self.cache_config.mamba_cache_mode == "align":
-            for i, num_tokens in enumerate(
-                self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
-            ):
-                self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
-            mamba_utils.postprocess_mamba(
-                scheduler_output,
-                self.kv_cache_config,
-                self.input_batch,
-                self.requests,
-                self.mamba_state_idx,
-                self.compilation_config.static_forward_context,
-                self.model.get_mamba_state_copy_func(),
-                self._get_mamba_copy_bufs(),
-            )
+            mamba_bufs = self._get_mamba_bufs()
+            if self.sm75_spec_syncs_enabled:
+                # On SM75 safe-sync routes, keep the older CPU-side postprocess
+                # path until the fused GPU align postprocess is proven stable
+                # for hybrid speculative decoding workloads.
+                accepted = self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted
+                mamba_utils.postprocess_mamba(
+                    scheduler_output,
+                    self.kv_cache_config,
+                    self.input_batch,
+                    self.requests,
+                    self.mamba_state_idx,
+                    self.compilation_config.static_forward_context,
+                    self.model.get_mamba_state_copy_func(),
+                    mamba_bufs.preprocess,
+                )
+            else:
+                mamba_utils.postprocess_mamba_align_gpu(
+                    bufs=mamba_bufs,
+                    num_reqs=num_reqs,
+                    num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
+                    num_accepted_tokens_cpu_tensor=(
+                        self.input_batch.num_accepted_tokens_cpu_tensor
+                    ),
+                    input_batch=self.input_batch,
+                    kv_cache_config=self.kv_cache_config,
+                    forward_context=self.compilation_config.static_forward_context,
+                    mamba_state_copy_funcs=self.model.get_mamba_state_copy_func(),
+                )
+            assert self.num_accepted_tokens_event is not None
+            self.num_accepted_tokens_event.record()
         else:
             self.input_batch.num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
                 self.num_accepted_tokens.gpu[:num_reqs], non_blocking=True
@@ -4034,6 +4057,7 @@ class GPUModelRunner(
                 if deferred_state_corrections_fn:
                     deferred_state_corrections_fn()
                     deferred_state_corrections_fn = None
+                mamba_bufs = self._get_mamba_bufs()
                 mamba_utils.preprocess_mamba(
                     scheduler_output,
                     self.kv_cache_config,
@@ -4043,7 +4067,7 @@ class GPUModelRunner(
                     self.requests,
                     self.compilation_config.static_forward_context,
                     self.model.get_mamba_state_copy_func(),
-                    self._get_mamba_copy_bufs(),
+                    mamba_bufs.preprocess,
                 )
                 # preprocess_mamba resets num_accepted_tokens_cpu to 1
                 # for requests whose state was copied to a new block.
@@ -4053,6 +4077,15 @@ class GPUModelRunner(
                     self.input_batch.num_accepted_tokens_cpu[:num_reqs]
                 )
                 self.num_accepted_tokens.copy_to_gpu(num_reqs)
+                if mamba_bufs.postprocess_align is not None:
+                    mamba_utils.stage_postprocess_inputs_to_gpu(
+                        mamba_bufs.postprocess_align,
+                        scheduler_output,
+                        self.input_batch.req_ids,
+                        num_reqs,
+                        self.requests,
+                        self.mamba_state_idx,
+                    )
 
             use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
             ubatch_slices_attn = ubatch_slices_padded if pad_attn else ubatch_slices
@@ -4306,8 +4339,12 @@ class GPUModelRunner(
         propose_drafts_after_bookkeeping = False
         if spec_config is not None:
             # Decide whether to run the drafter or zero out draft tokens.
+            num_drafter_query_tokens = self.num_spec_tokens + (
+                1 if spec_config.use_dflash() else 0
+            )
             input_fits_in_drafter = spec_decode_common_attn_metadata is not None and (
-                spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
+                spec_decode_common_attn_metadata.max_seq_len
+                + num_drafter_query_tokens
                 <= self.effective_drafter_max_model_len
             )
             use_gpu_toks = (
@@ -5060,8 +5097,15 @@ class GPUModelRunner(
         layer_ids = getattr(hf_config, "eagle_aux_hidden_state_layer_ids", None)
         if not layer_ids:
             dflash_config = getattr(hf_config, "dflash_config", None)
+            eagle_config = getattr(hf_config, "eagle_config", None)
             if dflash_config and isinstance(dflash_config, dict):
-                layer_ids = dflash_config.get("target_layer_ids")
+                target_layer_ids = dflash_config.get("target_layer_ids") or []
+                # DFlash target_layer_ids name the source layers before the
+                # residual stream is appended to aux outputs, while Eagle-style
+                # aux collection is 1-based over the emitted hidden-state slots.
+                layer_ids = [layer_id + 1 for layer_id in target_layer_ids]
+            if eagle_config and isinstance(eagle_config, dict):
+                layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):
             return tuple(layer_ids)
@@ -6988,7 +7032,7 @@ class GPUModelRunner(
         """
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
-        self._mamba_copy_bufs = None
+        self._mamba_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         self.initialize_attn_backend(kv_cache_config, is_profiling=is_profiling)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -63,6 +63,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 from vllm.model_executor.layers.mamba.ops.ssu_dispatch import (
     initialize_mamba_ssu_backend,
 )
+from vllm.model_executor.layers.mamba.mamba_utils import is_conv_state_dim_first
 from vllm.model_executor.layers.rotary_embedding import (
     MRotaryEmbedding,
     XDRotaryEmbedding,
@@ -980,6 +981,7 @@ class GPUModelRunner(
                 device=self.device,
                 with_postprocess_align=(
                     self.speculative_config is not None and self.model_config.is_hybrid
+                    and not is_conv_state_dim_first()
                 ),
             )
         return self._mamba_bufs
@@ -1481,10 +1483,12 @@ class GPUModelRunner(
 
         if self.cache_config.mamba_cache_mode == "align":
             mamba_bufs = self._get_mamba_bufs()
-            if self.sm75_spec_syncs_enabled:
+            if self.sm75_spec_syncs_enabled or mamba_bufs.postprocess_align is None:
                 # On SM75 safe-sync routes, keep the older CPU-side postprocess
                 # path until the fused GPU align postprocess is proven stable
-                # for hybrid speculative decoding workloads.
+                # for hybrid speculative decoding workloads. DS conv-state
+                # layout also falls back here because the fused path cannot
+                # safely slice shifted conv windows yet.
                 accepted = self.num_accepted_tokens.gpu[:num_reqs].cpu().numpy()
                 self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted
                 mamba_utils.postprocess_mamba(
@@ -5104,7 +5108,7 @@ class GPUModelRunner(
                 # residual stream is appended to aux outputs, while Eagle-style
                 # aux collection is 1-based over the emitted hidden-state slots.
                 layer_ids = [layer_id + 1 for layer_id in target_layer_ids]
-            if eagle_config and isinstance(eagle_config, dict):
+            elif eagle_config and isinstance(eagle_config, dict):
                 layer_ids = eagle_config.get("eagle_aux_hidden_state_layer_ids")
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -10,6 +10,8 @@ import torch
 from vllm.config import CacheConfig
 from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateCopyFunc,
+    get_conv_copy_spec,
+    get_temporal_copy_spec,
 )
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
@@ -18,6 +20,94 @@ from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
+
+
+@triton.jit
+def postprocess_mamba_fused_kernel(
+    num_accepted_tokens_ptr,
+    mamba_state_idx_ptr,
+    num_scheduled_tokens_ptr,
+    num_computed_tokens_ptr,
+    num_draft_tokens_ptr,
+    block_table_ptrs_ptr,
+    block_table_stride_req: tl.int64,
+    state_base_addrs_ptr,
+    state_block_strides_ptr,
+    state_elem_sizes_ptr,
+    state_inner_sizes_ptr,
+    state_conv_widths_ptr,
+    state_group_indices_ptr,
+    num_accepted_tokens_out_ptr,
+    num_reqs,
+    block_size: tl.constexpr,
+    COPY_BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    state_idx = tl.program_id(1)
+
+    if req_idx >= num_reqs:
+        return
+
+    num_accepted = tl.load(num_accepted_tokens_ptr + req_idx)
+    src_block_idx = tl.load(mamba_state_idx_ptr + req_idx)
+    num_scheduled = tl.load(num_scheduled_tokens_ptr + req_idx)
+    num_computed = tl.load(num_computed_tokens_ptr + req_idx)
+    num_draft = tl.load(num_draft_tokens_ptr + req_idx)
+
+    num_tokens_running_state = num_computed + num_scheduled - num_draft
+    new_num_computed = num_tokens_running_state + num_accepted - 1
+    aligned_new_computed = (new_num_computed // block_size) * block_size
+    if aligned_new_computed < num_tokens_running_state:
+        return
+
+    accept_token_bias = aligned_new_computed - num_tokens_running_state
+    dest_block_idx = aligned_new_computed // block_size - 1
+
+    state_base_addr = tl.load(state_base_addrs_ptr + state_idx)
+    state_block_stride = tl.load(state_block_strides_ptr + state_idx)
+    state_elem_size = tl.load(state_elem_sizes_ptr + state_idx)
+    state_inner_size = tl.load(state_inner_sizes_ptr + state_idx)
+    conv_width = tl.load(state_conv_widths_ptr + state_idx)
+    group_idx = tl.load(state_group_indices_ptr + state_idx).to(tl.int64)
+
+    group_base_addr = tl.load(block_table_ptrs_ptr + group_idx)
+    block_table_typed = group_base_addr.to(tl.pointer_type(tl.int32))
+    block_table_base = block_table_typed + req_idx * block_table_stride_req
+
+    src_block_id = tl.load(block_table_base + src_block_idx).to(tl.int64)
+    dest_block_id = tl.load(block_table_base + dest_block_idx).to(tl.int64)
+    is_conv_state = conv_width > 0
+
+    if is_conv_state:
+        src_offset = accept_token_bias.to(tl.int64) * state_inner_size * state_elem_size
+        src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
+        dst_addr = state_base_addr + dest_block_id * state_block_stride
+        num_elems_to_copy = (conv_width - accept_token_bias).to(
+            tl.int64
+        ) * state_inner_size
+        copy_size = num_elems_to_copy * state_elem_size
+    else:
+        actual_src_block_idx = src_block_idx + accept_token_bias
+        actual_src_block_id = tl.load(block_table_base + actual_src_block_idx).to(
+            tl.int64
+        )
+        src_addr = state_base_addr + actual_src_block_id * state_block_stride
+        dst_addr = state_base_addr + dest_block_id * state_block_stride
+        copy_size = state_inner_size * state_elem_size
+
+    if src_block_idx == dest_block_idx and state_idx == 0:
+        tl.store(num_accepted_tokens_out_ptr + req_idx, 1)
+
+    if src_block_idx == dest_block_idx and accept_token_bias == 0:
+        return
+
+    offsets = tl.arange(0, COPY_BLOCK_SIZE)
+    for i in range(0, copy_size, COPY_BLOCK_SIZE):
+        mask = (i + offsets) < copy_size
+        curr_src = (src_addr + i + offsets).to(tl.pointer_type(tl.uint8))
+        curr_dst = (dst_addr + i + offsets).to(tl.pointer_type(tl.uint8))
+        data = tl.load(curr_src, mask=mask)
+        tl.store(curr_dst, data, mask=mask)
 
 
 @triton.jit
@@ -94,6 +184,206 @@ class MambaCopyBuffers:
         )
 
 
+@dataclasses.dataclass
+class MambaSpecDecodeGPUContext:
+    state_base_addrs: torch.Tensor
+    state_block_strides: torch.Tensor
+    state_elem_sizes: torch.Tensor
+    state_inner_sizes: torch.Tensor
+    state_conv_widths: torch.Tensor
+    state_group_indices: torch.Tensor
+    block_size: int
+    num_layers: int
+    num_state_types: int
+    mamba_group_ids: list[int]
+    num_groups: int
+    num_accepted_tokens_out: torch.Tensor
+    block_table_ptrs: torch.Tensor
+    block_table_stride_req: int = 0
+    mamba_state_idx_buf: CpuGpuBuffer | None = None
+    num_scheduled_tokens_buf: CpuGpuBuffer | None = None
+    num_computed_tokens_buf: CpuGpuBuffer | None = None
+    num_draft_tokens_buf: CpuGpuBuffer | None = None
+    is_initialized: bool = False
+
+    @classmethod
+    def create(
+        cls,
+        max_num_reqs: int,
+        kv_cache_config: KVCacheConfig,
+        num_state_types: int,
+        device: torch.device,
+        make_buffer: Callable[..., CpuGpuBuffer],
+    ) -> "MambaSpecDecodeGPUContext":
+        mamba_group_ids, mamba_spec = get_mamba_groups(kv_cache_config)
+        num_layers = sum(
+            len(kv_cache_config.kv_cache_groups[gid].layer_names)
+            for gid in mamba_group_ids
+        )
+        total_states = num_layers * num_state_types
+        return cls(
+            state_base_addrs=torch.zeros(total_states, dtype=torch.int64, device=device),
+            state_block_strides=torch.zeros(
+                total_states, dtype=torch.int64, device=device
+            ),
+            state_elem_sizes=torch.zeros(
+                total_states, dtype=torch.int32, device=device
+            ),
+            state_inner_sizes=torch.zeros(
+                total_states, dtype=torch.int64, device=device
+            ),
+            state_conv_widths=torch.zeros(
+                total_states, dtype=torch.int32, device=device
+            ),
+            state_group_indices=torch.zeros(
+                total_states, dtype=torch.int32, device=device
+            ),
+            block_size=mamba_spec.block_size,
+            num_layers=num_layers,
+            num_state_types=num_state_types,
+            mamba_group_ids=mamba_group_ids,
+            num_groups=len(mamba_group_ids),
+            num_accepted_tokens_out=torch.zeros(
+                max_num_reqs, dtype=torch.int32, device=device
+            ),
+            block_table_ptrs=torch.zeros(
+                len(mamba_group_ids), dtype=torch.int64, device=device
+            ),
+            mamba_state_idx_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            num_scheduled_tokens_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            num_computed_tokens_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            num_draft_tokens_buf=make_buffer(max_num_reqs, dtype=torch.int32),
+            is_initialized=False,
+        )
+
+    def initialize_from_forward_context(
+        self,
+        kv_cache_config: KVCacheConfig,
+        forward_context: dict[str, Any],
+        mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+        block_tables: list[torch.Tensor],
+    ) -> None:
+        if self.is_initialized:
+            return
+
+        idx = 0
+        for group_local_idx, mamba_group_id in enumerate(self.mamba_group_ids):
+            layer_names = kv_cache_config.kv_cache_groups[mamba_group_id].layer_names
+            for layer_name in layer_names:
+                attention = forward_context[layer_name]
+                kv_caches: list[torch.Tensor] = attention.kv_cache
+                for state_type_idx, state in enumerate(kv_caches):
+                    self.state_base_addrs[idx] = state.data_ptr()
+                    block_stride_elems = state.stride(0) if state.dim() > 1 else state.numel()
+                    self.state_block_strides[idx] = (
+                        block_stride_elems * state.element_size()
+                    )
+                    self.state_elem_sizes[idx] = state.element_size()
+
+                    copy_func = mamba_state_copy_funcs[state_type_idx]
+                    assert (
+                        copy_func is get_conv_copy_spec
+                        or copy_func is get_temporal_copy_spec
+                    ), f"unexpected copy func: {copy_func}"
+                    if copy_func is get_conv_copy_spec:
+                        self.state_conv_widths[idx] = state.size(1) if state.dim() > 1 else 0
+                        self.state_inner_sizes[idx] = (
+                            state.stride(1) if state.dim() > 2 else 1
+                        )
+                    else:
+                        self.state_conv_widths[idx] = 0
+                        self.state_inner_sizes[idx] = (
+                            state[0].numel() if state.dim() > 1 else 1
+                        )
+
+                    self.state_group_indices[idx] = group_local_idx
+                    idx += 1
+
+        assert len(block_tables) == self.num_groups, (
+            f"expected {self.num_groups} block tables, got {len(block_tables)}"
+        )
+        strides = {bt.stride(0) for bt in block_tables}
+        assert len(strides) == 1, (
+            f"all mamba block tables must share stride(0), got {strides}"
+        )
+        self.block_table_stride_req = int(next(iter(strides)))
+        for i, bt in enumerate(block_tables):
+            self.block_table_ptrs[i] = bt.data_ptr()
+
+        self.is_initialized = True
+
+    def run_fused_postprocess(
+        self,
+        num_reqs: int,
+        num_accepted_tokens_gpu: torch.Tensor,
+        mamba_state_idx_gpu: torch.Tensor,
+        num_scheduled_tokens_gpu: torch.Tensor,
+        num_computed_tokens_gpu: torch.Tensor,
+        num_draft_tokens_gpu: torch.Tensor,
+    ) -> None:
+        if num_reqs == 0 or not self.is_initialized:
+            return
+
+        self.num_accepted_tokens_out[:num_reqs].copy_(
+            num_accepted_tokens_gpu[:num_reqs]
+        )
+
+        total_states = self.num_layers * self.num_state_types
+        grid = (num_reqs, total_states)
+        postprocess_mamba_fused_kernel[grid](
+            num_accepted_tokens_gpu,
+            mamba_state_idx_gpu,
+            num_scheduled_tokens_gpu,
+            num_computed_tokens_gpu,
+            num_draft_tokens_gpu,
+            self.block_table_ptrs,
+            self.block_table_stride_req,
+            self.state_base_addrs,
+            self.state_block_strides,
+            self.state_elem_sizes,
+            self.state_inner_sizes,
+            self.state_conv_widths,
+            self.state_group_indices,
+            self.num_accepted_tokens_out,
+            num_reqs,
+            block_size=self.block_size,
+            COPY_BLOCK_SIZE=1024,
+        )
+
+
+@dataclasses.dataclass
+class MambaBuffers:
+    preprocess: MambaCopyBuffers
+    postprocess_align: MambaSpecDecodeGPUContext | None
+
+    @classmethod
+    def create(
+        cls,
+        max_num_reqs: int,
+        kv_cache_config: KVCacheConfig,
+        copy_funcs: tuple[MambaStateCopyFunc, ...],
+        make_buffer: Callable[..., CpuGpuBuffer],
+        device: torch.device,
+        with_postprocess_align: bool,
+    ) -> "MambaBuffers":
+        return cls(
+            preprocess=MambaCopyBuffers.create(
+                max_num_reqs, kv_cache_config, copy_funcs, make_buffer
+            ),
+            postprocess_align=(
+                MambaSpecDecodeGPUContext.create(
+                    max_num_reqs=max_num_reqs,
+                    kv_cache_config=kv_cache_config,
+                    num_state_types=len(copy_funcs),
+                    device=device,
+                    make_buffer=make_buffer,
+                )
+                if with_postprocess_align
+                else None
+            ),
+        )
+
+
 def collect_mamba_copy_meta(
     copy_bufs: MambaCopyBuffers,
     kv_cache_config: KVCacheConfig,
@@ -144,6 +434,17 @@ def do_mamba_copy_block(copy_bufs: MambaCopyBuffers):
     )
 
 
+def cleanup_mamba_state_idx(
+    scheduler_output: SchedulerOutput,
+    mamba_state_idx: dict[str, int],
+) -> None:
+    finished_req_ids = scheduler_output.finished_req_ids
+    preempted_req_ids = scheduler_output.preempted_req_ids or set()
+    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
+    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
+        mamba_state_idx.pop(req_id, None)
+
+
 def preprocess_mamba(
     scheduler_output: SchedulerOutput,
     kv_cache_config: KVCacheConfig,
@@ -165,16 +466,7 @@ def preprocess_mamba(
     # TODO(Chen): we need to optimize this function a lot
     assert cache_config.enable_prefix_caching
     block_size = mamba_spec.block_size
-    finished_req_ids = scheduler_output.finished_req_ids
-    preempted_req_ids = scheduler_output.preempted_req_ids or set()
-    # We need to clear mamba_state_idx for resumed requests. When requests are
-    # force-preempted (e.g., during reset_prefix_cache / KV cache flush),
-    # they appear in resumed_req_ids without a corresponding entry in
-    # preempted_req_ids, leaving stale mamba_state_idx entries that can
-    # point to block indices beyond the new (smaller) block allocation.
-    resumed_req_ids = scheduler_output.scheduled_cached_reqs.resumed_req_ids
-    for req_id in itertools.chain(finished_req_ids, preempted_req_ids, resumed_req_ids):
-        mamba_state_idx.pop(req_id, None)
+    cleanup_mamba_state_idx(scheduler_output, mamba_state_idx)
 
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
@@ -271,3 +563,116 @@ def postprocess_mamba(
             if src_block_idx == dest_block_idx:
                 num_accepted_tokens_cpu[i] = 1
     do_mamba_copy_block(copy_bufs)
+
+
+def postprocess_mamba_align_gpu(
+    *,
+    bufs: MambaBuffers,
+    num_reqs: int,
+    num_accepted_tokens_gpu: torch.Tensor,
+    num_accepted_tokens_cpu_tensor: torch.Tensor,
+    input_batch: GPUInputBatch,
+    kv_cache_config: KVCacheConfig,
+    forward_context: dict[str, Any],
+    mamba_state_copy_funcs: tuple[MambaStateCopyFunc, ...],
+) -> None:
+    ctx = bufs.postprocess_align
+    assert ctx is not None
+    assert ctx.mamba_state_idx_buf is not None
+    assert ctx.num_scheduled_tokens_buf is not None
+    assert ctx.num_computed_tokens_buf is not None
+    assert ctx.num_draft_tokens_buf is not None
+
+    if not ctx.is_initialized:
+        ctx.initialize_from_forward_context(
+            kv_cache_config,
+            forward_context,
+            mamba_state_copy_funcs,
+            [
+                input_batch.block_table[gid].get_device_tensor(num_reqs)
+                for gid in ctx.mamba_group_ids
+            ],
+        )
+
+    ctx.run_fused_postprocess(
+        num_reqs=num_reqs,
+        num_accepted_tokens_gpu=num_accepted_tokens_gpu,
+        mamba_state_idx_gpu=ctx.mamba_state_idx_buf.gpu,
+        num_scheduled_tokens_gpu=ctx.num_scheduled_tokens_buf.gpu,
+        num_computed_tokens_gpu=ctx.num_computed_tokens_buf.gpu,
+        num_draft_tokens_gpu=ctx.num_draft_tokens_buf.gpu,
+    )
+    num_accepted_tokens_cpu_tensor[:num_reqs].copy_(
+        ctx.num_accepted_tokens_out[:num_reqs], non_blocking=True
+    )
+
+
+def stage_postprocess_metadata_to_gpu(
+    scheduler_output: SchedulerOutput,
+    req_ids: list[str],
+    num_reqs: int,
+    requests: dict[str, CachedRequestState],
+    num_scheduled_tokens_buf: CpuGpuBuffer,
+    num_computed_tokens_buf: CpuGpuBuffer,
+    num_draft_tokens_buf: CpuGpuBuffer,
+) -> None:
+    scheduled_spec_tokens = scheduler_output.scheduled_spec_decode_tokens
+    num_scheduled = scheduler_output.num_scheduled_tokens
+    scheduled_np = num_scheduled_tokens_buf.np
+    computed_np = num_computed_tokens_buf.np
+    draft_np = num_draft_tokens_buf.np
+    for i in range(num_reqs):
+        req_id = req_ids[i]
+        scheduled_np[i] = num_scheduled[req_id]
+        computed_np[i] = requests[req_id].num_computed_tokens
+        draft_np[i] = len(scheduled_spec_tokens.get(req_id, []))
+    num_scheduled_tokens_buf.copy_to_gpu(num_reqs)
+    num_computed_tokens_buf.copy_to_gpu(num_reqs)
+    num_draft_tokens_buf.copy_to_gpu(num_reqs)
+
+
+def stage_mamba_state_idx_to_gpu(
+    mamba_state_idx: dict[str, int],
+    req_ids: list[str],
+    num_reqs: int,
+    gpu_buf: CpuGpuBuffer,
+) -> None:
+    np_view = gpu_buf.np
+    for i in range(num_reqs):
+        req_id = req_ids[i]
+        state_idx = mamba_state_idx.get(req_id)
+        assert state_idx is not None, (
+            f"mamba_state_idx missing entry for {req_id!r}; "
+            "preprocess_mamba must run before stage_mamba_state_idx_to_gpu"
+        )
+        np_view[i] = state_idx
+    gpu_buf.copy_to_gpu(num_reqs)
+
+
+def stage_postprocess_inputs_to_gpu(
+    ctx: MambaSpecDecodeGPUContext,
+    scheduler_output: SchedulerOutput,
+    req_ids: list[str],
+    num_reqs: int,
+    requests: dict[str, CachedRequestState],
+    mamba_state_idx: dict[str, int],
+) -> None:
+    assert ctx.mamba_state_idx_buf is not None
+    assert ctx.num_scheduled_tokens_buf is not None
+    assert ctx.num_computed_tokens_buf is not None
+    assert ctx.num_draft_tokens_buf is not None
+    stage_mamba_state_idx_to_gpu(
+        mamba_state_idx,
+        req_ids,
+        num_reqs,
+        ctx.mamba_state_idx_buf,
+    )
+    stage_postprocess_metadata_to_gpu(
+        scheduler_output,
+        req_ids,
+        num_reqs,
+        requests,
+        ctx.num_scheduled_tokens_buf,
+        ctx.num_computed_tokens_buf,
+        ctx.num_draft_tokens_buf,
+    )

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -88,7 +88,7 @@ class KVBlockZeroer:
     def __init__(self, device: torch.device, pin_memory: bool):
         self.device = device
         self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
+        self._meta: list[tuple[torch.Tensor, int, int, int]] | None = None
         self._id_cap: int = 0
         self._ids_pinned: torch.Tensor | None = None
         self._ids_gpu: torch.Tensor | None = None
@@ -115,8 +115,7 @@ class KVBlockZeroer:
         Only AttentionSpec layers are processed; Mamba layers are skipped.
         """
         seen_ptrs: set[int] = set()
-        seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        seg_addrs_by_page_size: dict[int, list[int]] = defaultdict(list)
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
@@ -145,17 +144,31 @@ class KVBlockZeroer:
                 seen_ptrs.add(dp)
 
                 el = kv.element_size()
+                if (
+                    block_dim == 0
+                    and kv.ndim >= 2
+                    and kv.shape[1] == 2
+                ):
+                    key_cache, value_cache = kv.unbind(1)
+                    key_block_bytes = key_cache.shape[1:].numel() * el
+                    value_block_bytes = value_cache.shape[1:].numel() * el
+                    key_stride_bytes = key_cache.stride(0) * el
+                    value_stride_bytes = value_cache.stride(0) * el
+                    if (
+                        key_block_bytes == value_block_bytes
+                        and key_stride_bytes == key_block_bytes
+                        and value_stride_bytes == value_block_bytes
+                    ):
+                        assert key_block_bytes % 4 == 0
+                        cur_page_el = (key_block_bytes // 4) * ratio
+                        seg_addrs_by_page_size[cur_page_el].extend(
+                            [key_cache.data_ptr(), value_cache.data_ptr()]
+                        )
+                        continue
+
                 cur_bytes = kv.stride(block_dim) * el
                 assert cur_bytes % 4 == 0
-                kernel_block_el = cur_bytes // 4
-                cur_page_el = kernel_block_el * ratio
-                if page_size_el is None:
-                    page_size_el = cur_page_el
-                else:
-                    assert page_size_el == cur_page_el, (
-                        f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
-                    )
-
+                cur_page_el = (cur_bytes // 4) * ratio
                 block_stride_bytes = cur_bytes
                 outer_dims = [
                     d
@@ -165,13 +178,12 @@ class KVBlockZeroer:
                 outer_strides = [kv.stride(d) * el for d in outer_dims]
                 for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
                     off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                    seg_addrs.append(dp + off_bytes)
+                    seg_addrs_by_page_size[cur_page_el].append(dp + off_bytes)
 
-        if not seg_addrs or page_size_el is None:
+        if not seg_addrs_by_page_size:
             self._meta = None
             return
 
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
         self._id_cap = 8192
         self._ids_pinned = torch.empty(
             self._id_cap,
@@ -179,18 +191,22 @@ class KVBlockZeroer:
             pin_memory=self.pin_memory,
         )
         self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
-        self._meta = (
-            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
-            blk_size,
-            len(seg_addrs),
-        )
+        self._meta = []
+        for page_size_el, seg_addrs in sorted(seg_addrs_by_page_size.items()):
+            blk_size = min(largest_power_of_2_divisor(page_size_el), 1024)
+            self._meta.append(
+                (
+                    torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
+                    page_size_el,
+                    blk_size,
+                    len(seg_addrs),
+                )
+            )
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
         """Zero the KV cache memory for the given block IDs."""
         if not block_ids or self._meta is None:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
         n_blocks = len(block_ids)
         if n_blocks > self._id_cap:
             self._id_cap = n_blocks * 2
@@ -206,15 +222,16 @@ class KVBlockZeroer:
         self._ids_pinned[:n_blocks].numpy()[:] = block_ids
         idx = self._ids_gpu[:n_blocks]
         idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
-        grid = (n_blocks * n_segs * (page_size_el // blk_size),)
-        _zero_kv_blocks_kernel[grid](
-            seg_addrs,
-            idx,
-            n_blocks,
-            N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
-            BLOCK_SIZE=blk_size,
-        )
+        for seg_addrs, page_size_el, blk_size, n_segs in self._meta:
+            grid = (n_blocks * n_segs * (page_size_el // blk_size),)
+            _zero_kv_blocks_kernel[grid](
+                seg_addrs,
+                idx,
+                n_blocks,
+                N_SEGS=n_segs,
+                PAGE_SIZE_EL=page_size_el,
+                BLOCK_SIZE=blk_size,
+            )
 
 
 @dataclass


### PR DESCRIPTION
1. Add initial DFlash runtime support for Qwen speculative decode.
2. Fix launcher compilation capture sizing when SPECULATIVE_CONFIG is used directly.
3. Add an experimental dflash8 text-only profile for Qwen 27B INT4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds initial DFlash support for Qwen speculative decoding with local-argmax (vocab remap + token masks), robust paged-KV handling, and correct CUDA graph capture sizing. Also ships an experimental `dflash8` text-only profile for Qwen 27B INT4 and integrates a GPU-fused Mamba state aligner.

- **New Features**
  - Qwen DFlash drafter: per-layer types with sliding-window compute and full-attention KV allocation; fast local argmax supports draft→target vocab remap and allowed-token masks.
  - Flex attention: supports interleaved paged KV layout (`[num_blocks, 2, block_size, …]`) via on-the-fly compaction; direct-build now gated to power-of-two block sizes.
  - Spec decode + Mamba: allowed-token masks flow into greedy sampler; GPU-fused Mamba postprocess aligns states after acceptance (CPU fallback kept for SM75 safe-sync).
  - Launcher + profiles: derives effective tokens from `SPECULATIVE_CONFIG` JSON to set capture sizes; adds `profiles/qwen27b/experimental/int4/fp16kv-96K-dflash8-text-only.env`.

- **Bug Fixes**
  - Launcher validates `SPECULATIVE_CONFIG` JSON and fixes capture/compilation sizing when only `num_speculative_tokens` is provided.
  - Drafter fit check accounts for DFlash’s extra prefill token; KV zeroer supports interleaved K/V and mixed page sizes.
  - Fix dtype mismatch in Qwen DFlash FC combine; Gemma4 centroids path disables graphs when token masks are present; clear stale Mamba state indices on finish/preempt/resume to avoid misaligned copies.

<sup>Written for commit 62150e92836c9f6f22137902542dc13f0daedc91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

