### PR TITLE
Fix preserve GDN state slot zero during decode

### DIFF
--- a/tests/2080ti/test_gdn_causal_conv1d_update.py
+++ b/tests/2080ti/test_gdn_causal_conv1d_update.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required.")
+@pytest.mark.parametrize("dim", [4096, 5120], ids=["qwen36-35b", "qwen36-27b"])
+@pytest.mark.parametrize("state_slot", [0, 13], ids=["slot0", "nonzero-slot"])
+def test_gdn_single_token_causal_conv_update_matches_torch(
+    dim: int, state_slot: int
+) -> None:
+    from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+        causal_conv1d_update,
+    )
+    from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
+        causal_conv1d_update_torch,
+    )
+    from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    width = 4
+    state_len = width - 1
+    num_cache_lines = 17
+    weight = torch.randn(dim, width, device=device, dtype=dtype) * 0.1
+    bias = torch.randn(dim, device=device, dtype=dtype) * 0.1
+    conv_state = (
+        torch.randn(
+            num_cache_lines,
+            dim,
+            state_len,
+            device=device,
+            dtype=dtype,
+        )
+        * 0.1
+    )
+    untouched_state = conv_state.clone()
+    state_indices = torch.tensor([state_slot], device=device, dtype=torch.int32)
+    reference_state = conv_state[state_slot : state_slot + 1].clone()
+
+    for step in range(64):
+        x = torch.randn(1, dim, device=device, dtype=dtype) * 0.1
+        actual = causal_conv1d_update(
+            x.clone(),
+            conv_state,
+            weight,
+            bias,
+            "silu",
+            conv_state_indices=state_indices,
+            null_block_id=PAD_SLOT_ID,
+            validate_data=True,
+        )
+        expected = causal_conv1d_update_torch(
+            x.unsqueeze(-1),
+            reference_state,
+            weight,
+            bias,
+            "silu",
+        ).squeeze(-1)
+
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=1e-3,
+            atol=1e-3,
+            msg=lambda msg: f"decode step {step}: {msg}",
+        )
+        torch.testing.assert_close(
+            conv_state[state_slot : state_slot + 1],
+            reference_state,
+            rtol=0,
+            atol=0,
+            msg=lambda msg: f"conv state after decode step {step}: {msg}",
+        )
+
+    torch.testing.assert_close(
+        conv_state[:state_slot], untouched_state[:state_slot], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        conv_state[state_slot + 1 :],
+        untouched_state[state_slot + 1 :],
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required.")
+def test_gdn_recurrent_decode_accepts_state_slot_zero() -> None:
+    from vllm.model_executor.layers.fla.ops import (
+        fused_recurrent_gated_delta_rule_packed_decode,
+        fused_sigmoid_gating_delta_rule_update,
+    )
+    from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+    torch.manual_seed(11)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    heads = value_heads = 1
+    key_dim = value_dim = 16
+
+    q = torch.randn(heads, key_dim, device=device, dtype=dtype) * 0.1
+    k = torch.randn(heads, key_dim, device=device, dtype=dtype) * 0.1
+    v = torch.randn(value_heads, value_dim, device=device, dtype=dtype) * 0.1
+    a = torch.randn(1, value_heads, device=device, dtype=dtype) * 0.1
+    b = torch.randn(1, value_heads, device=device, dtype=dtype) * 0.1
+    A_log = torch.randn(value_heads, device=device, dtype=torch.float32) * 0.1
+    dt_bias = torch.randn(value_heads, device=device, dtype=dtype) * 0.1
+    state_indices = torch.tensor([0], device=device, dtype=torch.int32)
+    initial_state = (
+        torch.randn(
+            2,
+            value_heads,
+            value_dim,
+            key_dim,
+            device=device,
+            dtype=dtype,
+        )
+        * 0.1
+    )
+    untouched_state = initial_state[1].clone()
+
+    q_ref = torch.nn.functional.normalize(q.float(), dim=-1)
+    k_ref = torch.nn.functional.normalize(k.float(), dim=-1)
+    h_ref = initial_state[0].float()
+    gate = -torch.exp(A_log.float()) * torch.nn.functional.softplus(
+        a[0].float() + dt_bias.float()
+    )
+    h_ref = h_ref * torch.exp(gate)[:, None, None]
+    v_ref = v.float() - (h_ref * k_ref[:, None, :]).sum(dim=-1)
+    v_ref = v_ref * torch.sigmoid(b[0].float())[:, None]
+    h_ref = h_ref + v_ref[:, :, None] * k_ref[:, None, :]
+    out_ref = (h_ref * q_ref[:, None, :]).sum(dim=-1) * key_dim**-0.5
+
+    packed_state = initial_state.clone()
+    packed_out = torch.zeros(
+        1, 1, value_heads, value_dim, device=device, dtype=dtype
+    )
+    mixed_qkv = torch.cat([q.flatten(), k.flatten(), v.flatten()]).unsqueeze(0)
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=key_dim**-0.5,
+        initial_state=packed_state,
+        out=packed_out,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+        null_block_id=PAD_SLOT_ID,
+    )
+
+    torch.testing.assert_close(
+        packed_out[0, 0], out_ref, rtol=2e-3, atol=2e-3, check_dtype=False
+    )
+    torch.testing.assert_close(
+        packed_state[0], h_ref, rtol=2e-3, atol=2e-3, check_dtype=False
+    )
+    torch.testing.assert_close(packed_state[1], untouched_state, rtol=0, atol=0)
+
+    recurrent_state = initial_state.clone()
+    recurrent_out, _ = fused_sigmoid_gating_delta_rule_update(
+        A_log=A_log,
+        a=a,
+        b=b,
+        dt_bias=dt_bias,
+        q=q.reshape(1, 1, heads, key_dim),
+        k=k.reshape(1, 1, heads, key_dim),
+        v=v.reshape(1, 1, value_heads, value_dim),
+        initial_state=recurrent_state,
+        inplace_final_state=True,
+        cu_seqlens=torch.tensor([0, 1], device=device, dtype=torch.int32),
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+        null_block_id=PAD_SLOT_ID,
+    )
+
+    torch.testing.assert_close(
+        recurrent_out[0, 0], out_ref, rtol=2e-3, atol=2e-3, check_dtype=False
+    )
+    torch.testing.assert_close(
+        recurrent_state[0], h_ref, rtol=2e-3, atol=2e-3, check_dtype=False
+    )
+    torch.testing.assert_close(recurrent_state[1], untouched_state, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required.")
+def test_gdn_padding_sentinel_skips_only_padded_state() -> None:
+    from vllm.model_executor.layers.fla.ops import (
+        fused_recurrent_gated_delta_rule_packed_decode,
+    )
+    from vllm.model_executor.layers.mamba.ops.causal_conv1d import (
+        causal_conv1d_update,
+    )
+    from vllm.model_executor.layers.mamba.ops.cpu.causal_conv1d import (
+        causal_conv1d_update_torch,
+    )
+    from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+    torch.manual_seed(19)
+    device = torch.device("cuda")
+    dtype = torch.float16
+    dim = 64
+    width = 4
+    state_len = width - 1
+    weight = torch.randn(dim, width, device=device, dtype=dtype) * 0.1
+    bias = torch.randn(dim, device=device, dtype=dtype) * 0.1
+    conv_state = torch.randn(2, dim, state_len, device=device, dtype=dtype) * 0.1
+    untouched_conv_state = conv_state.clone()
+    state_indices = torch.tensor([0, PAD_SLOT_ID], device=device, dtype=torch.int32)
+    x = torch.randn(2, dim, device=device, dtype=dtype) * 0.1
+    reference_state = conv_state[:1].clone()
+    expected = causal_conv1d_update_torch(
+        x[:1].unsqueeze(-1), reference_state, weight, bias, "silu"
+    ).squeeze(-1)
+    actual = causal_conv1d_update(
+        x.clone(),
+        conv_state,
+        weight,
+        bias,
+        "silu",
+        conv_state_indices=state_indices,
+        null_block_id=PAD_SLOT_ID,
+        validate_data=True,
+    )
+
+    torch.testing.assert_close(actual[0], expected[0], rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(actual[1], x[1], rtol=0, atol=0)
+    torch.testing.assert_close(conv_state[0], reference_state[0], rtol=0, atol=0)
+    torch.testing.assert_close(conv_state[1], untouched_conv_state[1], rtol=0, atol=0)
+
+    heads = value_heads = 1
+    key_dim = value_dim = 16
+    mixed_qkv = torch.randn(
+        2, 2 * heads * key_dim + value_heads * value_dim, device=device, dtype=dtype
+    ) * 0.1
+    a = torch.randn(2, value_heads, device=device, dtype=dtype) * 0.1
+    b = torch.randn(2, value_heads, device=device, dtype=dtype) * 0.1
+    A_log = torch.randn(value_heads, device=device, dtype=torch.float32) * 0.1
+    dt_bias = torch.randn(value_heads, device=device, dtype=dtype) * 0.1
+    recurrent_state = torch.randn(
+        2, value_heads, value_dim, key_dim, device=device, dtype=dtype
+    ) * 0.1
+    untouched_recurrent_state = recurrent_state[1].clone()
+    recurrent_out = torch.zeros(
+        2, 1, value_heads, value_dim, device=device, dtype=dtype
+    )
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=key_dim**-0.5,
+        initial_state=recurrent_state,
+        out=recurrent_out,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+        null_block_id=PAD_SLOT_ID,
+    )
+
+    torch.testing.assert_close(
+        recurrent_state[1], untouched_recurrent_state, rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        recurrent_out[1], torch.zeros_like(recurrent_out[1]), rtol=0, atol=0
+    )

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -11,6 +11,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 from .op import exp
 
@@ -270,6 +271,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     stride_init_state_token: tl.constexpr,
     stride_final_state_token: tl.constexpr,
     stride_indices_seq: tl.constexpr,
+    null_block_id: tl.constexpr,
     H: tl.constexpr,
     HV: tl.constexpr,
     K: tl.constexpr,
@@ -292,8 +294,7 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq).to(tl.int64)
     p_o = o + (i_n * HV + i_hv) * V + o_v
 
-    # Skip if state index is invalid (NULL_BLOCK_ID=0)
-    if state_idx <= 0:
+    if state_idx < 0 or state_idx == null_block_id:
         zero = tl.zeros([BV], dtype=tl.float32).to(p_o.dtype.element_ty)
         tl.store(p_o, zero, mask=mask_v)
         return
@@ -347,6 +348,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     out: torch.Tensor,
     ssm_state_indices: torch.Tensor,
     use_qk_l2norm_in_kernel: bool = False,
+    null_block_id: int = NULL_BLOCK_ID,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if mixed_qkv.ndim != 2:
         raise ValueError(
@@ -464,6 +466,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         stride_init_state_token=stride_init_state_token,
         stride_final_state_token=stride_final_state_token,
         stride_indices_seq=stride_indices_seq,
+        null_block_id=null_block_id,
         H=H,
         HV=HV,
         K=K,

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -10,6 +10,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
 
 
 @triton.heuristics(
@@ -51,6 +52,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     stride_final_state_token: tl.constexpr,
     stride_indices_seq: tl.constexpr,
     stride_indices_tok: tl.constexpr,
+    null_block_id: tl.constexpr,
     USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
     INPLACE_FINAL_STATE: tl.constexpr,  # whether to store final state inplace
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
@@ -110,8 +112,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
                 tl.int64
             )
-            # Skip if state index is invalid (NULL_BLOCK_ID=0)
-            if state_idx <= 0:
+            if state_idx < 0 or state_idx == null_block_id:
                 return
             p_h0 = h0 + state_idx * stride_init_state_token
         else:
@@ -159,8 +160,7 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             final_state_idx = tl.load(
                 ssm_state_indices + i_n * stride_indices_seq + i_t
             ).to(tl.int64)
-            # Only store if state index is valid (not NULL_BLOCK_ID=0)
-            if final_state_idx > 0:
+            if final_state_idx >= 0 and final_state_idx != null_block_id:
                 p_ht = ht + final_state_idx * stride_final_state_token
                 p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
                 tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
@@ -196,6 +196,7 @@ def fused_sigmoid_gating_delta_rule_update(
     num_accepted_tokens: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
+    null_block_id: int = NULL_BLOCK_ID,
 ):
     """
     Fused triton implementation of sigmoid gating delta rule update.
@@ -269,6 +270,7 @@ def fused_sigmoid_gating_delta_rule_update(
         stride_final_state_token=stride_final_state_token,
         stride_indices_seq=stride_indices_seq,
         stride_indices_tok=stride_indices_tok,
+        null_block_id=null_block_id,
         INPLACE_FINAL_STATE=inplace_final_state,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
         IS_KDA=is_kda,

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -66,6 +66,7 @@ from vllm.utils.torch_utils import (
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 
 # Optional ROCm AITER Triton kernels for the GDN decode fast-path.
 # Availability is checked centrally via rocm_aiter_ops; the actual function
@@ -1330,6 +1331,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                     : attn_metadata.num_spec_decodes  # type: ignore[attr-defined]
                 ],
                 num_accepted_tokens=num_accepted_tokens,
+                null_block_id=PAD_SLOT_ID,
                 query_start_loc=spec_query_start_loc,
                 max_query_len=spec_state_indices_tensor.size(-1),
                 validate_data=False,
@@ -1350,6 +1352,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 has_initial_state=has_initial_state,
                 cache_indices=non_spec_state_indices_tensor,
                 query_start_loc=non_spec_query_start_loc,
+                null_block_id=PAD_SLOT_ID,
                 metadata=attn_metadata,
             ).transpose(0, 1)
         elif attn_metadata.num_decodes > 0:
@@ -1364,6 +1367,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                     : attn_metadata.num_actual_tokens  # type: ignore[attr-defined]
                 ],
                 validate_data=True,
+                null_block_id=PAD_SLOT_ID,
             )
         else:
             mixed_qkv_non_spec = None
@@ -1448,6 +1452,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                     ssm_state_indices=spec_state_indices_tensor,
                     num_accepted_tokens=num_accepted_tokens,
                     use_qk_l2norm_in_kernel=True,
+                    null_block_id=PAD_SLOT_ID,
                 )
             )
         else:
@@ -1478,6 +1483,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 ],
                 ssm_state_indices=decode_state_indices,
                 use_qk_l2norm_in_kernel=True,
+                null_block_id=PAD_SLOT_ID,
             )
         else:
             core_attn_out_decode = None
@@ -1565,6 +1571,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                     ],
                     ssm_state_indices=non_spec_state_indices_tensor,
                     use_qk_l2norm_in_kernel=True,
+                    null_block_id=PAD_SLOT_ID,
                 )
             )
         else:
@@ -1743,6 +1750,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 self.activation,
                 conv_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
                 validate_data=False,
+                null_block_id=PAD_SLOT_ID,
             )
         out_buf = core_attn_out[:num_actual_tokens].unsqueeze(1)
         fused_recurrent_gated_delta_rule_packed_decode(
@@ -1756,6 +1764,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             out=out_buf,
             ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
             use_qk_l2norm_in_kernel=True,
+            null_block_id=PAD_SLOT_ID,
         )
         if (
             (_GDN_DEBUG_SPLIT or _GDN_DEBUG_COMPARE)
@@ -1830,6 +1839,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             ),
             ssm_state_indices=local_state_indices,
             use_qk_l2norm_in_kernel=True,
+            null_block_id=PAD_SLOT_ID,
         )
         err = (core_attn_out - ref).abs()
         _, ref_state = fused_sigmoid_gating_delta_rule_update(
@@ -1850,6 +1860,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             ),
             ssm_state_indices=local_state_indices,
             use_qk_l2norm_in_kernel=True,
+            null_block_id=PAD_SLOT_ID,
         )
         state_err = (ssm_state_after - ref_state).abs()
         _GDN_DEBUG_COMPARE_USED += 1
@@ -1927,6 +1938,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             ),
             ssm_state_indices=local_state_indices,
             use_qk_l2norm_in_kernel=True,
+            null_block_id=PAD_SLOT_ID,
         )
         recurrent_err = (core_attn_out - recurrent_ref).abs()
         recurrent_state_err = (ssm_state_after - recurrent_state).abs()

--- a/vllm/v1/attention/backends/gdn_attn.py
+++ b/vllm/v1/attention/backends/gdn_attn.py
@@ -14,7 +14,7 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.utils import (
-    NULL_BLOCK_ID,
+    PAD_SLOT_ID,
     compute_causal_conv1d_metadata,
     mamba_get_block_table_tensor,
     split_decodes_and_prefills,
@@ -398,7 +398,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
                 spec_state_indices_tensor, non_blocking=True
             )
             spec_state_indices_tensor = self.spec_state_indices_tensor[:batch_size]
-            spec_state_indices_tensor[num_spec_decodes:].fill_(NULL_BLOCK_ID)
+            # State slot 0 is valid for GDN; use -1 for graph padding.
+            spec_state_indices_tensor[num_spec_decodes:].fill_(PAD_SLOT_ID)
 
             self.spec_sequence_masks[:num_spec_decodes].copy_(
                 spec_sequence_masks[:num_spec_decodes], non_blocking=True
@@ -444,7 +445,8 @@ class GDNAttentionMetadataBuilder(AttentionMetadataBuilder[GDNAttentionMetadata]
             non_spec_state_indices_tensor = self.non_spec_state_indices_tensor[
                 :batch_size
             ]
-            non_spec_state_indices_tensor[num_decodes:].fill_(NULL_BLOCK_ID)
+            # State slot 0 is valid for GDN; use -1 for graph padding.
+            non_spec_state_indices_tensor[num_decodes:].fill_(PAD_SLOT_ID)
 
             self.non_spec_query_start_loc[: num_decodes + 1].copy_(
                 non_spec_query_start_loc, non_blocking=True


### PR DESCRIPTION
## Summary

This patch fixes a GDN decode correctness bug in the SM75 fork.

- Use `PAD_SLOT_ID` (`-1`) for GDN CUDA-graph padding instead of `NULL_BLOCK_ID` (`0`).
- Pass the GDN padding sentinel through causal-conv and recurrent decode paths, including speculative and non-speculative paths.
- Keep `NULL_BLOCK_ID=0` as the default for non-GDN Mamba callers.
- Add CUDA regression coverage for both Qwen3.6 35B and 27B channel widths, valid state slot 0, nonzero state slots, and mixed real/padded batches.

The change is scoped to the GDN state-index contract. It does not change model weights, KV-cache precision, sampling defaults, launcher profiles, or the general Mamba sentinel default.

## Background

Users reported severe output-quality and tool-calling failures on the 2080 Ti fork compared with standard vLLM. The local reproduction used the official `Qwen/Qwen3.6-35B-A3B-FP8` checkpoint and the same GDN/Triton runtime route used by the affected service. The corresponding 27B route uses the same GDN state-index path.

## Root Cause

GDN state indices are cache-slot indices, and slot `0` is a valid allocated state entry. The fork also needs a sentinel for entries added only to pad CUDA-graph batches.

The old contract used the same value for both cases:

```text
valid GDN state slot:       0
CUDA-graph padding sentinel: 0  (NULL_BLOCK_ID)
```

As a result, a real request mapped to state slot 0 was indistinguishable from padding. The affected Triton guards treated it as invalid (`state_idx <= 0` or equivalent):

- causal convolution returned without updating the convolution state or producing the transformed token;
- recurrent decode skipped the state read/update and returned a zero or stale result, depending on the path;
- subsequent decode steps continued from stale recurrent state.

The failure depends on state-slot allocation and batching, so it can appear intermittent while still producing large downstream quality errors when slot 0 is selected. This is a logic/sentinel collision, not a model-weight corruption or a small floating-point precision drift.

## Fix

GDN graph padding now uses `PAD_SLOT_ID=-1`. The GDN call sites pass this value explicitly to causal-conv and recurrent kernels. The recurrent kernels accept a configurable `null_block_id` and now reject negative indices or the configured sentinel while allowing state slot 0.

Other Mamba callers retain their existing default `NULL_BLOCK_ID=0`, so this patch does not silently change their index contract.

## Test Environment

- Hardware: 2 x NVIDIA GeForce RTX 2080 Ti 22 GB, SM75, TP=2.
- Host platform: Intel Xeon E5-2667 v4, 1 socket, 8 cores / 16 threads, single NUMA node, X99-class platform.
- GPU interconnect: NVLink NV2 between the two GPUs; both GPUs report PCIe max Gen3 x16.
- Driver/runtime: NVIDIA driver 610.43.02. The runtime CUDA is 12.8 through PyTorch 2.11.0+cu128. `nvidia-smi` reports CUDA UMD 13.3, which is the driver-side CUDA support level, not the CUDA runtime used by PyTorch.
- Runtime packages: vLLM 2080 Ti Definitive Edition v0.1.14 (base vLLM 0.21.0), Python 3.11.15, PyTorch 2.11.0+cu128, Triton 3.6.0, FlashInfer 0.6.8.post1.
- Code under test: `fix/gdn-sm75-causal-conv`, PR commit `c256ad2`, based on `weicj/vLLM-2080Ti-Definitive:vllm-2080ti-deifinitive` at `0a0caa1`.
- Model/route: official `Qwen/Qwen3.6-35B-A3B-FP8` and `Qwen3.6-27B-FP8`; FP8 weight-only Marlin, FP16 KV cache, `mamba_cache_mode=align`, `gdn_prefill_backend=triton`, `MAX_NUM_SEQS=1`, and `MAX_BATCHED_TOKENS=2048`. The Torch-conv GDN debug fallback was disabled.
- Serving controls: `qwen-froggeric-v20.jinja`, `--generation-config vllm`, and TP=2.
- Validation tools: `tests/2080ti/test_gdn_causal_conv1d_update.py` for kernel correctness and `tools/tool_call_smoke.py` for service-level tool calls.

## Reproduction

On a CUDA-enabled checkout, run:

```bash
pytest -q tests/2080ti/test_gdn_causal_conv1d_update.py
```

The test module covers:

- causal-conv decode against the Torch reference for dimensions 4096 and 5120, with state slots 0 and 13;
- packed recurrent decode and normal recurrent decode with state slot 0;
- a mixed `[0, PAD_SLOT_ID]` batch proving that slot 0 is processed while only the padded entry is skipped.

Before this patch, the recurrent test cannot pass the GDN-specific sentinel through the old API, and the old hard-coded `<= 0` guards reject a valid state index of 0. After this patch, all of the above cases execute with the expected output and state updates.

## Runtime Validation

The following routes were validated with the code under test:

| Model route | Max model length | MTP | CUDA graph mode / capture | GPU utilization | Result |
|---|---:|---:|---|---:|---|
| Official 35B FP8, FP16 KV | 262,144 | 0 | `FULL_AND_PIECEWISE`, `[1]` | 0.97 | fixed factual prompts passed; tool-call smoke 3/3 |
| Official 27B FP8, FP16 KV | 131,072 | 0 | `FULL_AND_PIECEWISE`, `[1]` | 0.92 | fixed factual prompts passed; tool-call smoke 3/3 |
| Official 27B FP8, FP16 KV | 65,536 | 3 | `PIECEWISE`, `[4]` | 0.92 | fixed factual prompts and tool-call smoke passed |

- Direct CUDA kernel checks passed for both channel sizes, state slots 0/13, packed/normal recurrent paths, and the mixed padding sentinel case.

No before/after throughput claim is made here. These runs validate correctness and route health after the kernel change; they are not presented as a controlled performance comparison.

The tool-call check can be repeated against any of the served routes with:

```bash
python3 tools/tool_call_smoke.py --model <served-model-name>
```

The development checkout used for static validation does not have `pytest` installed, so the focused pytest command was not rerun there. Static validation passed with:

```bash
bash -n build.sh launcher.sh tools/validate_profiles.sh
bash tools/validate_profiles.sh  # profile_validation_ok total=17
python3 -m py_compile \
  vllm/v1/attention/backends/gdn_attn.py \
  vllm/model_executor/layers/mamba/gdn_linear_attn.py \
  vllm/model_executor/layers/fla/ops/fused_recurrent.py \
  vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py \
  tests/2080ti/test_gdn_causal_conv1d_update.py
git diff --check upstream/vllm-2080ti-deifinitive...HEAD
```

## Limitations

- ROCm/AITER execution was not tested. The validated target for this patch is the fork's CUDA/Triton SM75 route.
- This PR does not claim a model-quality improvement for unrelated checkpoint, sampling, KV-quantization, or chat-template problems.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a GDN decode bug where state slot 0 was treated as padding. GDN CUDA-graph padding now uses `PAD_SLOT_ID` (-1) so real requests at slot 0 are processed correctly.

- **Bug Fixes**
  - Propagates `PAD_SLOT_ID` through GDN causal-conv and recurrent decode in both speculative and non-speculative paths.
  - Kernels now reject negative indices or the configured sentinel and accept slot 0.
  - Keeps `NULL_BLOCK_ID=0` for non-GDN Mamba callers; no behavior change outside GDN.
  - Adds CUDA regression tests for Qwen3.6 35B/27B widths, slot 0 and nonzero slots, and mixed real/padded batches.

<sup>Written for commit c256ad299478d745efdeb7c5aef2ac863ac7399e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

