### PR TITLE
fix: preserve hybrid Mamba prefix-cache correctness with MTP

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Focused prefix-cache regressions for hybrid Mamba and EAGLE/MTP."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core.kv_cache_utils import (
+    get_request_block_hasher,
+    init_none_hash,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    SlidingWindowMLASpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.fixture(autouse=True)
+def _init_hash() -> None:
+    init_none_hash(sha256)
+
+
+def _make_request(request_id: str, token_ids: list[int], block_size: int) -> Request:
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=token_ids,
+        sampling_params=SamplingParams(max_tokens=17),
+        pooling_params=None,
+        block_hasher=get_request_block_hasher(block_size, sha256),
+    )
+
+
+def _full_spec(block_size: int) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+
+
+def _mamba_align_spec(block_size: int) -> MambaSpec:
+    return MambaSpec(
+        block_size=block_size,
+        shapes=(1, 1),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+
+
+def _make_manager(
+    block_size: int,
+    *,
+    hybrid: bool,
+    use_eagle: bool,
+) -> KVCacheManager:
+    groups = [KVCacheGroupSpec(["full"], _full_spec(block_size))]
+    if hybrid:
+        groups.append(
+            KVCacheGroupSpec(["mamba"], _mamba_align_spec(block_size))
+        )
+    return KVCacheManager(
+        KVCacheConfig(
+            num_blocks=100,
+            kv_cache_tensors=[],
+            kv_cache_groups=groups,
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=use_eagle,
+    )
+
+
+def _warm_then_lookup(
+    manager: KVCacheManager,
+    token_ids: list[int],
+    block_size: int,
+    chunks: tuple[int, ...] | None = None,
+):
+    first = _make_request("first", token_ids, block_size)
+    computed, num_computed = manager.get_computed_blocks(first)
+    assert num_computed == 0
+    for num_new_tokens in chunks or (len(token_ids),):
+        blocks = manager.allocate_slots(
+            first, num_new_tokens, num_computed, computed
+        )
+        assert blocks is not None
+        first.num_computed_tokens += num_new_tokens
+        computed = None
+        num_computed = 0
+    manager.free(first)
+
+    second = _make_request("second", token_ids, block_size)
+    return manager.get_computed_blocks(second)
+
+
+def test_eagle_cache_peek_capabilities_are_conservative() -> None:
+    block_size = 16
+    common = dict(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=2 * block_size,
+    )
+
+    assert _full_spec(block_size).supports_eagle_cache_peek
+    assert SlidingWindowSpec(**common).supports_eagle_cache_peek
+    assert not SlidingWindowMLASpec(**common).supports_eagle_cache_peek
+    assert not _mamba_align_spec(block_size).supports_eagle_cache_peek
+
+
+def test_hybrid_mamba_eagle_does_not_reuse_lookahead_state() -> None:
+    block_size = 16
+    token_ids = [i for i in range(4) for _ in range(block_size)] + [4] * 7
+    manager = _make_manager(block_size, hybrid=True, use_eagle=True)
+
+    computed, num_computed = _warm_then_lookup(
+        manager, token_ids, block_size, (3 * block_size, block_size + 7)
+    )
+
+    assert num_computed == 3 * block_size
+    assert [len(group) for group in computed.blocks] == [3, 3]
+
+
+def test_hybrid_mamba_prefix_cache_without_eagle() -> None:
+    block_size = 16
+    token_ids = [i for i in range(4) for _ in range(block_size)] + [4] * 7
+    manager = _make_manager(block_size, hybrid=True, use_eagle=False)
+
+    computed, num_computed = _warm_then_lookup(
+        manager, token_ids, block_size, (4 * block_size, 7)
+    )
+
+    assert num_computed == 4 * block_size
+    assert [len(group) for group in computed.blocks] == [4, 4]
+
+
+@pytest.mark.parametrize(("use_eagle", "expected_blocks"), [(False, 4), (True, 3)])
+def test_full_attention_prefix_cache_eagle_regression(
+    use_eagle: bool,
+    expected_blocks: int,
+) -> None:
+    block_size = 16
+    token_ids = [i for i in range(4) for _ in range(block_size)] + [4] * 7
+    manager = _make_manager(block_size, hybrid=False, use_eagle=use_eagle)
+
+    computed, num_computed = _warm_then_lookup(
+        manager, token_ids, block_size
+    )
+
+    assert num_computed == expected_blocks * block_size
+    assert [len(group) for group in computed.blocks] == [expected_blocks]
+
+
+def test_mamba_align_prefill_split_keeps_intermediate_chunks_aligned() -> None:
+    block_size = 16
+    short_request = _make_request("short", [0] * (block_size + 7), block_size)
+    eagle = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        use_eagle=True,
+    )
+
+    assert Scheduler._mamba_block_aligned_split(eagle, short_request, 5) == 0
+    assert (
+        Scheduler._mamba_block_aligned_split(
+            eagle, short_request, block_size + 3
+        )
+        == block_size
+    )
+    assert (
+        Scheduler._mamba_block_aligned_split(
+            eagle, short_request, block_size + 7
+        )
+        == block_size + 7
+    )
+
+    long_request = _make_request("long", [0] * (3 * block_size + 7), block_size)
+    no_eagle = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        use_eagle=False,
+    )
+    assert (
+        Scheduler._mamba_block_aligned_split(
+            no_eagle, long_request, len(long_request.prompt_token_ids)
+        )
+        == 3 * block_size
+    )
+    long_request.num_computed_tokens = 3 * block_size
+    assert Scheduler._mamba_block_aligned_split(
+        no_eagle, long_request, 7
+    ) == 7
+
+
+def test_mamba_align_eagle_split_stops_at_reusable_boundary() -> None:
+    block_size = 16
+    request = _make_request("cross", [0] * (3 * block_size + 7), block_size)
+    request.num_computed_tokens = block_size
+    eagle = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=block_size),
+        use_eagle=True,
+    )
+
+    scheduled = Scheduler._mamba_block_aligned_split(
+        eagle, request, 2 * block_size - 2
+    )
+    assert request.num_computed_tokens + scheduled == 2 * block_size

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -543,12 +543,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     )
                     continue
 
-                use_eagle = (
+                drop_eagle_block = (
                     idx in self.eagle_attn_group_indices and idx not in eagle_verified
+                    and spec.supports_eagle_cache_peek
                 )
 
                 _max_length = curr_hit_length
-                if use_eagle:
+                if drop_eagle_block:
                     # Eagle needs to match one more block and then pop the last.
                     _max_length = min(
                         curr_hit_length + spec.block_size, max_cache_hit_length
@@ -559,16 +560,16 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     kv_cache_group_ids=group_ids,
                     block_pool=self.block_pool,
                     kv_cache_spec=spec,
-                    use_eagle=use_eagle,
+                    use_eagle=drop_eagle_block,
                     alignment_tokens=self.lcm_block_size,
                 )
                 _new_hit_length = len(hit_blocks[0]) * spec.block_size
-                if use_eagle:
+                if drop_eagle_block:
                     eagle_verified.add(idx)
                 elif _new_hit_length < curr_hit_length:
                     # length shrunk; invalidate previous eagle verifications
                     eagle_verified.clear()
-                curr_hit_length = _new_hit_length
+                curr_hit_length = min(curr_hit_length, _new_hit_length)
                 for group_id, blocks in zip(group_ids, hit_blocks):
                     hit_blocks_by_group[group_id] = blocks
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -27,6 +27,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStat
 from vllm.logger import init_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.utils.math_utils import round_down
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -272,39 +273,31 @@ class Scheduler(SchedulerInterface):
             + num_new_local_computed_tokens
             + num_external_computed_tokens
         )
-        # Perform block-aligned splitting at prefill phase, including:
-        # * non-resumed requests: num_computed_tokens < num_prompt_tokens + 0
-        # * resumed requests: num_computed_tokens < (
-        #                       num_prompt_tokens + num_output_tokens
-        #                     )
-        # NOTE: Use `request.num_tokens - 1` to bypass normal decoding.
-        if num_computed_tokens < max(request.num_prompt_tokens, request.num_tokens - 1):
-            # To enable block-aligned caching of the Mamba state, `num_new_tokens`
-            # must be a multiple of `block_size`.
-            # As an exception, if `num_new_tokens` is less than `block_size`, the
-            # state is simply not cached, requiring no special handling.
-            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
-            # matching block. To prevent this from causing a Mamba cache miss, the
-            # last chunk must be not smaller than `block_size`.
+        # In align mode a cached Mamba block represents recurrent state after
+        # exactly (block_index + 1) * block_size tokens. Therefore every
+        # non-final prefill chunk must end on a block boundary. The final tail
+        # may remain unaligned because it is not reused as a boundary state.
+        prefill_end = max(request.num_prompt_tokens, request.num_tokens - 1)
+        if num_computed_tokens < prefill_end:
             block_size = self.cache_config.block_size
-            last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
+
+            # EAGLE drops the last matched full-attention block. Keep the last
+            # reusable Mamba boundary one block earlier so all hybrid groups
+            # describe the same prefix length.
+            last_cache_position = round_down(request.num_tokens, block_size)
             if self.use_eagle:
                 last_cache_position = max(last_cache_position - block_size, 0)
-            num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
-            if num_computed_tokens_after_sched < last_cache_position:
-                # align to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
-            elif (
-                num_computed_tokens
-                < last_cache_position
-                < num_computed_tokens_after_sched
-            ):
-                # force to cache the last chunk
-                num_new_tokens = last_cache_position - num_computed_tokens
-            else:
-                # prefill the last few tokens
-                pass
+
+            chunk_end = num_computed_tokens + num_new_tokens
+            if num_computed_tokens < last_cache_position:
+                chunk_end = min(
+                    round_down(chunk_end, block_size), last_cache_position
+                )
+            elif chunk_end < prefill_end:
+                chunk_end = round_down(chunk_end, block_size)
+
+            num_new_tokens = max(chunk_end - num_computed_tokens, 0)
+
         return num_new_tokens
 
     def schedule(self) -> SchedulerOutput:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -93,6 +93,14 @@ class KVCacheSpec:
     block_size: int
 
     @property
+    def supports_eagle_cache_peek(self) -> bool:
+        """Whether EAGLE/MTP may peek one extra block and then drop it.
+
+        Recurrent state caches cannot be rewound like token KV caches.
+        """
+        return False
+
+    @property
     def page_size_bytes(self) -> int:
         """
         The size of a page with `block_size` tokens in bytes.
@@ -215,6 +223,10 @@ class FullAttentionSpec(AttentionSpec):
     def __post_init__(self):
         if self.head_size_v is None:
             object.__setattr__(self, "head_size_v", self.head_size)
+
+    @property
+    def supports_eagle_cache_peek(self) -> bool:
+        return True
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
@@ -360,6 +372,10 @@ class MLAAttentionSpec(FullAttentionSpec):
         return self.block_size // self.compress_ratio
 
     @property
+    def supports_eagle_cache_peek(self) -> bool:
+        return False
+
+    @property
     def real_page_size_bytes(self) -> int:
         if self.cache_dtype_str == "fp8_ds_mla":
             if self.model_version == "deepseek_v4":
@@ -443,6 +459,10 @@ class SlidingWindowSpec(AttentionSpec):
             object.__setattr__(self, "head_size_v", self.head_size)
 
     @property
+    def supports_eagle_cache_peek(self) -> bool:
+        return True
+
+    @property
     def real_page_size_bytes(self) -> int:
         # Mirror ``FullAttentionSpec.real_page_size_bytes`` for NVFP4 KV cache.
         if self.kv_quant_mode.is_nvfp4:
@@ -512,6 +532,10 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
     @property
     def storage_block_size(self) -> int:
         return self.block_size // self.compress_ratio
+    @property
+    def supports_eagle_cache_peek(self) -> bool:
+        return False
+
 
     @property
     def real_page_size_bytes(self) -> int:


### PR DESCRIPTION
## Summary

Manually backports the hybrid Mamba/GDN prefix-cache correctness changes from vllm-project/vllm#47861 to this vLLM 0.21.0 SM75 fork.

- Gate EAGLE cache peek/drop by cache-spec capability.
- Keep Mamba/GDN recurrent state out of token-KV rollback behavior.
- Keep hybrid group hit lengths monotonically consistent.
- Align non-final Mamba prefill chunks to reusable block boundaries.
- Preserve SM75, TurboQuant, INT8 KV and NVFP4 paths.

## Root cause

EAGLE lookahead rollback was applied across hybrid cache groups without distinguishing reversible token KV blocks from recurrent Mamba/GDN state. Non-final aligned prefill chunks could also stop at a state boundary that was unsafe to reuse.

## Validation

- Focused unit tests: 7 passed.
- no-MTP + prefix cache quick check: tool call, 10K recall and 30K recall all passed with the original 8008 thinking-disabled template settings.
- MTP3 + prefix cache: 512-token short decode 88.5 tok/s, TTFT 0.186s.
- Repeated ~12K static prefix: cold TTFT 7.872s, hot TTFT 2.136s, 8448 cached tokens; both structured tool calls valid with no tool-call or think-tag leakage.
- MTP acceptance rate was not emitted because the historical line disables runtime stats.

## Notes

The historical 8008 line used max_num_batched_tokens=2048. Prefix-cache align mode requires at least the computed Mamba block size (2112), so validation used 2112 as the only non-cache parameter adjustment. No thread/NUMA optimization is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hybrid Mamba + EAGLE/MTP prefix caching so lookahead rollbacks never touch recurrent state and prefill splits stay block‑aligned for safe reuse. Keeps cache hit lengths consistent across groups.

- **Bug Fixes**
  - Added `supports_eagle_cache_peek` to KV specs; enabled for full‑attention (incl. NVFP4), disabled for Mamba and SlidingWindowMLA.
  - Coordinator now peeks/drops only when allowed, keeps hit lengths monotonic, and avoids cross‑group rollback of Mamba/GDN state.
  - Scheduler aligns non‑final Mamba prefill chunks to block boundaries; with EAGLE, the last reusable boundary is one block earlier.
  - New focused tests cover hybrid Mamba + EAGLE reuse, block‑aligned splits, and capability gating.

<sup>Written for commit 40129ea697fdf302701fddd0cf5e7b8b73b52fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

