### PR TITLE
Fix MTP Mamba align prefix cache retention

### DIFF
--- a/tests/2080ti/test_mamba_align_mtp_prefix_cache.py
+++ b/tests/2080ti/test_mamba_align_mtp_prefix_cache.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+from vllm.v1.core.sched.scheduler import Scheduler
+
+
+def _split_with_mtp_cache_retention(enabled: bool, num_tokens: int = 14) -> int:
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.use_eagle = True
+    scheduler.retain_mamba_align_mtp_cache_block = enabled
+    scheduler.cache_config = SimpleNamespace(block_size=4)
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=num_tokens,
+        num_tokens=num_tokens,
+    )
+    return scheduler._mamba_block_aligned_split(request, num_new_tokens=14)
+
+
+def test_mamba_align_mtp_can_retain_final_cache_boundary() -> None:
+    """MTP should not discard a complete Mamba block before the prompt tail."""
+    # The legacy EAGLE rule drops the final complete block (12 -> 8).
+    assert _split_with_mtp_cache_retention(enabled=False) == 8
+    # MTP still computes the two-token tail, so the 12-token state is valid.
+    assert _split_with_mtp_cache_retention(enabled=True) == 12
+    # Without a tail, preserve EAGLE's safety block.
+    assert _split_with_mtp_cache_retention(enabled=True, num_tokens=12) == 8

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     VLLM_PORT: int | None = None
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
     VLLM_USE_MODELSCOPE: bool = False
+    VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK: bool = False
     VLLM_RINGBUFFER_WARNING_INTERVAL: int = 60
     VLLM_NCCL_SO_PATH: str | None = None
     LD_LIBRARY_PATH: str | None = None
@@ -1131,6 +1132,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE": lambda: os.getenv(
         "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE", "auto"
     ).lower(),
+    "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK": lambda: os.getenv(
+        "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
+    ).strip().lower()
+    in {"1", "true", "yes", "on"},
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -251,6 +252,15 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        self.retain_mamba_align_mtp_cache_block = (
+            speculative_config is not None
+            and speculative_config.method == "mtp"
+            and self.need_mamba_block_aligned_split
+            and os.getenv(
+                "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
+            ).strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -288,8 +298,15 @@ class Scheduler(SchedulerInterface):
             # last chunk must be not smaller than `block_size`.
             block_size = self.cache_config.block_size
             last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
-            if self.use_eagle:
+            # MTP follows the EAGLE scheduler path, but an uncached prompt tail
+            # still runs and produces the hidden states needed by the proposer.
+            # In that case the final aligned Mamba state is valid and retaining
+            # it avoids throwing away a full (often ~2K-token) prefix block.
+            retain_final_mtp_block = (
+                self.retain_mamba_align_mtp_cache_block
+                and last_cache_position < request.num_tokens
+            )
+            if self.use_eagle and not retain_final_mtp_block:
                 last_cache_position = max(last_cache_position - block_size, 0)
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
             if num_computed_tokens_after_sched < last_cache_position:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
-import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -256,10 +255,7 @@ class Scheduler(SchedulerInterface):
             speculative_config is not None
             and speculative_config.method == "mtp"
             and self.need_mamba_block_aligned_split
-            and os.getenv(
-                "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
-            ).strip().lower()
-            in {"1", "true", "yes", "on"}
+            and envs.VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK
         )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:


### PR DESCRIPTION
## Summary

- retain the final block-aligned Mamba cache state for MTP when an uncached prompt tail is still evaluated
- keep the existing EAGLE safety backoff when the prompt ends exactly on a block boundary
- gate the behavior behind `VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK=1`
- add a focused 2080 Ti regression test

## Motivation

Qwen3.5 MTP uses the EAGLE scheduler path. The generic EAGLE rule backs the final cache position up by one full Mamba block, which discarded about 2K reusable prompt tokens even though the uncached tail still produced the proposer hidden states.

In the tested 8008 deployment, the hot-cache result improved from 6,336 / 8,339 cached prompt tokens at about 1.18 s TTFT to 8,448 / 8,525 cached tokens at about 235 ms TTFT. Decode throughput stayed around 102 tok/s.

The exact-boundary case remains on the legacy EAGLE path.

## Validation

- `python -m py_compile` for scheduler and regression test
- focused regression: legacy split 8, retained split 12 with a tail, exact-boundary split 8
- live Qwen3.5 MTP A/B on the 8008 deployment

Related upstream issue: https://github.com/vllm-project/vllm/issues/38182

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains the final Mamba‑aligned prefix cache block for MTP when the prompt has an uncached tail, avoiding EAGLE backoff and reducing TTFT on hot‑cache prompts. Previously EAGLE always dropped the last complete block; now MTP keeps it with a tail and still prunes on an exact block boundary.

- Opt-in via `VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK` (truthy: 1/true/yes/on; default off); registered in `vllm.envs`.
- Applies only to Mamba cache mode "align" on the EAGLE path with MTP; all other cases unchanged.
- Adds a focused 2080 Ti regression test that verifies tail retention (12) and boundary prune (8).
- Qwen3.5 MTP hot-cache: cached tokens 6,336→8,448 and TTFT ~1.18s→~235ms; decode throughput unchanged.

<sup>Written for commit e2cf45f0bfc5de5a2913bb3bded684f6713001dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

