### PR TITLE
fix: support native CPU KV offload with Mamba align

### DIFF
--- a/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
+++ b/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    OffloadingConnectorScheduler,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+
+
+
+def test_hybrid_mamba_external_hit_is_aligned_and_does_not_crash():
+    """External hybrid hit is block-aligned and accepted by Mamba scheduling."""
+    offload_scheduler = object.__new__(OffloadingConnectorScheduler)
+    offload_scheduler._sliding_window_groups = (1,)
+    offload_scheduler._lookup_groups = (0, 1)
+    offload_scheduler._mamba_align_size = 16
+    offload_scheduler._blocks_being_loaded = None
+
+    class _AllHitManager:
+        def lookup(self, key, req_context):
+            return True
+
+    offload_scheduler.manager = _AllHitManager()
+    offload_scheduler.config = SimpleNamespace(
+        kv_group_configs=(
+            SimpleNamespace(
+                offloaded_block_size=32, sliding_window_size_in_blocks=None
+            ),
+            SimpleNamespace(offloaded_block_size=16, sliding_window_size_in_blocks=1),
+        )
+    )
+    request = SimpleNamespace(num_tokens=33, request_id="unit")
+    state = SimpleNamespace(
+        req=request,
+        req_context=None,
+        num_locally_computed_tokens=0,
+        group_states=(
+            SimpleNamespace(offload_keys=[b"fa0", b"fa1"]),
+            SimpleNamespace(offload_keys=[b"m0", b"m1", b"m2"]),
+        ),
+    )
+
+    # 33-token request is reduced to the 32-token Mamba boundary.
+    assert offload_scheduler._lookup(state) == 32
+
+    scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=16), use_eagle=False
+    )
+    model_request = SimpleNamespace(
+        num_computed_tokens=0, num_prompt_tokens=33, num_tokens=34
+    )
+    # External KV tokens must be accepted by the local split calculation.
+    assert (
+        Scheduler._mamba_block_aligned_split(
+            scheduler,
+            model_request,
+            20,
+            num_external_computed_tokens=16,
+        )
+        == 16
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -15,7 +15,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
     TransferJob,
 )
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
+from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
@@ -80,6 +80,18 @@ def get_sliding_window_size_in_blocks(
 
     assert isinstance(kv_cache_spec, FullAttentionSpec)
     return None
+
+
+def resolve_mamba_align_size(spec: "OffloadingSpec") -> int | None:
+    """Return the offloaded token boundary required by Mamba align mode."""
+    mamba_align_size: int | None = None
+    for idx, gpu_block_size in enumerate(spec.gpu_block_size):
+        kv_spec = spec.kv_cache_config.kv_cache_groups[idx].kv_cache_spec
+        if isinstance(kv_spec, MambaSpec) and kv_spec.mamba_cache_mode == "align":
+            offload_block_size = gpu_block_size * spec.block_size_factor
+            assert mamba_align_size is None or mamba_align_size == offload_block_size
+            mamba_align_size = offload_block_size
+    return mamba_align_size
 
 
 class SchedulerOffloadConfig(NamedTuple):
@@ -208,6 +220,7 @@ class OffloadingConnectorScheduler:
         # used by _lookup
         self._sliding_window_groups: tuple[int, ...] = tuple(sliding_window_groups)
         self._lookup_groups = tuple(full_attention_groups) + self._sliding_window_groups
+        self._mamba_align_size: int | None = resolve_mamba_align_size(spec)
 
         self._req_status: dict[ReqId, RequestOffloadState] = {}
         self._current_batch_load_jobs: dict[int, TransferJob] = {}
@@ -321,6 +334,12 @@ class OffloadingConnectorScheduler:
             # for sliding window attention, we must reduce by 1 to make sure
             # we still have a hit after reduction
             max_hit_size_tokens -= 1
+        if self._mamba_align_size is not None:
+            # Mamba align stores a single recurrent state at block boundaries.
+            # Never load a partial boundary or a state beyond the valid hit.
+            max_hit_size_tokens = round_down(
+                max_hit_size_tokens, self._mamba_align_size
+            )
         num_hit_tokens: int = 0
         defer_lookup = False
         lookup_groups = self._lookup_groups

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -264,9 +264,6 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        assert num_external_computed_tokens == 0, (
-            "External KV connector is not verified yet"
-        )
         num_computed_tokens = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
@@ -668,7 +665,8 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                if self.need_mamba_block_aligned_split:
+                # External KV loads do not perform local work in this step.
+                if self.need_mamba_block_aligned_split and not load_kv_async:
                     num_new_tokens = self._mamba_block_aligned_split(
                         request,
                         num_new_tokens,


### PR DESCRIPTION
## Summary
- Backports upstream [#42554](https://github.com/vllm-project/vllm/pull/42554): skip local Mamba block split during external KV async load.
- Backports upstream [#44599](https://github.com/vllm-project/vllm/pull/44599): round CPU offload hit windows down to Mamba align block boundaries.
- Avoids the external KV hit assertion and wrong recurrent state at block boundaries.
- No dependency on PR #89 (40129ea); targets the base branch directly.

## Validation
- CPU unit test passed.
- 10560-token boundary: cold TTFT 6229.2 ms; hot TTFT 1266.0 ms; 8448 cached tokens; outputs identical.
- 10562-token non-boundary request normal.
- 30GiB native CPU KV, TP2 normal.