### PR TITLE
fix: complete named tool choice response handling

### DIFF
--- a/tests/entrypoints/openai/test_named_tool_choice_serving.py
+++ b/tests/entrypoints/openai/test_named_tool_choice_serving.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
+    RequestResponseMetadata,
+)
+from vllm.outputs import CompletionOutput, RequestOutput
+from vllm.tokenizers.mistral import MistralTokenizer
+from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            },
+        },
+    }
+]
+NAMED_CHOICE = {"type": "function", "function": {"name": "get_weather"}}
+ARGUMENTS = '{"city": "Shanghai"}'
+
+
+def _request(stream: bool) -> ChatCompletionRequest:
+    return ChatCompletionRequest.model_validate(
+        {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "tools": TOOLS,
+            "tool_choice": NAMED_CHOICE,
+            "stream": stream,
+        }
+    )
+
+
+def _result(text: str, finish_reason: str | None) -> RequestOutput:
+    return RequestOutput(
+        request_id="named-tool",
+        prompt="prompt",
+        prompt_token_ids=[1, 2],
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text=text,
+                token_ids=[3],
+                cumulative_logprob=None,
+                logprobs=None,
+                finish_reason=finish_reason,
+                stop_reason=None,
+            )
+        ],
+        finished=finish_reason is not None,
+        num_cached_tokens=0,
+    )
+
+
+async def _results(texts: list[tuple[str, str | None]]):
+    for text, finish_reason in texts:
+        yield _result(text, finish_reason)
+
+
+class _PlainContentParser:
+    def __init__(self, *_args, **_kwargs):
+        self.tool_parser = None
+        self._stream_state = type("StreamState", (), {})()
+
+    def parse(self, model_output, _request, enable_auto_tools=False):
+        return None, model_output, []
+
+    def parse_delta(self, delta_text, **_kwargs):
+        return DeltaMessage(content=delta_text)
+
+
+class _FakeMistralTokenizer(MistralTokenizer):
+    pass
+
+
+def _serving(parser_cls=None):
+    instance = OpenAIServingChat.__new__(OpenAIServingChat)
+    instance.use_harmony = False
+    instance.tool_call_id_type = "random_uuid"
+    instance.parser_cls = parser_cls
+    instance.tool_parser = None
+    instance.enable_auto_tools = False
+    instance.enable_force_include_usage = False
+    instance.response_role = "assistant"
+    instance.enable_log_outputs = False
+    instance.request_logger = None
+    instance.enable_prompt_tokens_details = False
+    instance.system_fingerprint = None
+    instance.return_tokens_as_token_ids = False
+    return instance
+
+
+async def _full(text: str, parser=None, tokenizer=object()):
+    request = _request(False)
+    return await _serving().chat_completion_full_generator(
+        request,
+        _results([(text, "stop")]),
+        "named-full",
+        "test-model",
+        request.messages,
+        tokenizer,
+        RequestResponseMetadata(request_id="named-full"),
+        parser,
+    )
+
+
+async def _stream(
+    texts: list[tuple[str, str | None]],
+    tokenizer=object(),
+):
+    request = _request(True)
+    chunks = []
+    async for item in _serving(_PlainContentParser).chat_completion_stream_generator(
+        request,
+        _results(texts),
+        "named-stream",
+        "test-model",
+        request.messages,
+        tokenizer,
+        RequestResponseMetadata(request_id="named-stream"),
+    ):
+        if item.startswith("data: ") and item.strip() != "data: [DONE]":
+            chunks.append(json.loads(item[len("data: ") :].strip()))
+    return [
+        choice
+        for chunk in chunks
+        for choice in chunk.get("choices", [])
+    ]
+
+
+def test_named_tool_choice_full_wraps_plain_content():
+    response = asyncio.run(_full(ARGUMENTS, _PlainContentParser()))
+    choice = response.choices[0]
+
+    assert choice.message.content is None
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.tool_calls is not None
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+    assert choice.message.tool_calls[0].function.arguments == ARGUMENTS
+
+
+def test_named_tool_choice_stream_wraps_plain_content():
+    choices = asyncio.run(
+        _stream([("{", None), ('"city": "Shanghai"}', "stop")])
+    )
+    tool_deltas = [
+        choice["delta"]["tool_calls"][0]
+        for choice in choices
+        if choice["delta"].get("tool_calls")
+    ]
+
+    assert tool_deltas[0]["id"]
+    assert tool_deltas[0]["type"] == "function"
+    assert tool_deltas[0]["function"] == {
+        "name": "get_weather",
+        "arguments": "{",
+    }
+    assert tool_deltas[1]["function"]["arguments"] == '"city": "Shanghai"}'
+    assert choices[-1]["finish_reason"] == "tool_calls"
+
+
+def test_named_tool_choice_empty_full_does_not_create_tool_call():
+    response = asyncio.run(_full("", None))
+    choice = response.choices[0]
+
+    assert choice.message.content is None
+    assert not choice.message.tool_calls
+    assert choice.finish_reason == "stop"
+
+
+def test_named_tool_choice_empty_stream_does_not_create_tool_call():
+    choices = asyncio.run(_stream([("", "stop")]))
+
+    assert choices[-1]["finish_reason"] == "stop"
+    assert not choices[-1]["delta"].get("tool_calls")
+
+
+def test_named_tool_choice_mistral_stream_uses_mistral_id():
+    tokenizer = _FakeMistralTokenizer.__new__(_FakeMistralTokenizer)
+    choices = asyncio.run(
+        _stream([("{", None), ('"city": "Shanghai"}', "stop")], tokenizer)
+    )
+    tool_delta = next(
+        choice["delta"]["tool_calls"][0]
+        for choice in choices
+        if choice["delta"].get("tool_calls")
+    )
+
+    assert MistralToolCall.is_valid_id(tool_delta["id"])

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -491,6 +491,26 @@ class OpenAIServingChat(OpenAIServing):
         else:
             history_tool_call_cnt = 0
 
+        if tool_choice_function_name:
+            if is_mistral_tokenizer(tokenizer):
+                from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
+
+                named_tool_call_ids = [
+                    MistralToolCall.generate_random_id() for _ in range(num_choices)
+                ]
+            else:
+                named_tool_call_ids = [
+                    make_tool_call_id(
+                        id_type=self.tool_call_id_type,
+                        func_name=tool_choice_function_name,
+                        idx=history_tool_call_cnt + i,
+                    )
+                    for i in range(num_choices)
+                ]
+        else:
+            named_tool_call_ids = []
+        named_tool_name_sent = [False] * num_choices
+
         # Always track previous_texts for comprehensive output logging
         previous_texts = [""] * num_choices
 
@@ -563,12 +583,12 @@ class OpenAIServingChat(OpenAIServing):
                     # NOTE num_choices defaults to 1 so this usually executes
                     # once per request
                     for i in range(num_choices):
+                        initial_delta = DeltaMessage(role=role)
+                        if not tool_choice_function_name:
+                            initial_delta.content = ""
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=i,
-                            delta=DeltaMessage(
-                                role=role,
-                                content="",
-                            ),
+                            delta=initial_delta,
                             logprobs=None,
                             finish_reason=None,
                         )
@@ -776,6 +796,45 @@ class OpenAIServingChat(OpenAIServing):
                     else:
                         delta_message = DeltaMessage(content=delta_text)
 
+                    # A named tool grammar emits only the function arguments as
+                    # JSON. If the model-specific parser does not produce a
+                    # tool call for that format, wrap its content here instead
+                    # of returning the arguments as assistant text.
+                    if (
+                        tool_choice_function_name
+                        and delta_message is not None
+                        and not delta_message.tool_calls
+                        and delta_message.content
+                    ):
+                        arguments_delta = delta_message.content
+                        reasoning_delta = delta_message.reasoning
+                        delta_message = DeltaMessage(reasoning=reasoning_delta)
+                        delta_message.tool_calls = [
+                            DeltaToolCall(
+                                index=0,
+                                id=(
+                                    named_tool_call_ids[i]
+                                    if not named_tool_name_sent[i]
+                                    else None
+                                ),
+                                type=(
+                                    "function"
+                                    if not named_tool_name_sent[i]
+                                    else None
+                                ),
+                                function=DeltaFunctionCall(
+                                    name=(
+                                        tool_choice_function_name
+                                        if not named_tool_name_sent[i]
+                                        else None
+                                    ),
+                                    arguments=arguments_delta,
+                                ),
+                            )
+                        ]
+                        named_tool_name_sent[i] = True
+                        tools_streamed[i] = True
+
                     # update the previous values for the next iteration
                     if (
                         is_mistral_grammar_path
@@ -928,11 +987,10 @@ class OpenAIServingChat(OpenAIServing):
                         # Send the finish response for each request.n only once
                         # In OpenAI's API, when a tool is called, the
                         # finish_reason is:
-                        # "tool_calls" for "auto" or "required" tool calls,
-                        # and "stop" for named tool calls.
+                        # "tool_calls" whenever a tool call was streamed.
                         if (
                             auto_tools_called
-                            or (tools_streamed[i] and not tool_choice_function_name)
+                            or tools_streamed[i]
                             or (self.use_harmony and harmony_tools_streamed[i])
                         ):
                             finish_reason_ = "tool_calls"
@@ -1172,6 +1230,22 @@ class OpenAIServingChat(OpenAIServing):
                 content = output.text
                 tool_calls = []
 
+            # Named tool grammars generate the selected function's arguments
+            # as plain JSON. Preserve parser-produced tool calls, but wrap the
+            # JSON when a model-specific parser leaves it as content.
+            if (
+                isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+                and not tool_calls
+                and content
+            ):
+                tool_calls = [
+                    FunctionCall(
+                        name=request.tool_choice.function.name,
+                        arguments=content,
+                    )
+                ]
+                content = None
+
             auto_tools_called = False
             if is_mistral_tokenizer(tokenizer):
                 from vllm.tool_parsers.mistral_tool_parser import MistralToolCall
@@ -1236,7 +1310,7 @@ class OpenAIServingChat(OpenAIServing):
                 message = ChatMessage(
                     role=role,
                     reasoning=reasoning,
-                    content="",
+                    content=None,
                     tool_calls=tool_call_class_items,
                 )
 
@@ -1346,13 +1420,19 @@ class OpenAIServingChat(OpenAIServing):
                     "completion."
                 )
                 message = ChatMessage(role=role, reasoning=reasoning, content=content)
-            # In OpenAI's API, when a tool is called, the finish_reason is:
-            # "tool_calls" for "auto" or "required" tool calls,
-            # and "stop" for named tool calls.
-            is_finish_reason_tool_calls = auto_tools_called or (
-                request.tool_choice
-                and request.tool_choice == "required"
-                and output.finish_reason == "stop"
+            is_finish_reason_tool_calls = (
+                auto_tools_called
+                or (
+                    isinstance(
+                        request.tool_choice, ChatCompletionNamedToolChoiceParam
+                    )
+                    and bool(message.tool_calls)
+                )
+                or (
+                    request.tool_choice
+                    and request.tool_choice == "required"
+                    and output.finish_reason == "stop"
+                )
             )
 
             choice_data = ChatCompletionResponseChoice(


### PR DESCRIPTION
## Summary

Supersedes #90 with the review fixes included.

- Use Mistral's required 9-character alphanumeric tool-call IDs for named-tool streaming.
- Only wrap non-empty generated arguments as a named tool call.
- Keep empty full and streaming outputs as normal `stop` responses instead of fabricating empty tool calls.
- Add focused serving regression tests for normal, empty, and Mistral paths.

## Validation

Validated on superserver with the vLLM runtime environment (`torch 2.11.0+cu128`):

- 5 new named-tool serving tests passed.
- 3 existing parser regression tests passed.
- Positive full and streaming fallback probes passed.
- Mistral ID validation passed (9 alphanumeric characters).
- Empty full/streaming probes returned no tool calls and `finish_reason=stop`.

The branch is based on the current `vllm-2080ti-deifinitive` HEAD.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes named tool choice handling for full and streaming responses. Old behavior sometimes surfaced raw JSON as assistant content and could fabricate empty tool calls; new behavior wraps non-empty arguments as tool calls, avoids empty tool calls, emits Mistral-compliant IDs, and sets finish_reason to tool_calls when a tool call is streamed.

- Streaming: generate per-choice tool-call IDs (use `MistralToolCall` 9‑char IDs when the tokenizer is Mistral); stream id/type/name once; wrap plain JSON deltas into `tool_calls`; do not create tool calls for empty streams; finish_reason is tool_calls whenever a tool call was streamed.
- Full responses: when `tool_choice` is named and the parser yields content but no tool call, wrap the JSON into a function call and set content to null; keep empty outputs as stop with no tool calls; set message content to null when tool_calls are present.
- Tests: add focused serving tests in `tests/entrypoints/openai/test_named_tool_choice_serving.py` covering normal, empty, and Mistral paths; validate `MistralToolCall` ID format.
- Client note: handle finish_reason=tool_calls for named tool streams when a tool call was produced.

<sup>Written for commit 94fcc74946fc27b2aeeca2641b2f3124e77b4ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

