### PR TITLE
fix: make launcher non-interactive overrides explicit

### DIFF
--- a/docs/non-interactive-launcher.md
+++ b/docs/non-interactive-launcher.md
@@ -1,0 +1,112 @@
+# Non-Interactive Launcher
+
+`launcher.sh` supports a complete non-interactive startup path for scripted
+deployment, CI checks, and reproducible route validation.
+
+The final precedence is:
+
+`CLI > ENV > PROFILE > default`
+
+`CLI` includes direct flags such as `--max-model-len 262144`, `--set
+KEY=VALUE`, and `--unset KEY`.
+
+## Flag Naming
+
+Known launcher keys can be passed directly as `--lower-kebab-case`:
+
+- `MODEL_DIR` -> `--model-dir`
+- `PROFILE` -> `--profile`
+- `MAX_MODEL_LEN` -> `--max-model-len`
+- `MM_LIMIT_JSON` -> `--mm-limit-json`
+
+For advanced environment variables that are not part of the direct launcher
+surface, use:
+
+- `--set KEY=VALUE`
+- `--unset KEY`
+
+`--unset KEY` clears inherited profile or environment values and then lets the
+launcher fall back to lower-priority defaults. If you need to keep an explicit
+empty string instead of falling back, use `--set KEY=`.
+
+## Common Examples
+
+Print the resolved launch summary without starting the server:
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env
+```
+
+Start from a shipped profile and override only a few fields:
+
+```bash
+./launcher.sh --non-interactive \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --mode normal \
+  --service-scope lan \
+  --max-model-len 196608 \
+  --gpu-devices 0,1
+```
+
+Environment values still work, but CLI wins over them:
+
+```bash
+MAX_MODEL_LEN=131072 \
+MODE=fast \
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --max-model-len 262144
+```
+
+Use `--set` for advanced runtime envs:
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --set VLLM_TURBOQUANT_FLASHINFER_BACKEND=fa2 \
+  --set CC=/usr/bin/gcc-12
+```
+
+Clear a profile-provided field and let the launcher refill the lower-level
+default:
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --unset max-model-len
+```
+
+Force an explicit empty value:
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --set REASONING_PARSER=
+```
+
+## Derived Defaults
+
+Some launcher fields are still normalized after profile loading:
+
+- `MESSAGE_TYPE`, `MM_LIMIT_JSON`, `LANGUAGE_MODEL_ONLY`, and
+  `SKIP_MM_PROFILING`
+- mode-derived runtime knobs such as `ENFORCE_EAGER`,
+  `VLLM_SM75_SPEC_SYNC_MODE`, and
+  `VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH`
+- family defaults such as `REASONING_PARSER=qwen3` on validated Qwen3 routes
+- Qwen prefix-cache defaults such as `MAMBA_CACHE_MODE=align`
+
+Those defaults only fill missing values. Explicit CLI values keep priority.
+
+## Validation Workflow
+
+Use `--print-config` first when changing scripts or deployment automation. It
+prints the final launch summary and exits before starting vLLM, which makes it
+the safest way to verify that every override landed on the final config.

--- a/docs/non-interactive-launcher.zh-CN.md
+++ b/docs/non-interactive-launcher.zh-CN.md
@@ -1,0 +1,108 @@
+# 非交互 Launcher
+
+`launcher.sh` 现在支持完整的非交互启动路径，可用于脚本部署、CI 校验和可复现的
+route 验证。
+
+最终优先级为：
+
+`CLI > ENV > PROFILE > default`
+
+其中 `CLI` 包括直接参数（如 `--max-model-len 262144`）、`--set KEY=VALUE`
+以及 `--unset KEY`。
+
+## 参数命名
+
+已纳入 launcher 管理面的配置，可以直接写成 `--lower-kebab-case`：
+
+- `MODEL_DIR` -> `--model-dir`
+- `PROFILE` -> `--profile`
+- `MAX_MODEL_LEN` -> `--max-model-len`
+- `MM_LIMIT_JSON` -> `--mm-limit-json`
+
+对于不在直接 launcher 参数面上的高级环境变量，使用：
+
+- `--set KEY=VALUE`
+- `--unset KEY`
+
+`--unset KEY` 会清掉继承自 profile 或环境变量的值，然后回落到更低优先级的
+launcher 默认层。如果你需要保留“显式空字符串”而不是回落默认值，使用
+`--set KEY=`。
+
+## 常见示例
+
+只打印最终启动摘要，不真正启动服务：
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env
+```
+
+基于仓库内置 profile 启动，并只覆写少量字段：
+
+```bash
+./launcher.sh --non-interactive \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --mode normal \
+  --service-scope lan \
+  --max-model-len 196608 \
+  --gpu-devices 0,1
+```
+
+环境变量仍然可用，但 CLI 优先级更高：
+
+```bash
+MAX_MODEL_LEN=131072 \
+MODE=fast \
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --max-model-len 262144
+```
+
+用 `--set` 传递高级运行时环境变量：
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --set VLLM_TURBOQUANT_FLASHINFER_BACKEND=fa2 \
+  --set CC=/usr/bin/gcc-12
+```
+
+清掉 profile 提供的字段，并让 launcher 回填更低层默认值：
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --unset max-model-len
+```
+
+强制保留显式空值：
+
+```bash
+./launcher.sh --print-config \
+  --model-dir /models/Qwen3-30B-A3B-Instruct-2507-AWQ \
+  --profile qwen27b/normal/int4/fp16kv-256K-mtp3-text-only.env \
+  --set REASONING_PARSER=
+```
+
+## 派生默认值
+
+profile 加载后，launcher 仍会对部分字段做规范化：
+
+- `MESSAGE_TYPE`、`MM_LIMIT_JSON`、`LANGUAGE_MODEL_ONLY`、
+  `SKIP_MM_PROFILING`
+- 模式派生运行时参数，如 `ENFORCE_EAGER`、
+  `VLLM_SM75_SPEC_SYNC_MODE`、`VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH`
+- 已验证 Qwen3 路线上默认补齐的 `REASONING_PARSER=qwen3`
+- Qwen prefix-cache 路线默认补齐的 `MAMBA_CACHE_MODE=align`
+
+这些默认值只会补空缺字段，不会再反向覆盖显式 CLI 输入。
+
+## 推荐校验方式
+
+调整脚本或部署自动化时，优先先跑 `--print-config`。它会打印最终生效的启动摘要，
+并在真正启动 vLLM 前退出，是确认每个覆写项是否真正落到最终配置上的最稳妥方式。

--- a/launcher.sh
+++ b/launcher.sh
@@ -413,7 +413,9 @@ config_key_has_override() {
 
 config_key_has_explicit_value() {
   local key=$1
-  [[ -n "${CONFIG_OVERRIDE_SOURCE[$key]+x}" && -z "${CONFIG_OVERRIDE_UNSET[$key]+x}" ]]
+  [[ -n "${CONFIG_OVERRIDE_SOURCE[$key]+x}" \
+    && "${CONFIG_OVERRIDE_SOURCE[$key]}" != mode \
+    && -z "${CONFIG_OVERRIDE_UNSET[$key]+x}" ]]
 }
 
 config_key_is_boolean() {
@@ -465,6 +467,13 @@ parse_set_assignment() {
 
 register_env_config_overrides() {
   init_config_registry
+
+  if ! config_key_has_override GPU_DEVICES && env_var_is_exported CUDA_VISIBLE_DEVICES; then
+    set_config_override GPU_DEVICES "${CUDA_VISIBLE_DEVICES:-}" env
+    if [[ -z "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+      CONFIG_OVERRIDE_UNSET["GPU_DEVICES"]=1
+    fi
+  fi
 
   local key
   for key in "${!CONFIG_KNOWN_KEYS[@]}"; do
@@ -2188,11 +2197,15 @@ edit_advanced_parameters() {
   LANGUAGE_MODEL_ONLY=$(prompt_toggle01 "Language-model only" "${LANGUAGE_MODEL_ONLY:-1}") || return 0
   SKIP_MM_PROFILING=$(prompt_toggle01 "Skip multimodal profiling" "${SKIP_MM_PROFILING:-1}") || return 0
   ENFORCE_EAGER=$(prompt_toggle01 "Enforce eager" "${ENFORCE_EAGER:-0}") || return 0
+  CONFIG_OVERRIDE_SOURCE["ENFORCE_EAGER"]=menu
+  unset 'CONFIG_OVERRIDE_UNSET[ENFORCE_EAGER]'
   NO_ASYNC_SCHEDULING=$(prompt_toggle01 "No async scheduling" "${NO_ASYNC_SCHEDULING:-0}") || return 0
   DISABLE_HYBRID_KV_CACHE_MANAGER=$(prompt_toggle01 "Disable hybrid KV cache manager" "${DISABLE_HYBRID_KV_CACHE_MANAGER:-0}") || return 0
   DISABLE_PREFIX_CACHING=$(prompt_toggle01 "Disable prefix caching" "${DISABLE_PREFIX_CACHING:-0}") || return 0
   DISABLE_CUSTOM_ALL_REDUCE=$(prompt_toggle01 "Disable custom all-reduce" "${DISABLE_CUSTOM_ALL_REDUCE:-0}") || return 0
   DISABLE_LOG_STATS=$(prompt_toggle01 "Disable log stats" "${DISABLE_LOG_STATS:-0}") || return 0
+  CONFIG_OVERRIDE_SOURCE["DISABLE_LOG_STATS"]=menu
+  unset 'CONFIG_OVERRIDE_UNSET[DISABLE_LOG_STATS]'
   normalize_message_type_defaults
 }
 
@@ -2969,31 +2982,42 @@ set_derived_default() {
   export "$key"
 }
 
+set_mode_default() {
+  local key=$1
+  local value=$2
+  config_key_has_explicit_value "$key" && return 0
+  printf -v "$key" '%s' "$value"
+  export "$key"
+  CONFIG_OVERRIDE_SOURCE["$key"]=mode
+  unset "CONFIG_OVERRIDE_UNSET[$key]"
+}
+
 apply_mode() {
   normalize_mode
   case "$MODE" in
     normal)
-      set_derived_default ENFORCE_EAGER 0
-      set_derived_default DISABLE_LOG_STATS 1
-      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
-      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
+      set_mode_default ENFORCE_EAGER 0
+      set_mode_default DISABLE_LOG_STATS 1
+      set_mode_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_mode_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
       ;;
     fast)
-      set_derived_default ENFORCE_EAGER 0
-      set_derived_default DISABLE_LOG_STATS 1
-      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
-      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
+      set_mode_default ENFORCE_EAGER 0
+      set_mode_default DISABLE_LOG_STATS 1
+      set_mode_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_mode_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
       ;;
     aggressive)
-      set_derived_default ENFORCE_EAGER 0
-      set_derived_default DISABLE_LOG_STATS 1
-      set_derived_default VLLM_SM75_SPEC_SYNC_MODE nosync
-      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
+      set_mode_default ENFORCE_EAGER 0
+      set_mode_default DISABLE_LOG_STATS 1
+      set_mode_default VLLM_SM75_SPEC_SYNC_MODE nosync
+      set_mode_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
       ;;
     safe)
-      set_derived_default ENFORCE_EAGER 1
-      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
-      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
+      set_mode_default ENFORCE_EAGER 1
+      set_mode_default DISABLE_LOG_STATS 0
+      set_mode_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_mode_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
       ;;
     *)
       die "MODE must be safe, normal, fast, or aggressive."

--- a/launcher.sh
+++ b/launcher.sh
@@ -312,9 +312,253 @@ ROUTE_PROFILE_KEYS=(
   VLLM_INT8KV_FA_PREFILL
 )
 
+NON_INTERACTIVE_CONFIG_KEYS=(
+  MODEL_DIR
+  PROFILE_DIR
+  PROFILE
+  PROFILE_FILE
+  MODE
+  PORT
+  SERVICE_SCOPE
+  GPU_DEVICES
+  TP_SIZE
+  CHAT_TEMPLATE_FILE
+  CHAT_TEMPLATE_PRESET
+  TEMPLATE_DIR
+  REASONING_PARSER
+  DEFAULT_CHAT_TEMPLATE_KWARGS
+  REASONING_MODE
+  REASONING_BUDGET
+  ENABLE_AUTO_TOOL_CHOICE
+  TOOL_CALL_PARSER
+  TOOL_PARSER_PLUGIN
+  ENABLE_PREFIX_CACHING
+  ENABLE_PROMPT_TOKENS_DETAILS
+  DISABLE_PREFIX_CACHING
+  VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH
+  VLLM_ENFORCE_STRICT_TOOL_CALLING
+  MAMBA_CACHE_MODE
+  ENFORCE_EAGER
+  NO_ASYNC_SCHEDULING
+  DISABLE_LOG_STATS
+  VLLM_SM75_SPEC_SYNC_MODE
+  RUNTIME_ROOT
+  LOG_DIR
+  STATE_FILE
+  FLASHQLA_ROOT
+  START_TIMEOUT
+)
+
+NON_INTERACTIVE_BOOLEAN_KEYS=(
+  LANGUAGE_MODEL_ONLY
+  SKIP_MM_PROFILING
+  ENABLE_AUTO_TOOL_CHOICE
+  ENABLE_PREFIX_CACHING
+  ENABLE_PROMPT_TOKENS_DETAILS
+  DISABLE_PREFIX_CACHING
+  VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH
+  VLLM_ENFORCE_STRICT_TOOL_CALLING
+  ENFORCE_EAGER
+  NO_ASYNC_SCHEDULING
+  DISABLE_HYBRID_KV_CACHE_MANAGER
+  DISABLE_CUSTOM_ALL_REDUCE
+  DISABLE_LOG_STATS
+  VLLM_ALLOW_LONG_MAX_MODEL_LEN
+  VLLM_INT8KV_FA_CASCADE_DEQUANT
+  VLLM_INT8KV_FA_CONTINUATION_DEQUANT
+  VLLM_INT8KV_FA_PREFILL
+)
+
+declare -A CONFIG_FLAG_TO_KEY=()
+declare -A CONFIG_KNOWN_KEYS=()
+declare -A CONFIG_BOOLEAN_KEYS=()
+declare -A CONFIG_OVERRIDE_SOURCE=()
+declare -A CONFIG_OVERRIDE_UNSET=()
+CONFIG_REGISTRY_INITIALIZED=0
+
+config_key_to_flag() {
+  local key=${1,,}
+  key=${key//_/-}
+  printf -- '--%s\n' "$key"
+}
+
+normalize_config_key() {
+  local raw=${1#--}
+  local key=${raw//-/_}
+  key=${key^^}
+  [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]] || die "Invalid config key: $1"
+  printf '%s\n' "$key"
+}
+
+init_config_registry() {
+  [[ "$CONFIG_REGISTRY_INITIALIZED" == "1" ]] && return 0
+
+  local key
+  for key in "${ROUTE_PROFILE_KEYS[@]}" "${NON_INTERACTIVE_CONFIG_KEYS[@]}"; do
+    [[ -n "$key" ]] || continue
+    CONFIG_KNOWN_KEYS["$key"]=1
+    CONFIG_FLAG_TO_KEY["$(config_key_to_flag "$key")"]="$key"
+  done
+  for key in "${NON_INTERACTIVE_BOOLEAN_KEYS[@]}"; do
+    [[ -n "$key" ]] || continue
+    CONFIG_BOOLEAN_KEYS["$key"]=1
+  done
+  CONFIG_REGISTRY_INITIALIZED=1
+}
+
+config_key_has_override() {
+  local key=$1
+  [[ -n "${CONFIG_OVERRIDE_SOURCE[$key]+x}" ]]
+}
+
+config_key_has_explicit_value() {
+  local key=$1
+  [[ -n "${CONFIG_OVERRIDE_SOURCE[$key]+x}" && -z "${CONFIG_OVERRIDE_UNSET[$key]+x}" ]]
+}
+
+config_key_is_boolean() {
+  local key=$1
+  [[ -n "${CONFIG_BOOLEAN_KEYS[$key]+x}" ]]
+}
+
+env_var_is_exported() {
+  printenv "$1" >/dev/null 2>&1
+}
+
+set_config_override() {
+  local key=$1
+  local value=$2
+  local source=${3:-cli}
+
+  printf -v "$key" '%s' "$value"
+  export "$key"
+  CONFIG_OVERRIDE_SOURCE["$key"]="$source"
+  unset "CONFIG_OVERRIDE_UNSET[$key]"
+}
+
+unset_config_override() {
+  local key=$1
+  local source=${2:-cli}
+
+  unset "$key"
+  CONFIG_OVERRIDE_SOURCE["$key"]="$source"
+  CONFIG_OVERRIDE_UNSET["$key"]=1
+}
+
+config_key_from_flag() {
+  local flag=$1
+  local key=${CONFIG_FLAG_TO_KEY[$flag]:-}
+  [[ -n "$key" ]] || return 1
+  printf '%s\n' "$key"
+}
+
+parse_set_assignment() {
+  local assignment=$1
+  local source=${2:-cli}
+  local key value
+
+  [[ "$assignment" == *=* ]] || die "--set expects KEY=VALUE."
+  key=$(normalize_config_key "${assignment%%=*}")
+  value=${assignment#*=}
+  set_config_override "$key" "$value" "$source"
+}
+
+register_env_config_overrides() {
+  init_config_registry
+
+  local key
+  for key in "${!CONFIG_KNOWN_KEYS[@]}"; do
+    env_var_is_exported "$key" || continue
+    config_key_has_override "$key" && continue
+    CONFIG_OVERRIDE_SOURCE["$key"]=env
+    if [[ -z "${!key:-}" ]]; then
+      CONFIG_OVERRIDE_UNSET["$key"]=1
+    fi
+  done
+}
+
+apply_launcher_path_defaults() {
+  RUNTIME_ROOT=${RUNTIME_ROOT:-"$MANAGER_ROOT"}
+  PROFILE_DIR=${PROFILE_DIR:-"$MANAGER_ROOT/profiles"}
+  LOG_DIR=${LOG_DIR:-"$MANAGER_ROOT/run-logs"}
+
+  if config_key_has_override PROFILE_DIR && ! config_key_has_explicit_value TEMPLATE_DIR; then
+    TEMPLATE_DIR="$PROFILE_DIR/templates"
+  fi
+  TEMPLATE_DIR=${TEMPLATE_DIR:-"$PROFILE_DIR/templates"}
+
+  if config_key_has_override LOG_DIR && ! config_key_has_explicit_value STATE_FILE; then
+    STATE_FILE="$LOG_DIR/start-manager.state"
+  fi
+  STATE_FILE=${STATE_FILE:-"$LOG_DIR/start-manager.state"}
+}
+
+parse_launcher_args() {
+  init_config_registry
+
+  local arg key value
+  while (($#)); do
+    arg=$1
+    shift
+    case "$arg" in
+      --non-interactive)
+        NON_INTERACTIVE=1
+        ;;
+      --print-config)
+        PRINT_CONFIG=1
+        NON_INTERACTIVE=1
+        ;;
+      --set)
+        (($#)) || die "--set expects KEY=VALUE."
+        parse_set_assignment "$1" cli
+        shift
+        NON_INTERACTIVE=1
+        ;;
+      --set=*)
+        parse_set_assignment "${arg#--set=}" cli
+        NON_INTERACTIVE=1
+        ;;
+      --unset)
+        (($#)) || die "--unset expects KEY."
+        key=$(normalize_config_key "$1")
+        unset_config_override "$key" cli
+        shift
+        NON_INTERACTIVE=1
+        ;;
+      --unset=*)
+        key=$(normalize_config_key "${arg#--unset=}")
+        unset_config_override "$key" cli
+        NON_INTERACTIVE=1
+        ;;
+      --*=*)
+        key=$(config_key_from_flag "${arg%%=*}") || die "Unknown option: ${arg%%=*}"
+        value=${arg#*=}
+        set_config_override "$key" "$value" cli
+        NON_INTERACTIVE=1
+        ;;
+      --*)
+        key=$(config_key_from_flag "$arg") || die "Unknown option: $arg"
+        if config_key_is_boolean "$key" && { (($# == 0)) || [[ "${1:-}" == --* ]]; }; then
+          value=1
+        else
+          (($#)) || die "Option $arg expects a value."
+          value=$1
+          shift
+        fi
+        set_config_override "$key" "$value" cli
+        NON_INTERACTIVE=1
+        ;;
+      *)
+        die "Unknown positional argument: $arg"
+        ;;
+    esac
+  done
+}
+
 reset_route_profile_fields() {
   local key
   for key in "${ROUTE_PROFILE_KEYS[@]}"; do
+    config_key_has_override "$key" && continue
     unset "$key"
   done
 }
@@ -344,7 +588,7 @@ source_profile_defaults() {
   while IFS= read -r key; do
     [[ -n "$key" ]] || continue
     profile_key_is_global "$key" && continue
-    if [[ ${!key+x} ]]; then
+    if config_key_has_override "$key" || [[ ${!key+x} ]]; then
       continue
     fi
     value=$(read_profile_value "$file" "$key")
@@ -362,6 +606,7 @@ apply_profile_overrides() {
   while IFS= read -r key; do
     [[ -n "$key" ]] || continue
     profile_key_is_global "$key" && continue
+    config_key_has_override "$key" && continue
     value=$(read_profile_value "$file" "$key")
     printf -v "$key" '%s' "$value"
     export "$key"
@@ -675,6 +920,9 @@ apply_family_reasoning_defaults() {
   # Qwen3/Qwen3.5 tokenizer configs do not always advertise the parser.
   # Keep request thinking defaults template-driven, but make response parsing
   # explicit so thinking text is not returned as normal content.
+  if config_key_has_explicit_value REASONING_PARSER; then
+    return 0
+  fi
   if reasoning_parser_is_disabled; then
     return 0
   fi
@@ -695,6 +943,10 @@ apply_prefix_cache_defaults() {
     return 0
   fi
 
+  if config_key_has_explicit_value MAMBA_CACHE_MODE; then
+    return 0
+  fi
+
   if [[ "$ENABLE_PREFIX_CACHING" == "1" && "$MODEL_FAMILY" == qwen* ]]; then
     MAMBA_CACHE_MODE=${MAMBA_CACHE_MODE:-align}
   elif [[ "${MAMBA_CACHE_MODE:-}" == "align" ]]; then
@@ -705,26 +957,34 @@ apply_prefix_cache_defaults() {
 }
 
 normalize_message_type_defaults() {
-  local stale_text_only_flags=0
-  if [[ "${MESSAGE_TYPE:-}" == "text+image" || -n "${MM_LIMIT_JSON:-}" ]]; then
+  if config_key_has_explicit_value MESSAGE_TYPE; then
+    MESSAGE_TYPE=${MESSAGE_TYPE:-text-only}
+  elif [[ "${MESSAGE_TYPE:-}" == "text+image" || -n "${MM_LIMIT_JSON:-}" || "${LANGUAGE_MODEL_ONLY:-1}" == "0" ]]; then
     MESSAGE_TYPE=text+image
   else
     MESSAGE_TYPE=text-only
   fi
 
   if [[ "$MESSAGE_TYPE" == "text+image" ]]; then
-    [[ "${LANGUAGE_MODEL_ONLY:-0}" == "1" ]] && stale_text_only_flags=1
-    MM_LIMIT_JSON=${MM_LIMIT_JSON:-'{"image":1,"video":0,"audio":0}'}
-    LANGUAGE_MODEL_ONLY=0
-    if (( stale_text_only_flags )); then
-      SKIP_MM_PROFILING=0
-    else
+    if ! config_key_has_explicit_value MM_LIMIT_JSON; then
+      MM_LIMIT_JSON=${MM_LIMIT_JSON:-'{"image":1,"video":0,"audio":0}'}
+    fi
+    if ! config_key_has_explicit_value LANGUAGE_MODEL_ONLY; then
+      LANGUAGE_MODEL_ONLY=0
+    fi
+    if ! config_key_has_explicit_value SKIP_MM_PROFILING; then
       SKIP_MM_PROFILING=$(normalize_bool "${SKIP_MM_PROFILING:-0}")
     fi
   else
-    MM_LIMIT_JSON=""
-    LANGUAGE_MODEL_ONLY=1
-    SKIP_MM_PROFILING=1
+    if ! config_key_has_explicit_value MM_LIMIT_JSON; then
+      MM_LIMIT_JSON=""
+    fi
+    if ! config_key_has_explicit_value LANGUAGE_MODEL_ONLY; then
+      LANGUAGE_MODEL_ONLY=1
+    fi
+    if ! config_key_has_explicit_value SKIP_MM_PROFILING; then
+      SKIP_MM_PROFILING=1
+    fi
   fi
 }
 
@@ -1356,6 +1616,9 @@ Notes:
     enables strict tool-output constraints for automatic tool choice.
   - thinking_token_budget is a per-request chat parameter in this vLLM runtime.
   - text+image requires a checkpoint that actually supports vision inputs.
+  - Use --set KEY=VALUE for advanced envs such as VLLM_* or compiler paths.
+  - Use --unset KEY to clear inherited profile/env values and fall back to
+    launcher defaults; use --set KEY= to force an empty value when allowed.
   - --print-config prints the final launch summary and exits without starting.
 EOF
   echo
@@ -2695,31 +2958,42 @@ default_gpu_util() {
   fi
 }
 
+set_derived_default() {
+  local key=$1
+  local value=$2
+  config_key_has_explicit_value "$key" && return 0
+  if [[ -n "${!key+x}" && -n "${!key}" ]]; then
+    return 0
+  fi
+  printf -v "$key" '%s' "$value"
+  export "$key"
+}
+
 apply_mode() {
   normalize_mode
   case "$MODE" in
     normal)
-      export ENFORCE_EAGER=0
-      export DISABLE_LOG_STATS=1
-      export VLLM_SM75_SPEC_SYNC_MODE=safe
-      export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=0
+      set_derived_default ENFORCE_EAGER 0
+      set_derived_default DISABLE_LOG_STATS 1
+      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
       ;;
     fast)
-      export ENFORCE_EAGER=0
-      export DISABLE_LOG_STATS=1
-      export VLLM_SM75_SPEC_SYNC_MODE=safe
-      export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=1
+      set_derived_default ENFORCE_EAGER 0
+      set_derived_default DISABLE_LOG_STATS 1
+      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
       ;;
     aggressive)
-      export ENFORCE_EAGER=0
-      export DISABLE_LOG_STATS=1
-      export VLLM_SM75_SPEC_SYNC_MODE=nosync
-      export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=1
+      set_derived_default ENFORCE_EAGER 0
+      set_derived_default DISABLE_LOG_STATS 1
+      set_derived_default VLLM_SM75_SPEC_SYNC_MODE nosync
+      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 1
       ;;
     safe)
-      export ENFORCE_EAGER=1
-      export VLLM_SM75_SPEC_SYNC_MODE=safe
-      export VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH=0
+      set_derived_default ENFORCE_EAGER 1
+      set_derived_default VLLM_SM75_SPEC_SYNC_MODE safe
+      set_derived_default VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH 0
       ;;
     *)
       die "MODE must be safe, normal, fast, or aggressive."
@@ -2849,7 +3123,7 @@ set_sm75_runtime_env() {
   export TORCHINDUCTOR_CACHE_DIR="$MANAGER_ROOT/torchinductor-cache"
   export TRITON_CACHE_DIR="$MANAGER_ROOT/triton-cache"
   export PYTHONUNBUFFERED=1
-  if [[ "${ENABLE_AUTO_TOOL_CHOICE:-0}" == "1" ]]; then
+  if [[ "${ENABLE_AUTO_TOOL_CHOICE:-0}" == "1" ]] && ! config_key_has_explicit_value VLLM_ENFORCE_STRICT_TOOL_CALLING; then
     export VLLM_ENFORCE_STRICT_TOOL_CALLING=${VLLM_ENFORCE_STRICT_TOOL_CALLING:-1}
   fi
   if [[ -n "${REASONING_BUDGET:-}" ]]; then
@@ -3608,8 +3882,12 @@ prepare_runtime_defaults() {
   ENABLE_AUTO_TOOL_CHOICE=$(normalize_bool "${ENABLE_AUTO_TOOL_CHOICE:-0}")
   apply_family_reasoning_defaults
   if [[ "$ENABLE_AUTO_TOOL_CHOICE" == "1" ]]; then
-    TOOL_CALL_PARSER=${TOOL_CALL_PARSER:-qwen3_xml}
-    VLLM_ENFORCE_STRICT_TOOL_CALLING=${VLLM_ENFORCE_STRICT_TOOL_CALLING:-1}
+    if ! config_key_has_explicit_value TOOL_CALL_PARSER; then
+      TOOL_CALL_PARSER=${TOOL_CALL_PARSER:-qwen3_xml}
+    fi
+    if ! config_key_has_explicit_value VLLM_ENFORCE_STRICT_TOOL_CALLING; then
+      VLLM_ENFORCE_STRICT_TOOL_CALLING=${VLLM_ENFORCE_STRICT_TOOL_CALLING:-1}
+    fi
   fi
   validate_mode_kv_policy
 }
@@ -3903,10 +4181,6 @@ has_arg() {
 }
 
 run_start_flow() {
-  local profile_file
-  if profile_file=$(resolve_profile_file); then
-    apply_profile_overrides "$profile_file"
-  fi
   collect_config_env
   apply_mode
   set_sm75_runtime_env
@@ -3921,10 +4195,16 @@ run_start_flow() {
 main() {
   cd "$MANAGER_ROOT"
 
-  if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  if has_arg "--help" "$@" || has_arg "-h" "$@"; then
     show_help
     exit 0
   fi
+
+  parse_launcher_args "$@"
+  register_env_config_overrides
+  apply_launcher_path_defaults
+  NON_INTERACTIVE=$(normalize_bool "${NON_INTERACTIVE:-0}")
+  PRINT_CONFIG=$(normalize_bool "${PRINT_CONFIG:-0}")
 
   if [[ ! -x "$RUNTIME_ROOT/.venv/bin/python" ]]; then
     banner
@@ -3933,7 +4213,7 @@ main() {
 
   mkdir -p "$LOG_DIR"
 
-  if [[ "${1:-}" == "--non-interactive" || "${1:-}" == "--print-config" || "${NON_INTERACTIVE:-0}" == "1" || ! -t 0 ]]; then
+  if [[ "${NON_INTERACTIVE:-0}" == "1" || "${PRINT_CONFIG:-0}" == "1" || ! -t 0 ]]; then
     run_start_flow "$@"
   else
     service_manager


### PR DESCRIPTION
1. Add a complete non-interactive launcher override path with explicit CLI and env precedence.
2. Prevent derived launcher defaults from overwriting explicit multimodal and runtime overrides.
3. Add non-interactive launcher documentation in English and Simplified Chinese.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fully non-interactive `launcher.sh` with explicit override precedence (CLI > ENV > PROFILE > default). Tightens defaulting so explicit settings are never clobbered by mode, profile, or derived values.

- **New Features**
  - Known keys accept `--lower-kebab-case` with both `--key value` and `--key=value`; boolean flags default to `1` when present. Supports `--non-interactive`, `--print-config`, `--set KEY=VALUE`, and `--unset KEY` (use `--set KEY=` for an empty value). Maps `CUDA_VISIBLE_DEVICES` to `GPU_DEVICES`.
  - Applies path defaults for `RUNTIME_ROOT`, `PROFILE_DIR`, `TEMPLATE_DIR`, `LOG_DIR`, and `STATE_FILE`, deriving `TEMPLATE_DIR` from `PROFILE_DIR` and `STATE_FILE` from `LOG_DIR` only when not explicitly set. Adds docs in `docs/non-interactive-launcher.md` and `docs/non-interactive-launcher.zh-CN.md`.

- **Bug Fixes**
  - Explicit CLI/ENV/PROFILE values now consistently win over normalization and mode defaults for multimodal flags (`MESSAGE_TYPE`, `MM_LIMIT_JSON`, `LANGUAGE_MODEL_ONLY`, `SKIP_MM_PROFILING`), reasoning/prefix settings (`REASONING_PARSER`, `MAMBA_CACHE_MODE`), and tooling/runtime knobs (`TOOL_CALL_PARSER`, `VLLM_ENFORCE_STRICT_TOOL_CALLING`, `ENFORCE_EAGER`, `VLLM_SM75_SPEC_SYNC_MODE`, `VLLM_ALLOW_MAMBA_SPEC_FULL_CUDAGRAPH`, `DISABLE_LOG_STATS`).

<sup>Written for commit 15541d6e4734d038a3d8f9660f24ebce2c14157e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

