### PR TITLE
2080Ti (sm_75) 能力补齐: int8 KV + FlashInfer 反量化桥接 + GGUF/AWQ 双路线

### DIFF
--- a/MODIFICATION_LOG.md
+++ b/MODIFICATION_LOG.md
@@ -1,67 +1,38 @@
-# vLLM-2080Ti-dev 修改记录
+# MODIFICATION_LOG —— vllm-2080Ti-dev 本地修改记录(2026-08-10)
 
-基准:原始 fork weicj/vLLM-2080Ti-Definitive @ 0a0caa1(即 vllm-orig-2080Ti,git 干净)
-目标:为 GGUF/Q4 路线添加的功能修复,全部以"默认不影响其他格式"为原则:
-  - GGUF 专属逻辑用 `load_format == "gguf"` 或环境变量 `VLLM_GDN_GGUF_LAYOUT=1` 分流
-  - 未设置时(默认)完全走原版路径,兼容 AWQ/GPTQ/FP16/BF16 等 vLLM 原生格式
-  - 每处改动带 `[FORK 兼容]` 注释
+> 纪律:改 vLLM 共享代码必须 GGUF+AWQ 双兼容 + [FORK 兼容] 注释 + 本日志登记。
 
-验证流程(每移植一组后执行):
-1. AWQ(原始 checkpoint):serve_awq.sh → "23*47=" 应为 "1081"
-2. GGUF(Q4):serve_gguf.sh → "1+1=" 应为 "2"
+## 本次会话修改
 
----
+### 3. fused_recurrent.py + gdn_linear_attn.py — packed decode 内核 v-head 映射修复(2026-08-10,12*8=9 根因)✅
+- 文件:vllm/model_executor/layers/fla/ops/fused_recurrent.py + layers/mamba/gdn_linear_attn.py
+- 问题:`fused_recurrent_gated_delta_rule_packed_decode_kernel` 的 v-head→k-head 映射写死
+  `i_h = i_hv % H`(llama.cpp GGUF/mod16 交错映射)。div3 布局(AWQ/transformers 官方)应为
+  `i_h = i_hv // (HV // H)`(q/k repeat_interleave 连续分组,transformers
+  modeling_qwen3_5.py:523-525 实证)。映射错乱 → decode 阶段部分 v-head 输出反相
+  (探针实测 head 2/7/15/22 余弦 -1.0)→ 生成错乱(12*8=9、23*47=2347)
+- 修复 3 处([FORK 兼容 2026-08-10 GPTQ8]):
+  1. packed decode 内核加 `GGUF_LAYOUT: tl.constexpr` 分支:GGUF 保持 `% H`,div3 用 `// (HV // H)`
+  2. `fused_recurrent_gated_delta_rule_packed_decode` 加 `gguf_layout: bool = False` 参数
+  3. gdn_linear_attn.py `_forward_core_decode_non_spec` 调用处传 `gguf_layout=_GDN_GGUF_LAYOUT`
+- 验证:12*8=96 ✓、23*47=1081(竖式)✓、200 字短文 ✓、工具调用(get_weather)✓;
+  AWQ 此前也答错('128')证实是共享 div3 路径问题,本修复对 AWQ 同样生效
+- 影响:div3 布局(GPTQ8/AWQ)decode 路径;GGUF(mod16)行为不变(% H 保持)
 
-## 移植记录
+### 2. ~~marlin_utils.py — marlin_permute_scales 支持非 64/32 组(2026-08-10)~~ ⛔ 已回滚
+- 结论:误诊。vLLM 内部 `transform_w_s` 先 permute 成 [groups, n] 才调 marlin_permute_scales,
+  旧版代码本就正确;判别脚本传错布局 [n, groups] 导致误判。补丁已回滚,文件恢复原状。
+  教训:判别脚本必须复刻 vLLM 真实调用链,输入布局假设错误是最高危错误源。
 
-### [1] A 类:GGUF 配置/加载修复(4 文件,2026-08-09)
-- `transformers_utils/config.py`:qwen35→Qwen3_5Config 映射;GGUF 主文件纯文本时 vision=None(走 Qwen3_5ForCausalLM)
-  - 仅影响 model_type=="qwen35" 且 GGUF 加载路径;safetensors 多模态不受影响
-- `transformers_utils/configs/qwen3_5.py`:GGUF 加载时顶层 kwargs 转发给 text_config
-  - 仅 GGUF 路径(字段缺失时);原版行为(子配置 dict)不变
-- `v1/core/kv_cache_utils.py`:mamba cache page_size_padded 填充修复
-  - 仅 `mamba_cache_mode != "align"` 且层支持 padding 时生效;align 模式走原版
-- `v1/attention/backends/flex_attention.py`:key/value_cache view→reshape(4 行)
-  - reshape 比 view 宽容(非连续张量也可),数值等价,所有格式通用
+### 1. qwen3_5.py — 纯文本 ForCausalLM 补 IsHybrid(2026-08-10)
+- 文件:vllm/model_executor/models/qwen3_5.py
+- 修改:
+  1. `Qwen3_5ForCausalLM` 继承增加 `IsHybrid`(原 `Qwen3_5ForCausalLMBase` 无此标记)
+  2. `Qwen3_5ForCausalLMBase` 新增 `get_mamba_state_dtype_from_config` / `get_mamba_state_shape_from_config`(原只在多模态 `Qwen3_5ForConditionalGeneration` 中,纯文本类缺失导致 `is_hybrid=False` → mamba_block_size 不推导 → `get_kv_cache_spec` 断言崩溃)
+- 原因:GGUF 纯文本(Qwen3_5ForCausalLM)也含 linear_attn 混合层,必须标记 IsHybrid
+- 兼容性:GGUF(纯文本)修复;AWQ(多模态)走原类不受影响。标注 [FORK 兼容]
+- 上游对照:原版 Qwen3_5ForConditionalGeneration 继承 IsHybrid,纯文本类是 fork 加的,属 fork 补漏
 
-### [2] qwen3_next.py:Qwen3NextRMSNorm 按 load_format 分流(2026-08-09)
-- 新增 `_get_qwen3_next_rms_norm_cls(load_format)`:GGUF → 普通 RMSNorm(llama.cpp 权重含 +1);
-  其他(safetensors/AWQ 等)→ GemmaRMSNorm(原版 1+w 语义)
-- 删除 GDN 输入的 .float() 强制转换(原版 4 处):各格式走原生 dtype
-  (GGUF FP32 / AWQ FP16),避免精度与 dtype 错配
+## 历史修改(此前会话,登记在案)
 
-### [3] B 类:GDN 内核双路线布局(GGUF mod16 vs AWQ div3)(2026-08-09)
-- `fla/ops/fused_sigmoid_gating.py`:
-  - 内核新增 `GGUF_LAYOUT: tl.constexpr` 参数
-  - i_h 映射:GGUF_LAYOUT=True → `(i_hv + V_START) % H`(mod16,llama.cpp 布局);
-    False(默认)→ `i_hv // (HV // H)`(div3,transformers/AWQ 原版)
-  - 包装函数新增 `gguf_layout=False` 参数并透传内核
-- `fla/ops/fused_recurrent.py`:
-  - 两处内核 i_h = `i_hv % H`(mod16)。仅 GGUF 的 forward_native(chunk)路径使用;
-    AWQ 等走 forward_cuda(fi_chunk_gated_delta_rule,flashinfer 内置 div3),不受影响
-- `mamba/gdn_linear_attn.py`:
-  - 模块级 `_GDN_GGUF_LAYOUT`(环境变量 `VLLM_GDN_GGUF_LAYOUT=1`,默认 False)
-  - import `get_tp_group`(GGUF q/k all-gather 用)
-  - `_gdn_v_start`(v-head 全局起始,仅 GGUF 且 TP>1 时非 0,默认 0)
-  - prefill 非 spec 分支:GGUF → fused_post_conv_prep + q/k all-gather;
-    AWQ/其他 → 原版 rearrange_mixed_qkv(无 gather)
-  - decode split_non_spec:q/k all-gather 仅 GGUF
-  - 内核调用(spec/decode)传 v_start(默认 0)+ gguf_layout(默认 False)
-  - **prefill 主路径(2.3)双分支**:GGUF → `fused_sigmoid_gating_delta_rule_update` 直接内核
-    (a_prefill/b_prefill,use_qk_l2norm=True,v_start/gguf_layout=True),且输出逐 token state
-    须按 `last_recurrent_state[prefill_query_start_loc[1:]-1]` 切分取每序列末尾;
-    AWQ/其他 → 原版 `self.chunk_gated_delta_rule`(chunk 式,输出即每序列末尾 state)
-  - **if split_non_spec 分支 q/k gather 仅 GGUF**(`tp_size>1 and _GDN_GGUF_LAYOUT`);
-    AWQ div3 半切直用不 gather(当前版无条件 gather 会破坏 AWQ,dev 已修正)
-  - `_output_projection` dtype 分流:z 对齐 core dtype;GGUF FP32 模式(VLLM_GGUF_FP32=1)
-    proj_in 保持 FP32,否则(AWQ)转 FP16;非量化层转 weight.dtype
-  - `core_attn_out` 分配两处 dtype=torch.float32(GGUF FP32 链必需;AWQ 经 proj_in 分流回 FP16)
-  - split_non_spec=False 时补 `a_prefill=a, b_prefill=b` 兜底(当前版会 NameError)
-
-### [4] 验证(dev 工作副本,2026-08-09)
-- [x] AWQ(dev,原始 checkpoint):1+1= → '2' ✓;23*47= → 1081 ✓;7*8-6= → '56' ✓
-- [x] GGUF(dev,VLLM_GDN_GGUF_LAYOUT=1):1+1= → '2\n1+1=2\n' ✓(与旧版一致);
-      23*47= → '1081(10' ✓;7*8-6= → '56-6=50' ✓
-- [x] **双兼容达成**:同一份代码,GGUF 走 mod16 直接内核 + gather,AWQ 走 div3 chunk 原版路径
-- 注:当前版(Definitive)的"AWQ 正常"实为 orig 目录功劳(其无条件直接内核+gather 会破坏 AWQ);
-  dev 是首个真正双兼容的版本
+(此处按需补录 prior sessions 的 [FORK 兼容] 改动清单)

--- a/MODIFICATION_LOG.md
+++ b/MODIFICATION_LOG.md
@@ -1,0 +1,67 @@
+# vLLM-2080Ti-dev 修改记录
+
+基准:原始 fork weicj/vLLM-2080Ti-Definitive @ 0a0caa1(即 vllm-orig-2080Ti,git 干净)
+目标:为 GGUF/Q4 路线添加的功能修复,全部以"默认不影响其他格式"为原则:
+  - GGUF 专属逻辑用 `load_format == "gguf"` 或环境变量 `VLLM_GDN_GGUF_LAYOUT=1` 分流
+  - 未设置时(默认)完全走原版路径,兼容 AWQ/GPTQ/FP16/BF16 等 vLLM 原生格式
+  - 每处改动带 `[FORK 兼容]` 注释
+
+验证流程(每移植一组后执行):
+1. AWQ(原始 checkpoint):serve_awq.sh → "23*47=" 应为 "1081"
+2. GGUF(Q4):serve_gguf.sh → "1+1=" 应为 "2"
+
+---
+
+## 移植记录
+
+### [1] A 类:GGUF 配置/加载修复(4 文件,2026-08-09)
+- `transformers_utils/config.py`:qwen35→Qwen3_5Config 映射;GGUF 主文件纯文本时 vision=None(走 Qwen3_5ForCausalLM)
+  - 仅影响 model_type=="qwen35" 且 GGUF 加载路径;safetensors 多模态不受影响
+- `transformers_utils/configs/qwen3_5.py`:GGUF 加载时顶层 kwargs 转发给 text_config
+  - 仅 GGUF 路径(字段缺失时);原版行为(子配置 dict)不变
+- `v1/core/kv_cache_utils.py`:mamba cache page_size_padded 填充修复
+  - 仅 `mamba_cache_mode != "align"` 且层支持 padding 时生效;align 模式走原版
+- `v1/attention/backends/flex_attention.py`:key/value_cache view→reshape(4 行)
+  - reshape 比 view 宽容(非连续张量也可),数值等价,所有格式通用
+
+### [2] qwen3_next.py:Qwen3NextRMSNorm 按 load_format 分流(2026-08-09)
+- 新增 `_get_qwen3_next_rms_norm_cls(load_format)`:GGUF → 普通 RMSNorm(llama.cpp 权重含 +1);
+  其他(safetensors/AWQ 等)→ GemmaRMSNorm(原版 1+w 语义)
+- 删除 GDN 输入的 .float() 强制转换(原版 4 处):各格式走原生 dtype
+  (GGUF FP32 / AWQ FP16),避免精度与 dtype 错配
+
+### [3] B 类:GDN 内核双路线布局(GGUF mod16 vs AWQ div3)(2026-08-09)
+- `fla/ops/fused_sigmoid_gating.py`:
+  - 内核新增 `GGUF_LAYOUT: tl.constexpr` 参数
+  - i_h 映射:GGUF_LAYOUT=True → `(i_hv + V_START) % H`(mod16,llama.cpp 布局);
+    False(默认)→ `i_hv // (HV // H)`(div3,transformers/AWQ 原版)
+  - 包装函数新增 `gguf_layout=False` 参数并透传内核
+- `fla/ops/fused_recurrent.py`:
+  - 两处内核 i_h = `i_hv % H`(mod16)。仅 GGUF 的 forward_native(chunk)路径使用;
+    AWQ 等走 forward_cuda(fi_chunk_gated_delta_rule,flashinfer 内置 div3),不受影响
+- `mamba/gdn_linear_attn.py`:
+  - 模块级 `_GDN_GGUF_LAYOUT`(环境变量 `VLLM_GDN_GGUF_LAYOUT=1`,默认 False)
+  - import `get_tp_group`(GGUF q/k all-gather 用)
+  - `_gdn_v_start`(v-head 全局起始,仅 GGUF 且 TP>1 时非 0,默认 0)
+  - prefill 非 spec 分支:GGUF → fused_post_conv_prep + q/k all-gather;
+    AWQ/其他 → 原版 rearrange_mixed_qkv(无 gather)
+  - decode split_non_spec:q/k all-gather 仅 GGUF
+  - 内核调用(spec/decode)传 v_start(默认 0)+ gguf_layout(默认 False)
+  - **prefill 主路径(2.3)双分支**:GGUF → `fused_sigmoid_gating_delta_rule_update` 直接内核
+    (a_prefill/b_prefill,use_qk_l2norm=True,v_start/gguf_layout=True),且输出逐 token state
+    须按 `last_recurrent_state[prefill_query_start_loc[1:]-1]` 切分取每序列末尾;
+    AWQ/其他 → 原版 `self.chunk_gated_delta_rule`(chunk 式,输出即每序列末尾 state)
+  - **if split_non_spec 分支 q/k gather 仅 GGUF**(`tp_size>1 and _GDN_GGUF_LAYOUT`);
+    AWQ div3 半切直用不 gather(当前版无条件 gather 会破坏 AWQ,dev 已修正)
+  - `_output_projection` dtype 分流:z 对齐 core dtype;GGUF FP32 模式(VLLM_GGUF_FP32=1)
+    proj_in 保持 FP32,否则(AWQ)转 FP16;非量化层转 weight.dtype
+  - `core_attn_out` 分配两处 dtype=torch.float32(GGUF FP32 链必需;AWQ 经 proj_in 分流回 FP16)
+  - split_non_spec=False 时补 `a_prefill=a, b_prefill=b` 兜底(当前版会 NameError)
+
+### [4] 验证(dev 工作副本,2026-08-09)
+- [x] AWQ(dev,原始 checkpoint):1+1= → '2' ✓;23*47= → 1081 ✓;7*8-6= → '56' ✓
+- [x] GGUF(dev,VLLM_GDN_GGUF_LAYOUT=1):1+1= → '2\n1+1=2\n' ✓(与旧版一致);
+      23*47= → '1081(10' ✓;7*8-6= → '56-6=50' ✓
+- [x] **双兼容达成**:同一份代码,GGUF 走 mod16 直接内核 + gather,AWQ 走 div3 chunk 原版路径
+- 注:当前版(Definitive)的"AWQ 正常"实为 orig 目录功劳(其无条件直接内核+gather 会破坏 AWQ);
+  dev 是首个真正双兼容的版本

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -28,6 +28,7 @@ CacheDType = Literal[
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
     "turboquant_3bit_nc",
+    "int8_per_tensor",  # [FORK-PORT] PR#41505 symmetric int8 per-tensor KV
     "int8_per_token_head",
     "fp8_per_token_head",
     "nvfp4",
@@ -256,6 +257,13 @@ class CacheConfig:
                 "memory footprint and boosts the performance. "
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
+            )
+        elif cache_dtype == "int8_per_tensor":  # [FORK-PORT] PR#41505
+            logger.info(
+                "Using int8_per_tensor data type to store kv cache. "
+                "It reduces the GPU memory footprint and boosts the "
+                "performance. Meanwhile, it may cause accuracy drop "
+                "without a proper scaling factor",
             )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -201,8 +201,12 @@ class CudaCommunicator(DeviceCommunicatorBase):
             assert out is not None
             return out
         ca_comm = self.ca_comm
+        # [FORK] profiling 期间禁用 custom AR (128K IPC 泄漏, 官方 #46515)
+        import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+        _profiling_disabled = getattr(_car_mod, "_PROFILING_CAR_DISABLED", False)
         if (
             ca_comm is not None
+            and not _profiling_disabled
             and not ca_comm.disabled
             and ca_comm.should_custom_ar(input_)
         ):

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -4,6 +4,9 @@
 from contextlib import contextmanager
 from typing import cast
 
+# [FORK] profiling 期间 custom AR 禁用标志 (128K IPC 泄漏调试)
+_PROFILING_CAR_DISABLED = False
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -232,6 +235,9 @@ class CustomAllreduce:
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
     def should_custom_ar(self, inp: torch.Tensor):
+        # [FORK] profiling 调试日志 (profile_cudagraph_memory 期间打印)
+        if _PROFILING_CAR_DISABLED:
+            print(f"[FORK-CAR] should_custom_ar: disabled={self.disabled} size={inp.numel()*inp.element_size()}", flush=True)
         if self.disabled:
             return False
         inp_size = inp.numel() * inp.element_size()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -704,6 +704,10 @@ class EngineArgs:
         # support `EngineArgs(compilation_config={...})`
         # without having to manually construct a
         # CompilationConfig object
+        # [FORK 兼容] 修复: CLI 传入的 JSON 字符串未被转成 dict,
+        # 导致 compilation_config 参数静默失效(总是用默认 mode=3 编译)
+        if isinstance(self.compilation_config, str):
+            self.compilation_config = json.loads(self.compilation_config)
         if isinstance(self.compilation_config, dict):
             self.compilation_config = CompilationConfig(**self.compilation_config)
         if isinstance(self.attention_config, dict):

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,6 +150,11 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
+    # [FORK-PORT] PR#41505: int8_per_tensor 的对称量化范围是 ±127
+    # (fp8 默认用 envs K/V_SCALE_CONSTANT=200/100; int8 必须用 127)
+    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        layer.k_range.fill_(127.0)
+        layer.v_range.fill_(127.0)
 
     # The output scale on host memory. This should be the input scale of
     # the quant op after this attention layer.
@@ -501,12 +506,34 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
+        # [FORK] int8_per_tensor: warmup/dummy 前向的 K/V 全零 → scale=0 垃圾缓存
+        # (hybrid #37554 实锤: 校准期 recurrent state 未初始化)。跳过零值校准,
+        # 保持 calculate_kv_scales 标志, 等第一个真实请求 (长 prefill) 再校准。
+        if self.kv_cache_dtype == "int8_per_tensor":
+            k_absmax = torch.abs(key).max().item()
+            v_absmax = torch.abs(value).max().item()
+            if k_absmax == 0.0 or v_absmax == 0.0:
+                print(
+                    f"[FORK-INT8SCALE] {self.layer_name} 跳过零值校准 "
+                    f"(k_absmax={k_absmax:.6f} v_absmax={v_absmax:.6f}), 等真实请求",
+                    flush=True,
+                )
+                return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         self._k_scale.copy_(torch.abs(key).max() / self.k_range)
         self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
+        # [FORK] int8_per_tensor 调试: 打印实际校准的 scale 值
+        if self.kv_cache_dtype == "int8_per_tensor":
+            print(
+                f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
+                f"v_scale={self._v_scale_float:.6f} "
+                f"k_absmax={torch.abs(key).max().item():.4f} "
+                f"v_absmax={torch.abs(value).max().item():.4f}",
+                flush=True,
+            )
         # We only calculate the scales once
         self.calculate_kv_scales = False
 
@@ -595,6 +622,13 @@ def maybe_calc_kv_scales(
     # Only calculate if the layer's calculate_kv_scales flag is True
     # This flag gets set to False after the first forward pass
     if not self.calculate_kv_scales:
+        return
+
+    # [FORK] int8_per_tensor: CUDA graph 捕获/回放期间跳过 — calc_kv_scales 里有
+    # .item() CPU 同步, 在 capture 中触发 cudaErrorStreamCaptureInvalidated。
+    # 标志保留到第一个真实 eager prefill (长 chunk 超图捕获尺寸) 再校准。
+    _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+    if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
         return
 
     self.calc_kv_scales(query, key, value)

--- a/vllm/model_executor/layers/conv.py
+++ b/vllm/model_executor/layers/conv.py
@@ -219,12 +219,6 @@ class Conv3dLayer(ConvLayerBase):
     def _forward_mulmat(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 5
         B, C, T, H, W = x.shape
-        if B > 100:  # 临时探针
-            print(
-                f"[DBG-CONV] x={tuple(x.shape)} kernel={tuple(self.kernel_size)} "
-                f"input_size={self.input_size}",
-                flush=True,
-            )
         K1, K2, K3 = self.kernel_size
         T, H, W = T // K1, H // K2, W // K3
         x = x.unfold(2, K1, K1).unfold(3, K2, K2).unfold(4, K3, K3)

--- a/vllm/model_executor/layers/conv.py
+++ b/vllm/model_executor/layers/conv.py
@@ -219,6 +219,12 @@ class Conv3dLayer(ConvLayerBase):
     def _forward_mulmat(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 5
         B, C, T, H, W = x.shape
+        if B > 100:  # 临时探针
+            print(
+                f"[DBG-CONV] x={tuple(x.shape)} kernel={tuple(self.kernel_size)} "
+                f"input_size={self.input_size}",
+                flush=True,
+            )
         K1, K2, K3 = self.kernel_size
         T, H, W = T // K1, H // K2, W // K3
         x = x.unfold(2, K1, K1).unfold(3, K2, K2).unfold(4, K3, K3)

--- a/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_delta_h.py
@@ -29,12 +29,13 @@ NUM_WARPS = [2, 4, 8, 16]
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+# [FORK] 固定 GDN kernel 配置 (修正版):
+# 2026-08-16 微基准: BV32/w4 全 shape 最优 (32K: 112ms vs 原 BV32/w2 145ms, -23%;
+# BV64 反而更慢 136-249ms — 与 chunk_o 相反)。缩 autotune 无效 (key 不含 T,
+# warmup 假最优被复用), 直接固定。
 @triton.autotune(
     configs=[
-        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for num_warps in [2, 4]
-        for num_stages in [2, 3, 4]
-        for BV in [32, 64]
+        triton.Config({"BV": 32}, num_warps=4, num_stages=2)  # 微基准最优
     ],
     key=["H", "K", "V", "BT"],
     use_cuda_graph=use_cuda_graph,

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -28,13 +28,13 @@ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8]
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
     }
 )
+# [FORK] 固定 GDN kernel 配置 (修正版):
+# 2026-08-16 微基准: 原固定 BK32/BV32/w2 是可行集最差 (32K 慢 8.4x);
+# 缩 autotune (6 组合) 也无效 — key 不含 T, warmup(T=64) 搜索的假最优被所有
+# shape 复用。直接固定微基准最优 BK32/BV64/w4 (sm_75 共享内存 44KB 安全)
 @triton.autotune(
     configs=[
-        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
-        for BK in BKV_LIST
-        for BV in BKV_LIST
-        for num_warps in NUM_WARPS
-        for num_stages in [2, 3, 4]
+        triton.Config({"BK": 32, "BV": 64}, num_warps=4, num_stages=2)  # 32K 实测最优
     ],
     key=["H", "K", "V", "BT"],
 )

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -281,11 +281,20 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
     BV: tl.constexpr,
     SOFTPLUS_THRESHOLD: tl.constexpr,
     USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    GGUF_LAYOUT: tl.constexpr,  # [FORK 兼容] True=GGUF mod16;False=AWQ/官方 div3
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    # llama.cpp fused GDN: k-head = v-head % num_k_heads
-    i_h = i_hv % H
+    # [FORK 兼容 2026-08-10 GPTQ8] v-head → k-head 映射必须与布局一致:
+    #   GGUF/mod16(llama.cpp):k-head = v-head % num_k_heads(交错)
+    #   AWQ/transformers 官方 div3:repeat_interleave 语义 = v-head // (HV // H)(连续分组)
+    # 原实现写死 % H,导致 div3 布局 decode 阶段映射错乱(12*8=1 根因)。
+    if GGUF_LAYOUT:
+        # llama.cpp fused GDN: k-head = v-head % num_k_heads
+        i_h = i_hv % H
+    else:
+        # transformers 官方 div3: q/k repeat_interleave(ratio) → 连续分组
+        i_h = i_hv // (HV // H)
 
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
@@ -351,6 +360,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
     ssm_state_indices: torch.Tensor,
     use_qk_l2norm_in_kernel: bool = False,
     null_block_id: int = NULL_BLOCK_ID,
+    gguf_layout: bool = False,  # [FORK 兼容] True=GGUF mod16;False=AWQ/官方 div3
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if mixed_qkv.ndim != 2:
         raise ValueError(
@@ -477,6 +487,7 @@ def fused_recurrent_gated_delta_rule_packed_decode(
         BV=BV,
         SOFTPLUS_THRESHOLD=20.0,
         USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+        GGUF_LAYOUT=gguf_layout,  # [FORK 兼容] 布局分支
         num_warps=num_warps,
         num_stages=num_stages,
     )

--- a/vllm/model_executor/layers/fla/ops/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/fused_recurrent.py
@@ -62,7 +62,8 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # llama.cpp fused GDN: k-head = v-head % num_k_heads (fastmodulo(h_idx, neqk1))
+    i_h = i_hv % H
     if IS_VARLEN:
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int64),
@@ -283,7 +284,8 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # llama.cpp fused GDN: k-head = v-head % num_k_heads
+    i_h = i_hv % H
 
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)

--- a/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
+++ b/vllm/model_executor/layers/fla/ops/fused_sigmoid_gating.py
@@ -48,6 +48,8 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     V: tl.constexpr,
     BK: tl.constexpr,
     BV: tl.constexpr,
+    V_START: tl.constexpr,  # 本 TP rank 的 v-head 全局起始(interleaved 布局 TP 切分用)
+    GGUF_LAYOUT: tl.constexpr,  # [FORK 兼容] True=GGUF/llama.cpp 布局(mod16);False=AWQ/官方 div3 布局
     stride_init_state_token: tl.constexpr,
     stride_final_state_token: tl.constexpr,
     stride_indices_seq: tl.constexpr,
@@ -63,7 +65,19 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # llama.cpp fused GDN 内核: k-head = v-head % num_k_heads (fastmodulo(h_idx, neqk1))
+    # q/k 已 all-gather 为全量(gather 顺序=[rank0 数据, rank1 数据]):
+    #   rank0(TP0, 后半权重 q8-15) -> gather 0-7 是 q8-15
+    #   rank1(TP1, 前半权重 q0-7)  -> gather 8-15 是 q0-7
+    # 本 rank 的 v-head 全局起始 v_start(TP0=24, TP1=0), 全局 v = v_start + i_hv
+    # 需要 q/k 的 gather 位置 p 满足 (p + H//2) % H = (v_start + i_hv) % H
+    # => p = (v_start + i_hv + H//2) % H; 令 V_START = (v_start + H//2) % H
+    if GGUF_LAYOUT:
+        # [FORK 兼容] GGUF/llama.cpp mod16 布局(需 q/k 全量 gather)
+        i_h = (i_hv + V_START) % H
+    else:
+        # [FORK 兼容] AWQ/transformers 官方 div3 布局(TP 切分下 q/k 各半,直接用本 rank 的 k-head)
+        i_h = i_hv // (HV // H)
     if IS_VARLEN:
         bos, eos = (
             tl.load(cu_seqlens + i_n).to(tl.int64),
@@ -145,7 +159,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             b_h *= tl.exp(b_g)
         else:
             b_h *= tl.exp(b_g[None, :])
-        # [BV]
+        # llama.cpp GDN (delta-net-base.cpp / gated_delta_net.cu):
+        #   kv = S @ k (衰减后 state 的读取 = g*kv_old)
+        #   delta = (v - kv) * beta
+        #   S' = g*S + delta ⊗ k
+        # 注: 原来这里 b_v 和 b_k 都乘了 beta(双 beta), 与 llama.cpp 不符, 已修正
         b_v -= tl.sum(b_h * b_k[None, :], 1)
         b_v *= b_beta
         # [BV, BK]
@@ -197,6 +215,8 @@ def fused_sigmoid_gating_delta_rule_update(
     use_qk_l2norm_in_kernel: bool = False,
     is_kda: bool = False,
     null_block_id: int = NULL_BLOCK_ID,
+    v_start: int = 0,
+    gguf_layout: bool = False,  # [FORK 兼容] True=GGUF mod16 布局;False=AWQ 官方 div3 布局
 ):
     """
     Fused triton implementation of sigmoid gating delta rule update.
@@ -266,6 +286,8 @@ def fused_sigmoid_gating_delta_rule_update(
         V=V,
         BK=BK,
         BV=BV,
+        V_START=v_start,
+        GGUF_LAYOUT=gguf_layout,
         stride_init_state_token=stride_init_state_token,
         stride_final_state_token=stride_final_state_token,
         stride_indices_seq=stride_indices_seq,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -704,16 +704,17 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         # initialize GGUF param after we know the quantize type
         is_gguf_weight = getattr(param, "is_gguf_weight", False)
         is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
-        if isinstance(loaded_shard_id, tuple) and (
-            is_gguf_weight or is_gguf_weight_type
-        ):
-            raise NotImplementedError(
-                "Shard id with multiple indices is not supported for GGUF."
-            )
         if is_gguf_weight_type:
             if loaded_shard_id is not None:
-                param.data[loaded_shard_id].copy_(loaded_weight)
-                param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
+                if isinstance(loaded_shard_id, tuple):
+                    # Qwen3.5 GDN in_proj_qkv(shard 0,1,2) 等合并分片:
+                    # 同一量化类型广播到各 shard(键用 tuple,apply 按 idx 查)
+                    for sid in loaded_shard_id:
+                        param.data[sid].copy_(loaded_weight)
+                        param.shard_weight_type[sid] = loaded_weight.item()
+                else:
+                    param.data[loaded_shard_id].copy_(loaded_weight)
+                    param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
             else:
                 param.shard_weight_type = {
                     i: loaded_weight.item() for i, _ in enumerate(self.output_sizes)
@@ -722,6 +723,24 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         if is_gguf_weight:
             output_dim = getattr(param, "output_dim", None)
+            if isinstance(loaded_shard_id, tuple):
+                # 合并 shard(如 Qwen3.5 GDN in_proj_qkv = [q,k,v] 合并存一个
+                # GGUF tensor attn_qkv):必须按 output_sizes 边界切分,再对
+                # 每个 shard 单独做 TP 分片;整体 narrow 会导致 q/k/v 错位
+                # (vLLM 官方只测过 Gemma2/3,未覆盖 Qwen3Next GGUF 布局)。
+                cur_offset = 0
+                for sid in loaded_shard_id:
+                    osize = self.output_sizes[sid]
+                    shard_size = osize // self.tp_size
+                    start_idx = self.tp_rank * shard_size
+                    shard_w = loaded_weight.narrow(
+                        output_dim, cur_offset + start_idx, shard_size
+                    )
+                    param.shard_id.append(sid)
+                    param.shard_id_map[sid] = len(param.data_container)
+                    param.data_container.append(shard_w)
+                    cur_offset += osize
+                return
             shard_size = loaded_weight.size(output_dim) // self.tp_size
             start_idx = self.tp_rank * shard_size
 

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -883,9 +883,13 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         normed_3d = normed.reshape(z_shape_og)
         proj_in = rearrange(normed_3d, "... h d -> ... (h d)")
         _wp = getattr(self.out_proj, "qweight", None)
-        if _wp is not None:
-            # [FORK 兼容] 量化层(AWQ/GGUF):qweight 是 int32 打包,不能转成它的 dtype;
-            # AWQ 内核要求 FP16 输入;GGUF FP32 模式(VLLM_GGUF_FP32=1)保持 FP32
+        _has_w = hasattr(self.out_proj, "weight")
+        if _wp is not None or not _has_w:
+            # [FORK 兼容] 量化层输入必须 fp16:
+            #   AWQ/GGUF 有 qweight(int32 打包,不能转成它的 dtype);
+            #   CT 量化层(compressed-tensors WNA16)无 weight 属性(只有
+            #   weight_packed/scale/shape),Marlin 内核同样要求 FP16 输入;
+            #   GGUF FP32 模式(VLLM_GGUF_FP32=1)保持 FP32
             if os.getenv("VLLM_GGUF_FP32", "0") != "1":
                 proj_in = proj_in.to(torch.float16)
         else:

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -893,6 +893,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         output_chunk, _ = self.out_proj(proj_in)
         output[:num_tokens] = output_chunk
 
+
         if (
             _GDN_DEBUG_OUTPUT
             and _GDN_DEBUG_OUTPUT_USED < 16
@@ -964,6 +965,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # ============================================================
         mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
         ba, _ = self.in_proj_ba(hidden_states)
+
 
         if self.gqa_interleaved_layout:
             # Qwen3-Next: unpack the interleaved GQA layout
@@ -1458,6 +1460,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             value_non_spec = value_non_spec.unsqueeze(0)
             g_non_spec = g_non_spec.unsqueeze(0)
             beta_non_spec = beta_non_spec.unsqueeze(0)
+
             if self.tp_size > 1 and _GDN_GGUF_LAYOUT:
                 # [FORK 兼容] 仅 GGUF(mod16)需要 q/k 全量(llama.cpp 映射 v-head%16
                 # 需要全部 16 个 k-head);AWQ(div3)TP 半切直用,不 gather
@@ -1877,6 +1880,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             out=out_buf,
             ssm_state_indices=non_spec_state_indices_tensor[:num_actual_tokens],  # type: ignore[index]
             use_qk_l2norm_in_kernel=True,
+            gguf_layout=_GDN_GGUF_LAYOUT,  # [FORK 兼容 2026-08-10 GPTQ8] div3 用 // 映射修复
             null_block_id=PAD_SLOT_ID,
         )
         if (

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -18,6 +18,7 @@ from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
+    get_tp_group,  # [FORK 兼容] GGUF 布局 q/k all-gather 用
 )
 from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
@@ -32,6 +33,11 @@ from vllm.model_executor.layers.fla.ops import (
 )
 from vllm.model_executor.layers.fla.ops.chunk import l2norm_fwd
 from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
+
+# [FORK 兼容] 双路线布局开关:
+#   VLLM_GDN_GGUF_LAYOUT=1 -> GGUF/llama.cpp mod16 布局(serve_gguf.sh 设置)
+#   未设置(默认)          -> AWQ/其他格式走 transform/div3 原版路径
+_GDN_GGUF_LAYOUT = os.getenv("VLLM_GDN_GGUF_LAYOUT", "0") == "1"
 from vllm.model_executor.layers.layernorm import RMSNormGated
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
@@ -443,6 +449,23 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
+        # [FORK 兼容] GGUF(mod16)布局下,本 rank 的 v-head 全局起始:
+        # rank0 拿后半(v24-47),rank1 拿前半(v0-23)(shard 逆序)
+        # 内核偏移 V_START = (v_start + H//2) % H:
+        #   TP0: (24+8)%16=0  -> i_h = i_hv % 16 (gather 0-7=自己的 q8-15)
+        #   TP1: (0+8)%16=8   -> i_h = (i_hv+8) % 16 (gather 8-15=TP1 的 q0-7)
+        # AWQ/其他格式(div3)不使用 V_START(内核走 div3 分支),恒为 0
+        v_start = (
+            (self.tp_size - 1 - self.tp_rank)
+            * (config.linear_num_value_heads // self.tp_size)
+            if self.tp_size > 1 and _GDN_GGUF_LAYOUT
+            else 0
+        )
+        self._gdn_v_start = (
+            (v_start + config.linear_num_key_heads // 2) % config.linear_num_key_heads
+            if self.tp_size > 1 and _GDN_GGUF_LAYOUT
+            else 0
+        )
         self.hidden_size = config.hidden_size
         self.num_v_heads = config.linear_num_value_heads
         self.num_k_heads = config.linear_num_key_heads
@@ -852,9 +875,21 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         z_shape_og = z.shape
         core_attn_out_2d = core_attn_out.reshape(-1, core_attn_out.shape[-1])
         z_2d = z.reshape(-1, z.shape[-1])
+        # [FORK 兼容] RMSNormGated 要求两个输入同 dtype:
+        # GGUF(FP32)core/z 都是 FP32;AWQ(FP16)core 为内核输出 FP32,z 为 FP16,
+        # 这里把 z 对齐到 core 的 dtype
+        z_2d = z_2d.to(core_attn_out_2d.dtype)
         normed = self.norm(core_attn_out_2d, z_2d)
         normed_3d = normed.reshape(z_shape_og)
         proj_in = rearrange(normed_3d, "... h d -> ... (h d)")
+        _wp = getattr(self.out_proj, "qweight", None)
+        if _wp is not None:
+            # [FORK 兼容] 量化层(AWQ/GGUF):qweight 是 int32 打包,不能转成它的 dtype;
+            # AWQ 内核要求 FP16 输入;GGUF FP32 模式(VLLM_GGUF_FP32=1)保持 FP32
+            if os.getenv("VLLM_GGUF_FP32", "0") != "1":
+                proj_in = proj_in.to(torch.float16)
+        else:
+            proj_in = proj_in.to(self.out_proj.weight.dtype)
         output_chunk, _ = self.out_proj(proj_in)
         output[:num_tokens] = output_chunk
 
@@ -890,7 +925,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             projected_states_ba = projected_states_ba.view(num_tokens, -1)
             core_attn_out = torch.empty(
                 (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-                dtype=hidden_states.dtype,
+                dtype=torch.float32,  # [FORK 兼容] GGUF FP32 链:core 必须 FP32(AWQ 在 proj_in 分流回 FP16)
                 device=hidden_states.device,
             )
             z = torch.empty(
@@ -956,7 +991,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # see discussions in https://github.com/vllm-project/vllm/pull/28182
         core_attn_out = torch.zeros(
             (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-            dtype=hidden_states.dtype,
+            dtype=torch.float32,  # [FORK 兼容] GGUF FP32 链:core 必须 FP32(AWQ 在 proj_in 分流回 FP16)
             device=hidden_states.device,
         )
 
@@ -1423,12 +1458,52 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             value_non_spec = value_non_spec.unsqueeze(0)
             g_non_spec = g_non_spec.unsqueeze(0)
             beta_non_spec = beta_non_spec.unsqueeze(0)
+            if self.tp_size > 1 and _GDN_GGUF_LAYOUT:
+                # [FORK 兼容] 仅 GGUF(mod16)需要 q/k 全量(llama.cpp 映射 v-head%16
+                # 需要全部 16 个 k-head);AWQ(div3)TP 半切直用,不 gather
+                _tp_grp = get_tp_group()
+                query_non_spec = _tp_grp._all_gather_out_place(query_non_spec, 2)
+                key_non_spec = _tp_grp._all_gather_out_place(key_non_spec, 2)
         else:
-            query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(
-                mixed_qkv_non_spec
-            )
-            g_non_spec = None
-            beta_non_spec = None
+            # [FORK 兼容] split_non_spec=False(纯 prefill)时,prefill 主调用
+            # 直接用全量 a/b(当前版未定义会 NameError,这里补兜底)
+            a_prefill = a
+            b_prefill = b
+            if _GDN_GGUF_LAYOUT:
+                # [FORK 兼容] GGUF(mod16)布局: fused_post_conv_prep 解包 + q/k 全量 gather
+                query_non_spec, key_non_spec, value_non_spec, g_non_spec, beta_non_spec = (
+                    fused_post_conv_prep(
+                        conv_output=mixed_qkv_non_spec,
+                        a=a,
+                        b=b,
+                        A_log=self.A_log,
+                        dt_bias=self.dt_bias,
+                        num_k_heads=self.num_k_heads // self.tp_size,
+                        head_k_dim=self.head_k_dim,
+                        head_v_dim=self.head_v_dim,
+                        apply_l2norm=True,
+                        output_g_exp=False,
+                    )
+                )
+                query_non_spec = query_non_spec.unsqueeze(0)
+                key_non_spec = key_non_spec.unsqueeze(0)
+                value_non_spec = value_non_spec.unsqueeze(0)
+                g_non_spec = g_non_spec.unsqueeze(0)
+                beta_non_spec = beta_non_spec.unsqueeze(0)
+                if self.tp_size > 1:
+                    # GGUF 映射 v-head%16 需要全部 16 个 k-head,TP 切分下各 rank 只有
+                    # 一半,all-gather 补齐(拼接顺序=[rank0, rank1])
+                    _tp_grp = get_tp_group()
+                    query_non_spec = _tp_grp._all_gather_out_place(query_non_spec, 2)
+                    key_non_spec = _tp_grp._all_gather_out_place(key_non_spec, 2)
+            else:
+                # [FORK 兼容] AWQ/其他格式(div3): 原版路径(rearrange_mixed_qkv,
+                # TP 切分下 q/k 各半,内核 div3 分支直接用本 rank 的 k-head,无需 gather)
+                query_non_spec, key_non_spec, value_non_spec = self.rearrange_mixed_qkv(
+                    mixed_qkv_non_spec
+                )
+                g_non_spec = None
+                beta_non_spec = None
 
         # 2. Recurrent attention
 
@@ -1452,6 +1527,8 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                     ssm_state_indices=spec_state_indices_tensor,
                     num_accepted_tokens=num_accepted_tokens,
                     use_qk_l2norm_in_kernel=True,
+                    v_start=self._gdn_v_start,  # [FORK 兼容] 仅 GGUF 非 0
+                    gguf_layout=_GDN_GGUF_LAYOUT,  # [FORK 兼容] GGUF=mod16,其他=div3
                     null_block_id=PAD_SLOT_ID,
                 )
             )
@@ -1468,6 +1545,15 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             query_decode, key_decode, value_decode = self.rearrange_mixed_qkv(
                 mixed_qkv_non_spec[:num_decode_tokens]
             )
+            if self.tp_size > 1 and _GDN_GGUF_LAYOUT:
+                # [FORK 兼容] 仅 GGUF(mod16)布局需要 q/k 全量 gather(AWQ div3 直接用本 rank 半切)
+                _tp_grp = get_tp_group()
+                query_decode = _tp_grp._all_gather_out_place(
+                    query_decode.unsqueeze(0), 2
+                ).squeeze(0)
+                key_decode = _tp_grp._all_gather_out_place(
+                    key_decode.unsqueeze(0), 2
+                ).squeeze(0)
             core_attn_out_decode, _ = fused_sigmoid_gating_delta_rule_update(
                 A_log=self.A_log,
                 a=a_non_spec[:num_decode_tokens],
@@ -1483,6 +1569,8 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 ],
                 ssm_state_indices=decode_state_indices,
                 use_qk_l2norm_in_kernel=True,
+                v_start=self._gdn_v_start,  # [FORK 兼容] 仅 GGUF 非 0
+                gguf_layout=_GDN_GGUF_LAYOUT,  # [FORK 兼容] GGUF=mod16,其他=div3
                 null_block_id=PAD_SLOT_ID,
             )
         else:
@@ -1498,23 +1586,48 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             assert prefill_query_start_loc is not None
             initial_state = ssm_state[prefill_state_indices].contiguous()
             initial_state[~prefill_has_initial_state, ...] = 0
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=prefill_query_start_loc,
-                chunk_indices=attn_metadata.chunk_indices,
-                chunk_offsets=attn_metadata.chunk_offsets,
-                use_qk_l2norm_in_kernel=False,
-            )
-            # Init cache
+            if _GDN_GGUF_LAYOUT:
+                # [FORK 兼容] GGUF: 直接内核(mod16 + v_start),输出逐 token state 须切分
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = fused_sigmoid_gating_delta_rule_update(
+                    A_log=self.A_log,
+                    a=a_prefill,
+                    b=b_prefill,
+                    dt_bias=self.dt_bias,
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    initial_state=initial_state.clone(),
+                    inplace_final_state=False,
+                    cu_seqlens=prefill_query_start_loc,
+                    use_qk_l2norm_in_kernel=True,
+                    v_start=self._gdn_v_start,
+                    gguf_layout=True,
+                )
+                # 参考输出每 token 的 state,取每个序列最后 token 的 state
+                last_recurrent_state = last_recurrent_state[
+                    prefill_query_start_loc[1:] - 1
+                ]
+            else:
+                # [FORK 兼容] AWQ/其他格式: 原始 fork chunk 式路径(div3,fi/fla chunk)
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = self.chunk_gated_delta_rule(
+                    q=query_non_spec,
+                    k=key_non_spec,
+                    v=value_non_spec,
+                    g=g_non_spec,
+                    beta=beta_non_spec,
+                    initial_state=initial_state,
+                    output_final_state=True,
+                    cu_seqlens=prefill_query_start_loc,
+                    chunk_indices=attn_metadata.chunk_indices,
+                    chunk_offsets=attn_metadata.chunk_offsets,
+                    use_qk_l2norm_in_kernel=False,
+                )
             ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
             global _GDN_DEBUG_PREFILL_USED
             if (

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.quantization import QuantizationMethods
 
 import gguf
+import os
 import torch
 from gguf import GGMLQuantizationType as WeightType
 from torch.nn.parameter import Parameter, UninitializedParameter
@@ -212,6 +213,13 @@ def _fused_mul_mat_gguf(
     # there is no need to call any kernel for fp16/bf16
     if qweight_type in UNQUANTIZED_TYPES:
         return x @ qweight.T
+    # GDN 精度修复:强制 fp32 反量化计算(跳过 MMQ fp16 内核的精度损失)
+    if os.getenv("VLLM_GGUF_FP32", "0") == "1":
+        block_size, type_size = gguf.GGML_QUANT_SIZES[qweight_type]
+        shape = (qweight.shape[0], qweight.shape[1] // type_size * block_size)
+        weight = ops.ggml_dequantize(qweight, qweight_type, *shape, torch.float32)
+        y = x.float() @ weight.T
+        return y if x.dtype == torch.float32 else y.to(x.dtype)
     # enable MMVQ in contiguous batching with batch_size=1
     if x.shape[0] <= mmvq_safe and qweight_type in MMVQ_QUANT_TYPES:
         y = ops.ggml_mul_mat_vec_a8(qweight, x, qweight_type, qweight.shape[0])
@@ -501,7 +509,7 @@ class GGUFLinearMethod(LinearMethodBase):
         qweight = layer.qweight
         shard_id_map = qweight.shard_id_map
         shard_id = qweight.shard_id
-        if len(data_container := qweight.data_container) > 1:
+        if len(data_container := qweight.data_container) >= 1:
             dtype = {data.dtype for data in data_container}
             assert len(dtype) == 1, ValueError(
                 f"Data container has mixed dtypes: {dtype}"
@@ -517,13 +525,20 @@ class GGUFLinearMethod(LinearMethodBase):
             )
             # (dim0_start, dim0_end, dim1_size)
             shard_offset_map = dict[str, tuple[int, int, int]]()
-            for idx in shard_id:
-                id_in_container = shard_id_map[idx]
-                start = sum(x.size(0) for x in data_container[:id_in_container])
-                end = start + data_container[id_in_container].size(0)
-                size = data_container[id_in_container].size(1)
-                padded_data[start:end, :size] = data_container[id_in_container]
+            # Qwen3.5 GDN:attn_gate(z)在 GGUF 文件里排在 attn_qkv 之前,
+            # 导致 shard_id=[3,0,1,2] 且 data_container=[z,q,k,v];
+            # 必须按 shard id 顺序拼接,否则 qkv 与 z 错位
+            # (forward 按 [qkv,z] split)。start 用 shard id 顺序的累计行数,
+            # 不能依赖 data_container 的物理顺序。
+            cur_start = 0
+            for idx in (sorted(shard_id) if all(isinstance(s, int) for s in shard_id) else shard_id):
+                data = data_container[shard_id_map[idx]]
+                start = cur_start
+                end = cur_start + data.size(0)
+                size = data.size(1)
+                padded_data[start:end, :size] = data
                 shard_offset_map[idx] = (start, end, size)
+                cur_start = end
             qweight.data_container.clear()
             padded_param = Parameter(padded_data, requires_grad=False)
             set_weight_attrs(padded_param, vars(qweight))
@@ -543,7 +558,10 @@ class GGUFLinearMethod(LinearMethodBase):
             shard_id = ["q", "k", "v"] if "q" in shard_id else shard_id
             qweight = layer.qweight
             result = []
-            for idx in shard_id:
+            # Qwen3.5 GDN:attn_gate(z)先加载导致 shard_id=[3,0,1,2];
+            # 必须按 shard id 排序输出(q,k,v,z),否则 forward 的
+            # [qkv,z] split 拿到 [z,q,...] 错位。
+            for idx in (sorted(shard_id) if all(isinstance(s, int) for s in shard_id) else shard_id):
                 start, end, offset = layer.qweight.shard_offset_map[idx]
                 qweight_type = layer.qweight_type.shard_weight_type[idx]
                 result.append(

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from huggingface_hub import hf_hub_download
 from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
 
+from vllm import _custom_ops as ops
 from vllm.config import ModelConfig, VllmConfig
 from vllm.config.load import LoadConfig
 from vllm.logger import init_logger
@@ -116,9 +117,8 @@ class GGUFModelLoader(BaseModelLoader):
         # models, this returns config itself.
         text_config = config.get_text_config()
         model_type = config.model_type
-        is_multimodal = (
-            hasattr(config, "vision_config") and config.vision_config is not None
-        )
+        # Qwen3_5Config 总是创建 vision_config,需以 mmproj 文件为准
+        is_multimodal = detect_gguf_multimodal(model_config.model) is not None
         gguf_to_hf_name_map = {}
         sideload_params: list[re.Pattern] = []
         # hack: ggufs have a different name than transformers
@@ -207,7 +207,9 @@ class GGUFModelLoader(BaseModelLoader):
 
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
-            vision_num_layers = config.vision_config.num_hidden_layers
+            vision_num_layers = getattr(
+                config.vision_config, "num_hidden_layers", None
+            ) or getattr(config.vision_config, "depth", None)
             vision_name_map = gguf.get_tensor_name_map(mm_proj_arch, vision_num_layers)
         else:
             vision_name_map = None
@@ -220,11 +222,59 @@ class GGUFModelLoader(BaseModelLoader):
             AutoModelForImageTextToText if is_multimodal else AutoModelForCausalLM
         )
         with torch.device("meta"):
-            dummy_model = auto_cls.from_config(
-                config, trust_remote_code=model_config.trust_remote_code
-            )
+            try:
+                dummy_model = auto_cls.from_config(
+                    config, trust_remote_code=model_config.trust_remote_code
+                )
+            except ValueError:
+                # Qwen3_5Config 未注册到 transformers AutoModel(GGUF qwen35 场景)。
+                # vLLM Qwen3_5 继承 Qwen3Next(混合注意力),用 Qwen3NextForCausalLM
+                # 对 text_config 生成同构参数名。
+                logger.info(
+                    "AutoModel 无法识别 %s,改用 Qwen3NextForCausalLM 生成参数名映射",
+                    type(config).__name__,
+                )
+                from transformers.models.qwen3_next.configuration_qwen3_next import (
+                    Qwen3NextConfig,
+                )
+                from transformers.models.qwen3_next.modeling_qwen3_next import (
+                    Qwen3NextForCausalLM,
+                )
+
+                tc = config.get_text_config()
+                q3n = Qwen3NextConfig(
+                    **{
+                        k: v
+                        for k, v in vars(tc).items()
+                        if not k.startswith("_") and k != "model_type"
+                    },
+                    # Qwen3.5-27B 是稠密模型:关掉 Qwen3Next 默认的 MoE 分支
+                    num_experts=1,
+                    num_experts_per_tok=1,
+                    mlp_only_layers=[],
+                    decoder_sparse_step=10**9,  # 全层 dense MLP
+                )
+                dummy_model = Qwen3NextForCausalLM(q3n)
 
         state_dict = dummy_model.state_dict()
+        # Qwen3.5 GGUF:ssm_alpha/ssm_beta 分开存储,vLLM 的 Qwen3_5 load_weights
+        # 按 in_proj_b/shard0 + in_proj_a/shard1 分片加载,把合并名拆开
+        if model_type == "qwen35":
+            renamed: dict = {}
+            for name, tensor in state_dict.items():
+                if name.endswith(".linear_attn.in_proj_ba.weight"):
+                    base = name[: -len("in_proj_ba.weight")]
+                    renamed[base + "in_proj_b.weight"] = tensor
+                    renamed[base + "in_proj_a.weight"] = tensor
+                elif name.endswith(".linear_attn.in_proj_qkvz.weight"):
+                    # vLLM 按 in_proj_qkv(shard 0,1,2)+ in_proj_z(shard 3)分片加载;
+                    # GGUF 的 attn_qkv→in_proj_qkv、attn_gate→in_proj_z
+                    base = name[: -len("in_proj_qkvz.weight")]
+                    renamed[base + "in_proj_qkv.weight"] = tensor
+                    renamed[base + "in_proj_z.weight"] = tensor
+                else:
+                    renamed[name] = tensor
+            state_dict = renamed
         if hf_checkpoint_map := getattr(
             dummy_model, "_checkpoint_conversion_mapping", None
         ):
@@ -307,6 +357,13 @@ class GGUFModelLoader(BaseModelLoader):
             if gguf_name is None:
                 return None
 
+            # suffix 为空(裸参数如 A_log/dt_bias)时不能加尾点,
+            # 否则映射键 'blk.N.ssm_a.' 与 GGUF tensor 名 'blk.N.ssm_a' 不匹配;
+            # 但以 bias 结尾的裸参数(如 dt_bias)对应的 GGUF tensor 名带 .bias
+            if not suffix:
+                if base_name.endswith("bias"):
+                    return gguf_name + ".bias"
+                return gguf_name
             return gguf_name + "." + suffix
 
         # Build mapping and track unmapped parameters
@@ -349,7 +406,7 @@ class GGUFModelLoader(BaseModelLoader):
         weight_type_map = {}
         for f in gguf_files:
             weight_type_map.update(get_gguf_weight_type_map(f, gguf_to_hf_name_map))
-        is_multimodal = hasattr(model_config.hf_config, "vision_config")
+        is_multimodal = detect_gguf_multimodal(model_name_or_path) is not None
         if is_multimodal:
             mmproj_file = detect_gguf_multimodal(model_name_or_path)
             assert mmproj_file is not None, (
@@ -380,7 +437,7 @@ class GGUFModelLoader(BaseModelLoader):
             Tuples of (parameter_name, tensor) for all model weights
         """
         hf_config = model_config.hf_config
-        is_multimodal = hasattr(hf_config, "vision_config")
+        is_multimodal = detect_gguf_multimodal(model_name_or_path) is not None
 
         if is_multimodal:
             # Load mm_proj (mm_encoder + projector) for multimodal weights
@@ -396,9 +453,57 @@ class GGUFModelLoader(BaseModelLoader):
                 gguf_files, gguf_to_hf_name_map
             )
         else:
-            yield from gguf_quant_weights_iterator(
+            base_iter = gguf_quant_weights_iterator(
                 model_name_or_path, gguf_to_hf_name_map
             )
+            yield from self._iter_lm_head_unquantized(base_iter)
+
+    def _iter_lm_head_unquantized(
+        self, base_iter: Generator[tuple[str, torch.Tensor], None, None]
+    ) -> Generator[tuple[str, torch.Tensor], None, None]:
+        """GGUF 的 lm_head(output.weight)常以量化类型存储(Q6_K 等),但
+        ParallelLMHead 不支持 qweight_type 参数:拦截 qweight_type/qweight,
+        反量化后以 lm_head.weight 产出。"""
+        qweight_type: int | None = None
+        embed_qwt_type: gguf.GGMLQuantizationType | None = None
+        for name, tensor in base_iter:
+            if name == "lm_head.qweight_type":
+                qweight_type = tensor.item()
+                continue
+            if name == "model.embed_tokens.qweight_type":
+                embed_qwt_type = tensor.item()
+                continue
+            if name == "lm_head.qweight":
+                assert qweight_type is not None
+                # ops.ggml_dequantize 仅 CUDA;CPU 上用 gguf.dequantize 反量化
+                # 内存纪律:dequant 是 float32(248320x5120 ≈ 5GB),转 fp16 后立即释放,
+                # 严禁缓存复用(曾致双表 10GB 驻留 + 双 worker → user cgroup OOM)
+                dequant = gguf.dequantize(
+                    tensor.numpy(), gguf.GGMLQuantizationType(qweight_type)
+                )
+                tensor = torch.from_numpy(dequant).to(torch.float16)
+                del dequant
+                name = "lm_head.weight"
+            elif name == "model.embed_tokens.qweight":
+                # llama.cpp 的 embed = token_embd.weight(Q4_K),lm_head = output.weight(Q6_K),
+                # 两表不相关(corr≈0)。此前误复用 output.weight 做 embed,导致整个链从输入就错。
+                # 现在正确反量化 token_embd.weight 作为 embed 表。
+                assert embed_qwt_type is not None
+                dequant = gguf.dequantize(
+                    tensor.numpy(), gguf.GGMLQuantizationType(embed_qwt_type)
+                )
+                tensor = torch.from_numpy(dequant).to(torch.float16)
+                del dequant
+                name = "model.embed_tokens.weight"
+            elif name.endswith(".linear_attn.conv1d.weight"):
+                # vLLM GDN conv1d 是 [conv_dim, 1, kernel](unsqueeze 过),
+                # GGUF 产出 [channels, kernel] 2D,补上中间维
+                tensor = tensor.unsqueeze(1)
+            elif name.endswith(".linear_attn.A_log"):
+                # GGUF 的 ssm_a 是 llama.cpp 预计算的 -exp(A_log)(小负值),
+                # vLLM forward 里再 -exp(A_log) 会双重 exp;转换回原始 log 值
+                tensor = torch.log(-tensor.float())
+            yield name, tensor
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config)
@@ -433,6 +538,14 @@ class GGUFModelLoader(BaseModelLoader):
             for name, weight_type in weight_type_map.items()
             if weight_type in ("F32", "F16", "BF16") and name.endswith(".weight")
         ]
+        # lm_head/output 在 GGUF 里常以量化类型存储(Q6_K 等),但 ParallelLMHead
+        # 不支持 qweight_type 元数据,强制按未量化(反量化)加载
+        if "lm_head" not in unquant_names:
+            unquant_names.append("lm_head")
+        # embed_tokens 同理:Qwen3_5 的 GGUFEmbeddingMethod 对 qweight_type
+        # 处理有缺陷(参数未创建),强制反量化走普通 weight 加载
+        if "model.embed_tokens" not in unquant_names:
+            unquant_names.append("model.embed_tokens")
         logger.debug("GGUF unquantized modules: %s", unquant_names)
         if TYPE_CHECKING:
             vllm_config.quant_config = cast(GGUFConfig, vllm_config.quant_config)

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -228,8 +228,8 @@ class GGUFModelLoader(BaseModelLoader):
                 )
             except ValueError:
                 # Qwen3_5Config 未注册到 transformers AutoModel(GGUF qwen35 场景)。
-                # vLLM Qwen3_5 继承 Qwen3Next(混合注意力),用 Qwen3NextForCausalLM
-                # 对 text_config 生成同构参数名。
+                # 用 Qwen3NextForCausalLM 生成文本参数名映射;视觉塔参数名
+                # 由下方手动补(model.visual.*,333 个,与 AWQ 权重一致)
                 logger.info(
                     "AutoModel 无法识别 %s,改用 Qwen3NextForCausalLM 生成参数名映射",
                     type(config).__name__,
@@ -257,6 +257,52 @@ class GGUFModelLoader(BaseModelLoader):
                 dummy_model = Qwen3NextForCausalLM(q3n)
 
         state_dict = dummy_model.state_dict()
+        # [FORK 兼容] Qwen3.5 GGUF 多模态:文本参数名对齐多模态模型
+        # (model.language_model.layers.N.xxx,与 AWQ 权重命名一致);
+        # 326-338 行的前缀处理会把它转成 gguf-py 认识的 model.layers.N.xxx,
+        # 而映射表值(load_weights 收到的名)能匹配 Qwen3_5ForConditionalGeneration
+        if is_multimodal:
+            state_dict = {
+                (
+                    name.replace("model.", "model.language_model.", 1)
+                    if name.startswith("model.")
+                    else name
+                ): tensor
+                for name, tensor in state_dict.items()
+            }
+        # [FORK 兼容] Qwen3.5 GGUF 多模态:补视觉塔参数名(dummy 是纯文本类,
+        # 无视觉参数;mmproj 权重映射需要 model.visual.* 键)。
+        # 结构取自 vLLM Qwen3_VisionTransformer(Qwen3.5 视觉塔,与 AWQ 权重一致):
+        # blocks(27 层):attn.qkv/attn.proj/mlp.linear_fc1/fc2/norm1/norm2;
+        # merger:linear_fc1/fc2/norm;patch_embed.proj;pos_embed
+        if is_multimodal:
+            _depth = getattr(config.vision_config, "depth", 27)
+            _vnames = [
+                "model.visual.patch_embed.proj.weight",
+                "model.visual.patch_embed.proj.bias",
+                "model.visual.pos_embed.weight",
+            ]
+            for _i in range(_depth):
+                _b = f"model.visual.blocks.{_i}"
+                _vnames += [
+                    f"{_b}.attn.qkv.weight", f"{_b}.attn.qkv.bias",
+                    f"{_b}.attn.proj.weight", f"{_b}.attn.proj.bias",
+                    f"{_b}.mlp.linear_fc1.weight", f"{_b}.mlp.linear_fc1.bias",
+                    f"{_b}.mlp.linear_fc2.weight", f"{_b}.mlp.linear_fc2.bias",
+                    f"{_b}.norm1.weight", f"{_b}.norm1.bias",
+                    f"{_b}.norm2.weight", f"{_b}.norm2.bias",
+                ]
+            _vnames += [
+                "model.visual.merger.linear_fc1.weight",
+                "model.visual.merger.linear_fc1.bias",
+                "model.visual.merger.linear_fc2.weight",
+                "model.visual.merger.linear_fc2.bias",
+                "model.visual.merger.norm.weight",
+                "model.visual.merger.norm.bias",
+            ]
+            for _vn in _vnames:
+                if _vn not in state_dict:
+                    state_dict[_vn] = torch.empty(0)
         # Qwen3.5 GGUF:ssm_alpha/ssm_beta 分开存储,vLLM 的 Qwen3_5 load_weights
         # 按 in_proj_b/shard0 + in_proj_a/shard1 分片加载,把合并名拆开
         if model_type == "qwen35":
@@ -320,7 +366,10 @@ class GGUFModelLoader(BaseModelLoader):
             # state_dict keys like 'model.language_model.layers.0...' and
             # 'model.vision_tower.vision_model...'.  Strip this outer
             # prefix so the keys match what gguf-py expects.
-            if is_multimodal and hf_name.startswith("model."):
+            if is_multimodal and (
+                hf_name.startswith("model.language_model.")
+                or hf_name.startswith("model.vision_tower.")
+            ):
                 hf_name = hf_name[6:]  # Remove outer 'model.'
 
             # Strip 'language_model.' prefix for multimodal models - gguf-py
@@ -348,11 +397,46 @@ class GGUFModelLoader(BaseModelLoader):
             gguf_name = None
             # Priority 1: Search vision/projector parameters for multimodal models
             if vision_name_map is not None:
-                gguf_name = vision_name_map.get_name(base_name)
+                # [FORK 兼容] Qwen3.5 GGUF 多模态:gguf-py 视觉键用
+                # vision_tower.* 风格,vLLM/AWQ 用 model.visual.*,转换后再查
+                vision_base = base_name
+                if vision_base.startswith("model.visual."):
+                    vision_base = (
+                        "vision_tower." + vision_base[len("model.visual."):]
+                    )
+                elif vision_base.startswith("visual."):
+                    vision_base = (
+                        "vision_tower." + vision_base[len("visual."):]
+                    )
+                gguf_name = vision_name_map.get_name(vision_base)
 
             # Priority 2: Search text backbone parameters
             if gguf_name is None:
                 gguf_name = text_name_map.get_name(base_name)
+
+            if gguf_name is None:
+                # [FORK 兼容] Qwen3.5 GGUF 多模态:gguf-py MMPROJ 映射缺失项,
+                # 手动补(视觉 mlp 的 ffn_up/down、pos_embed、merger)
+                if vision_name_map is not None:
+                    _vparts = vision_base.split(".")
+                    if (
+                        len(_vparts) == 5
+                        and _vparts[0] == "vision_tower"
+                        and _vparts[1] == "blocks"
+                        and _vparts[3] == "mlp"
+                    ):
+                        # vision_tower.blocks.N.mlp.linear_fcX → v.blk.N.ffn_up/down
+                        _fc = _vparts[4]
+                        _gguf_mlp = "ffn_up" if _fc == "linear_fc1" else "ffn_down"
+                        gguf_name = f"v.blk.{_vparts[2]}.{_gguf_mlp}"
+                    elif vision_base == "vision_tower.pos_embed":
+                        gguf_name = "v.position_embd"
+                    elif vision_base == "vision_tower.merger.linear_fc1":
+                        gguf_name = "mm.0"
+                    elif vision_base == "vision_tower.merger.linear_fc2":
+                        gguf_name = "mm.2"
+                    elif vision_base == "vision_tower.merger.norm":
+                        gguf_name = "v.post_ln"
 
             if gguf_name is None:
                 return None
@@ -445,7 +529,17 @@ class GGUFModelLoader(BaseModelLoader):
             assert mmproj_file is not None, (
                 "Could not find mm_proj file for multimodal GGUF model"
             )
-            yield from gguf_quant_weights_iterator(mmproj_file, gguf_to_hf_name_map)
+            # 注意:mmproj 的 F16 权重 GGUFReader.data 已是 [out, in]
+            # (vLLM 线性层布局),tensor.shape 元数据才是 [in, out],勿转置
+            for _name, _tensor in gguf_quant_weights_iterator(
+                mmproj_file, gguf_to_hf_name_map
+            ):
+                if _name.endswith(".patch_embed.proj.weight"):
+                    # GGUF conv 4D(1152,3,16,16)单帧共享权重;vLLM Conv3d
+                    # 是 5D(1152,3,2,16,16)(temporal_patch_size=2,与 AWQ 一致),
+                    # 2 帧共享权重:补时间维后复制 → (1152,3,2,16,16)
+                    _tensor = _tensor.unsqueeze(2).repeat(1, 1, 2, 1, 1)
+                yield _name, _tensor
 
         gguf_files = self._get_all_gguf_files(model_name_or_path)
         if len(gguf_files) > 1:

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -212,15 +212,27 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # See issue: https://github.com/vllm-project/vllm/issues/37554
 
         if cache_config.calculate_kv_scales:
-            logger.warning(
-                "Disabling calculate_kv_scales for hybrid model '%s'. "
-                "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
-                "produce unreliable KV cache scales during the "
-                "calibration pass because recurrent state is "
-                "uninitialized. Using default scale of 1.0 instead.",
-                vllm_config.model_config.model,
-            )
-            cache_config.calculate_kv_scales = False
+            # [FORK-PORT] PR#41505: int8_per_tensor 保留动态 scale。
+            # fp8 对 hybrid 禁用是 issue #37554 (校准期 recurrent state 未初始化
+            # 会污染 fp8 scale); int8 路径同样受此影响, 但测试需要真实 scale,
+            # 校准请求用真实长文本 prefill 来规避。fp8 维持官方禁用行为。
+            if cache_config.cache_dtype == "int8_per_tensor":
+                logger.info(
+                    "Keeping calculate_kv_scales for int8_per_tensor KV on "
+                    "hybrid model '%s' (FORK-PORT PR#41505; calibrate on real "
+                    "long prefill).",
+                    vllm_config.model_config.model,
+                )
+            else:
+                logger.warning(
+                    "Disabling calculate_kv_scales for hybrid model '%s'. "
+                    "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
+                    "produce unreliable KV cache scales during the "
+                    "calibration pass because recurrent state is "
+                    "uninitialized. Using default scale of 1.0 instead.",
+                    vllm_config.model_config.model,
+                )
+                cache_config.calculate_kv_scales = False
 
         # Enable FULL_AND_PIECEWISE by default
         MambaModelConfig.verify_and_update_config(vllm_config)

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -451,6 +451,8 @@ class Qwen3_5Model(Qwen3NextModel):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+
         return loaded_params
 
 
@@ -553,8 +555,46 @@ class Qwen3_5ForCausalLMBase(
         # [FORK 兼容] GGUF 纯文本(ForCausalLM)也需 SSM 状态拷贝函数(原版只在多模态类里)
         return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
 
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: "VllmConfig",
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
 
-class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: "VllmConfig"
+    ) -> tuple[tuple[int, int], tuple[int, int, int]]:
+        # [FORK 兼容] 纯文本 ForCausalLM 需自行实现(原版只在多模态类里),
+        # 供 IsHybrid 推导 mamba_block_size(GDN linear_attn 状态缓存)
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+
+class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase, IsHybrid):
+    # [FORK 兼容] GGUF 纯文本(Qwen3_5ForCausalLM)也含 linear_attn 混合层,
+    # 必须标记 IsHybrid 才能推导 mamba_block_size(GDN linear_attn 状态缓存),
+    # 否则 get_kv_cache_spec 断言 mamba_block_size is not None 崩溃。
     pass
 
 

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -38,7 +38,15 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import (
     GemmaRMSNorm as Qwen3_5RMSNorm,
+    RMSNorm,
 )
+
+# [FORK 兼容] GGUF 的 RMSNorm 权重含 +1(llama.cpp 惯例),用普通 RMSNorm;
+# safetensors/AWQ 等用 GemmaRMSNorm 原版(1+w 语义)。
+def _get_qwen3_5_rms_norm_cls(load_format) -> type:
+    if load_format == "gguf":
+        return RMSNorm
+    return Qwen3_5RMSNorm
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.mamba.gdn_linear_attn import GatedDeltaNetAttention
 from vllm.model_executor.layers.mamba.mamba_utils import (
@@ -133,6 +141,12 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
             if override_quant_config is None
             else override_quant_config
         )
+        # [FORK 兼容] GGUF 时 RMSNorm 权重含 +1,用普通 RMSNorm;
+        # multiproc worker 反序列化后 load_config 可能丢失,兜底为 gguf
+        try:
+            _lf = vllm_config.load_config.load_format
+        except Exception:
+            _lf = "gguf"
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
@@ -173,10 +187,10 @@ class Qwen3_5DecoderLayer(Qwen3NextDecoderLayer):
         else:
             raise ValueError(f"Invalid model_type {config.model_type}")
 
-        self.input_layernorm = Qwen3_5RMSNorm(
+        self.input_layernorm = _get_qwen3_5_rms_norm_cls(_lf)(
             config.hidden_size, eps=config.rms_norm_eps
         )
-        self.post_attention_layernorm = Qwen3_5RMSNorm(
+        self.post_attention_layernorm = _get_qwen3_5_rms_norm_cls(_lf)(
             config.hidden_size, eps=config.rms_norm_eps
         )
 
@@ -244,7 +258,14 @@ class Qwen3_5Model(Qwen3NextModel):
         )
 
         if get_pp_group().is_last_rank:
-            self.norm = Qwen3_5RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            # [FORK 兼容] GGUF 时用普通 RMSNorm(权重含 +1);worker 反序列化兜底 gguf
+            try:
+                _lf = vllm_config.load_config.load_format
+            except Exception:
+                _lf = "gguf"
+            self.norm = _get_qwen3_5_rms_norm_cls(_lf)(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
         else:
             self.norm = PPMissingLayer()
 
@@ -526,6 +547,11 @@ class Qwen3_5ForCausalLMBase(
             skip_prefixes=["mtp."],
         )
         return loader.load_weights(weights)
+
+    @classmethod
+    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        # [FORK 兼容] GGUF 纯文本(ForCausalLM)也需 SSM 状态拷贝函数(原版只在多模态类里)
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
 
 
 class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -308,6 +308,7 @@ class Qwen3NextAttention(nn.Module):
     ):
         qkv, _ = self.qkv_proj(hidden_states)
 
+
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(
                 [self.q_size * 2, self.kv_size, self.kv_size], dim=-1
@@ -466,6 +467,8 @@ class Qwen3NextDecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+
+
         hidden_states = self.mlp(hidden_states)
 
         if self.layer_scale:
@@ -481,6 +484,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 hidden_states = hidden_states * (
                     self.ffn_layer_scale.to(hidden_states.dtype) + 1
                 )
+
 
         return hidden_states, residual
 

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -29,8 +29,22 @@ from vllm.model_executor.layers.fused_moe import (
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import (
-    GemmaRMSNorm as Qwen3NextRMSNorm,
+    GemmaRMSNorm,
+    RMSNorm,
 )
+
+# [FORK 兼容] GGUF 的 RMSNorm 权重已含 +1(llama.cpp 惯例,见 conversion/gemma.py norm_shift),
+# 必须用普通 RMSNorm 直接乘;safetensors 权重是原始 w(1+w 语义),用 GemmaRMSNorm。
+# 与上游 vLLM PR #31464/#37220 的 Gemma2/3 GGUF 修复一致。
+# 注意:不能用 vllm_config.quant_config 判断(GGUF 路径下它是 None),
+# 用 model_config.load_format;其他格式(safetensors/AWQ 等)默认走 GemmaRMSNorm 原版。
+def _get_qwen3_next_rms_norm_cls(load_format) -> type:
+    if load_format == "gguf":
+        return RMSNorm
+    return GemmaRMSNorm
+
+
+Qwen3NextRMSNorm = GemmaRMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
     ReplicatedLinear,
@@ -210,6 +224,7 @@ class Qwen3NextAttention(nn.Module):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        load_format: str = "auto",  # [FORK 兼容] GGUF 时选普通 RMSNorm(权重含 +1)
     ) -> None:
         super().__init__()
         self.config = config
@@ -278,8 +293,12 @@ class Qwen3NextAttention(nn.Module):
             else {},
         )
 
-        self.q_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = Qwen3NextRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.q_norm = _get_qwen3_next_rms_norm_cls(load_format)(
+            self.head_dim, eps=config.rms_norm_eps
+        )
+        self.k_norm = _get_qwen3_next_rms_norm_cls(load_format)(
+            self.head_dim, eps=config.rms_norm_eps
+        )
 
     def forward(
         self,
@@ -332,6 +351,13 @@ class Qwen3NextDecoderLayer(nn.Module):
         model_config = vllm_config.model_config
         cache_config = vllm_config.cache_config
         quant_config = vllm_config.quant_config
+        # [FORK 兼容] GGUF 加载时所有 RMSNorm 权重含 +1,需普通 RMSNorm
+        # multiproc worker 反序列化后 load_config 可能丢失,兜底为 gguf
+        # (qwen35 目前只有 GGUF 加载路径)
+        try:
+            load_format = vllm_config.load_config.load_format
+        except Exception:
+            load_format = "gguf"
 
         self.layer_type = layer_type
         self.layer_idx = extract_layer_index(prefix)
@@ -350,6 +376,7 @@ class Qwen3NextDecoderLayer(nn.Module):
                 cache_config=cache_config,
                 quant_config=quant_config,
                 prefix=f"{prefix}.self_attn",
+                load_format=load_format,  # [FORK 兼容] GGUF 时 q/k_norm 用普通 RMSNorm
             )
         else:
             raise ValueError(f"Invalid layer_type {self.layer_type}")
@@ -374,10 +401,10 @@ class Qwen3NextDecoderLayer(nn.Module):
                 prefix=f"{prefix}.mlp",
             )
 
-        self.input_layernorm = Qwen3NextRMSNorm(
+        self.input_layernorm = _get_qwen3_next_rms_norm_cls(load_format)(
             config.hidden_size, eps=config.rms_norm_eps
         )
-        self.post_attention_layernorm = Qwen3NextRMSNorm(
+        self.post_attention_layernorm = _get_qwen3_next_rms_norm_cls(load_format)(
             config.hidden_size, eps=config.rms_norm_eps
         )
 

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -855,6 +855,12 @@ class Qwen3_VisionTransformer(nn.Module):
             else:
                 param = params_dict[name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                if name.startswith(("blocks.", "patch", "pos_embed", "merger")):  # 临时探针
+                    print(
+                        f"[DBG-VIS] {name}: param={tuple(param.data.shape)} "
+                        f"loaded={tuple(loaded_weight.shape)}",
+                        flush=True,
+                    )
                 weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -547,6 +547,7 @@ _MULTIMODAL_MODELS = {
         "qwen3_vl_moe",
         "Qwen3VLMoeForConditionalGeneration",
     ),
+    "Qwen3_5ForCausalLM": ("qwen3_5", "Qwen3_5ForCausalLM"),  # [FORK 兼容] GGUF 纯文本走文本模型
     "Qwen3_5ForConditionalGeneration": ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
     "Qwen3_5MoeForConditionalGeneration": (
         "qwen3_5",

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -197,6 +197,14 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             self.output_dim, shard_id_int * shard_size, shard_size
         )
 
+        if param_data.shape != loaded_weight.shape:  # 临时探针
+            print(
+                f"[DBG-QKV] shard={shard_id} param_data={tuple(param_data.shape)} "
+                f"loaded={tuple(loaded_weight.shape)} full={tuple(self.data.shape)} "
+                f"off={shard_offset} sz={shard_size} tp={self.tp_rank} id={shard_id_int}",
+                flush=True,
+            )
+
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 
@@ -225,6 +233,13 @@ class RowvLLMParameter(BasevLLMParameter):
 
         if len(loaded_weight.shape) == 0:
             loaded_weight = loaded_weight.reshape(1)
+
+        if self.data.shape != loaded_weight.shape:  # 临时探针
+            print(
+                f"[DBG-ROW] data={tuple(self.data.shape)} loaded={tuple(loaded_weight.shape)} "
+                f"input_dim={self.input_dim} tp={self.tp_rank} shard={shard_size}",
+                flush=True,
+            )
 
         assert self.data.shape == loaded_weight.shape
         self.data.copy_(loaded_weight)

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -197,14 +197,6 @@ class _ColumnvLLMParameter(BasevLLMParameter):
             self.output_dim, shard_id_int * shard_size, shard_size
         )
 
-        if param_data.shape != loaded_weight.shape:  # 临时探针
-            print(
-                f"[DBG-QKV] shard={shard_id} param_data={tuple(param_data.shape)} "
-                f"loaded={tuple(loaded_weight.shape)} full={tuple(self.data.shape)} "
-                f"off={shard_offset} sz={shard_size} tp={self.tp_rank} id={shard_id_int}",
-                flush=True,
-            )
-
         assert param_data.shape == loaded_weight.shape
         param_data.copy_(loaded_weight)
 

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -36,6 +36,7 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 from .config_parser_base import ConfigParserBase
 from .gguf_utils import (
     check_gguf_file,
+    detect_gguf_multimodal,
     is_gguf,
     is_remote_gguf,
     split_remote_gguf,
@@ -129,6 +130,8 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     qwen3_asr="Qwen3ASRConfig",
     qwen3_next="Qwen3NextConfig",
     qwen3_5="Qwen3_5Config",
+    # GGUF/llama.cpp 命名:架构 qwen35 对应 HF Qwen3_5Config
+    qwen35="Qwen3_5Config",
     qwen3_5_moe="Qwen3_5MoeConfig",
     laguna="LagunaConfig",
     lfm2_moe="Lfm2MoeConfig",
@@ -764,6 +767,31 @@ def get_config(
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
         model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]
         config.update({"architectures": [model_type]})
+        # Qwen3_5Config 恒有 vision_config → vLLM 误判为多模态模型
+        # (ForConditionalGeneration)。GGUF 主文件是纯文本(视觉在 mmproj)时,
+        # 置 None 走文本模型 Qwen3_5ForCausalLM。
+        if (
+            config.model_type == "qwen35"
+            and getattr(config, "vision_config", None) is not None
+            and not (detect_gguf_multimodal(str(model)) is not None)
+        ):
+            config.vision_config = None
+        # GGUF ssm 结构 → vLLM GDN 布局(Qwen3.5 系):
+        # ssm_alpha/beta 输出 48 维、ssm_out 6144 = 48*128、ssm_dt/a[48]
+        # → linear_num_value_heads 必须为 48(默认 32 会导致 shape 不匹配)
+        if config.model_type == "qwen35":
+            text_config = config.get_text_config()
+            text_config.linear_num_value_heads = 48
+            # GGUF rope.freq_base=1e7 → rope_parameters(否则 vLLM 用默认 10000,
+            # position 编码错误导致输出乱码);partial_rotary_factor=0.25
+            # (GGUF dimension_count=64 / head_dim=256,get_rope 默认 1.0 会覆盖)
+            rope_theta = getattr(config, "rope_theta", None)
+            if rope_theta is not None:
+                text_config.rope_parameters = {
+                    "rope_type": "default",
+                    "rope_theta": rope_theta,
+                    "partial_rotary_factor": 0.25,
+                }
 
     # Architecture mapping for models without explicit architectures field
     if not config.architectures:

--- a/vllm/transformers_utils/configs/qwen3_5.py
+++ b/vllm/transformers_utils/configs/qwen3_5.py
@@ -186,7 +186,24 @@ class Qwen3_5Config(PretrainedConfig):
         if isinstance(text_config, dict):
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
-            self.text_config = self.sub_configs["text_config"]()
+            # GGUF 加载时字段是顶层 kwargs(hidden_size 等),转发给 text_config,
+            # 否则 Qwen3_5TextConfig 全部用默认值(hidden=4096 等)
+            _text_keys = (
+                "vocab_size", "hidden_size", "intermediate_size",
+                "num_hidden_layers", "num_attention_heads",
+                "num_key_value_heads", "hidden_act",
+                "max_position_embeddings", "initializer_range",
+                "rms_norm_eps", "use_cache", "tie_word_embeddings",
+                "rope_parameters", "attention_bias", "attention_dropout",
+                "head_dim", "linear_conv_kernel_dim", "linear_key_head_dim",
+                "linear_value_head_dim", "linear_num_key_heads",
+                "linear_num_value_heads", "layer_types",
+                "full_attention_interval", "pad_token_id", "bos_token_id",
+                "eos_token_id",
+            )
+            self.text_config = self.sub_configs["text_config"](
+                **{k: v for k, v in kwargs.items() if k in _text_keys}
+            )
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -242,7 +242,32 @@ def extract_vision_config_from_gguf(mmproj_path: str) -> "SiglipVisionConfig | N
     # Create config with extracted parameters
     # Note: num_channels and attention_dropout use SiglipVisionConfig defaults
     # (3 and 0.0 respectively) which are correct for all models
-    config = SiglipVisionConfig(**config_params)
+    if projector_type == VisionProjectorType.GEMMA3:
+        config = SiglipVisionConfig(**config_params)
+    else:
+        # [FORK 兼容] Qwen3.5-VL(mmproj qwen3vl_merger):vision config 需
+        # Qwen3-VL 风格字段(depth/num_heads/spatial_merge_size),
+        # SiglipVisionConfig 缺这些字段(qwen3_vl.py get_data_parser 会崩)
+        from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5VisionConfig
+
+        # out_hidden_size = clip.vision.projection_dim(mmproj 元数据,
+        # Qwen3.5-VL 27B = 5120;默认 3584 是错的,merger 权重加载会 shape 崩)
+        _proj_field = reader.get_field("clip.vision.projection_dim")
+        _out_hs = (
+            int(_proj_field.parts[-1]) if _proj_field else 3584
+        )
+        config = Qwen3_5VisionConfig(
+            depth=config_params["num_hidden_layers"],
+            hidden_size=config_params["hidden_size"],
+            intermediate_size=config_params["intermediate_size"],
+            num_heads=config_params["num_attention_heads"],
+            patch_size=config_params["patch_size"],
+            out_hidden_size=_out_hs,
+            # GGUF mmproj 的 conv 是 2D 单帧(16x16);vLLM 预处理把图像/视频
+            # 按 temporal_patch_size=2 组织(3 通道 × 时间维 2,与 AWQ 一致),
+            # 权重加载时复制时间维(见 gguf_loader patch_embed 处理)
+            temporal_patch_size=2,
+        )
 
     if projector_type:
         logger.info(
@@ -291,6 +316,14 @@ def maybe_patch_hf_config_from_gguf(
                 architectures=["Gemma3ForConditionalGeneration"],
             )
             hf_config = new_hf_config
+        elif vision_config is not None and hf_config.model_type in (
+            "qwen3_5", "qwen3_next", "qwen35"
+        ):
+            # [FORK 兼容] Qwen3.5 GGUF 多模态:Qwen3_5Config 的 vision_config
+            # 是空模板(字段 None),用 mmproj 提取的真实配置替换;
+            # 架构改为 ForConditionalGeneration(多模态类,与 AWQ 一致)
+            hf_config.vision_config = vision_config
+            hf_config.architectures = ["Qwen3_5ForConditionalGeneration"]
 
     return hf_config
 

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -39,6 +39,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
     "int8": torch.int8,
+    "int8_per_tensor": torch.int8,  # [FORK-PORT] PR#41505
     "int8_per_token_head": torch.int8,
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
@@ -76,6 +77,8 @@ PIN_MEMORY = "microsoft" not in " ".join(platform.uname()).lower()
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
+        # [FORK-PORT] PR#41505: int8_per_tensor 也是量化 KV (torch_utils 版)
+        or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"
     )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1859,19 +1859,15 @@ class FlashInferImpl(AttentionImpl):
                 else:
                     if self.kv_cache_dtype == "int8_per_tensor" and (
                         _kv_cache_int8 is not None
-                    ):
+                    ) and num_decode_tokens == attn_metadata.num_decodes:
                         # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
                         # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
                         # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),
                         # 只处理请求块, 实测 42.8 tok/s。prefill 仍走 FlashInfer
                         # (反量化路径, 1400+ tok/s)。用原始 int8 cache + 张量 scale。
-                        import os
-                        if os.environ.get("VLLM_INT8_DECODE_TRITON_DEBUG"):
-                            print(
-                                f"[FORK-DBG] decode Triton 路径: dtype="
-                                f"{self.kv_cache_dtype} n={num_decode_tokens}",
-                                flush=True,
-                            )
+                        # 仅限每请求 1 token 的常规 decode (num_decode_tokens ==
+                        # num_decodes); 推测解码产生多 token 时回退 FlashInfer
+                        # 路径 (per-request metadata 语义不同, 见 #99 复审)。
                         from vllm.v1.attention.ops.triton_unified_attention import (
                             unified_attention,
                         )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,6 +1292,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
+    # [FORK] int8_per_tensor 未校准警告去重标志
+    _warned_uncalibrated = False
+
     def __init__(
         self,
         num_heads: int,
@@ -1501,6 +1504,21 @@ class FlashInferImpl(AttentionImpl):
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                if layer._k_scale_float == 1.0:
+                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
+                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
+                    # scale 保持 1.0 → 数据错误。每层只提示一次。
+                    if not FlashInferImpl._warned_uncalibrated:
+                        logger.warning(
+                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
+                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            layer.layer_name,
+                        )
+                        FlashInferImpl._warned_uncalibrated = True
+                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
+                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
+                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
+                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
                 _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
                     torch.float16
                 )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1277,6 +1277,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     disable_split_kv=self.disable_split_kv,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
+        # [FORK] int8_per_tensor decode 走 Triton 内核用 (FlashInfer 0.6.8
+        # 无 int8 decode 模板;全池反量化 5.7 tok/s vs Triton 42.8 tok/s)。
+        # 动态属性而非 dataclass 字段: _copy_tensor_tree 遍历 dataclass 字段
+        # 并 copy_, 视图与底层 buffer 同内存会触发 graph 捕获崩溃。
+        attn_metadata.seq_lens = seq_lens
+        attn_metadata.block_table = block_table_tensor
         return attn_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
@@ -1359,6 +1365,39 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+
+        # [FORK] int8 decode 走 Triton unified_attention 的 3D 分段参数
+        # (同 triton_attn.py): 长上下文 decode 用 3D 分段并行 softmax,
+        # 否则 2D 单段串行扫全部 KV → 32K 语境 decode 3.4 tok/s vs 26。
+        self._decode_3d: dict | None = None
+        if kv_cache_dtype == "int8_per_tensor":
+            MIN_LAUNCH_GRID_SIZE_2D = 128
+            NUM_PAR_SOFTMAX_SEGMENTS = 16
+            seq_threshold = MIN_LAUNCH_GRID_SIZE_2D // num_kv_heads
+            if vllm_config is not None:
+                capture_sizes = (
+                    vllm_config.compilation_config.cudagraph_capture_sizes
+                )
+                if capture_sizes:
+                    seq_threshold = min(
+                        capture_sizes,
+                        key=lambda x: abs(x - seq_threshold),
+                    )
+            headdim_padded = head_size  # 128 已是 2 的幂
+            self._decode_3d = {
+                "seq_threshold_3D": seq_threshold,
+                "num_par_softmax_segments": NUM_PAR_SOFTMAX_SEGMENTS,
+                "softmax_segm_output": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS,
+                     headdim_padded),
+                    dtype=torch.float32, device="cuda"),
+                "softmax_segm_max": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS),
+                    dtype=torch.float32, device="cuda"),
+                "softmax_segm_expsum": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS),
+                    dtype=torch.float32, device="cuda"),
+            }
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1499,37 +1538,44 @@ class FlashInferImpl(AttentionImpl):
         ):
             if self.kv_cache_dtype == "int8_per_tensor":
                 # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
-                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
-                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
+                # 枚举有但模板无, 直接喂会 illegal address)。prefill 反量化成
+                # fp16 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半;
+                # decode 走 Triton 内核 (原生 int8) 用原始 cache, 不反量化
+                # (decode-only 每步省全池反量化 ~17GB 流量, 5.7 → 42 tok/s)。
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
-                if layer._k_scale_float == 1.0:
-                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
-                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
-                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
-                    if layer.layer_name not in \
-                            FlashInferImpl._warned_uncalibrated_layers:
-                        logger.warning(
-                            "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
-                            "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
-                            layer.layer_name,
-                        )
-                        FlashInferImpl._warned_uncalibrated_layers.add(
-                            layer.layer_name
-                        )
-                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
-                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
-                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
-                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
-                _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
-                    torch.float16
-                )
-                _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
-                    torch.float16
-                )
-                kv_cache = torch.stack((_k, _v), dim=1)
+                _kv_cache_int8 = kv_cache
+                if attn_metadata.num_prefill_tokens > 0:
+                    if layer._k_scale_float == 1.0:
+                        # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA
+                        # graph) 时校准被跳过 (calc_kv_scales 零值跳过 + graph
+                        # 模式 return), scale 保持 1.0 → 数据错误。按层去重
+                        # (每层最多一次), 避免 graph 捕获阶段刷屏且真实请求
+                        # 时仍能看到提示。
+                        if layer.layer_name not in \
+                                FlashInferImpl._warned_uncalibrated_layers:
+                            logger.warning(
+                                "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
+                                "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
+                                layer.layer_name,
+                            )
+                            FlashInferImpl._warned_uncalibrated_layers.add(
+                                layer.layer_name
+                            )
+                    # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值
+                    # 一层 ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入,
+                    # 回放时读到校准后的值; 用 _k_scale_float (Python float)
+                    # 会被 CUDA graph 捕获折叠成常量 (启动时未校准 = 1.0) →
+                    # 数据错误。decode 分支走 Triton 内核时用 _kv_cache_int8
+                    # (原始 int8 + 张量 scale, 见 decode 分支)。
+                    _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
+                        torch.float16
+                    )
+                    _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
+                        torch.float16
+                    )
+                    kv_cache = torch.stack((_k, _v), dim=1)
             else:
                 torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.kv_cache_dtype
@@ -1811,14 +1857,71 @@ class FlashInferImpl(AttentionImpl):
                         get_dcp_group(),
                     )
                 else:
-                    decode_wrapper.run(
-                        decode_query,
-                        kv_cache_permute,
-                        k_scale=_kv_scale[0],
-                        v_scale=_kv_scale[1],
-                        out=out_decode,
-                        kv_cache_sf=kv_cache_sf,
-                    )
+                    if self.kv_cache_dtype == "int8_per_tensor" and (
+                        _kv_cache_int8 is not None
+                    ):
+                        # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
+                        # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
+                        # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),
+                        # 只处理请求块, 实测 42.8 tok/s。prefill 仍走 FlashInfer
+                        # (反量化路径, 1400+ tok/s)。用原始 int8 cache + 张量 scale。
+                        import os
+                        if os.environ.get("VLLM_INT8_DECODE_TRITON_DEBUG"):
+                            print(
+                                f"[FORK-DBG] decode Triton 路径: dtype="
+                                f"{self.kv_cache_dtype} n={num_decode_tokens}",
+                                flush=True,
+                            )
+                        from vllm.v1.attention.ops.triton_unified_attention import (
+                            unified_attention,
+                        )
+                        from vllm.v1.kv_cache_interface import KVQuantMode
+
+                        num_seqs = num_decode_tokens
+                        key_cache_i8, value_cache_i8 = _kv_cache_int8.unbind(1)
+                        seqused_k = attn_metadata.seq_lens[:num_seqs]
+                        cu_seqlens_q = torch.arange(
+                            num_seqs + 1,
+                            device=decode_query.device,
+                            dtype=torch.int32,
+                        )
+                        descale_shape = (num_seqs, key_cache_i8.shape[2])
+                        d3 = self._decode_3d or {}
+                        unified_attention(
+                            q=decode_query,
+                            k=key_cache_i8,
+                            v=value_cache_i8,
+                            out=out_decode,
+                            cu_seqlens_q=cu_seqlens_q,
+                            max_seqlen_q=1,
+                            seqused_k=seqused_k,
+                            max_seqlen_k=seqused_k.max(),
+                            softmax_scale=self.scale,
+                            causal=True,
+                            window_size=self.sliding_window,
+                            block_table=attn_metadata.block_table[:num_seqs],
+                            softcap=self.logits_soft_cap or 0.0,
+                            q_descale=None,
+                            k_descale=layer._k_scale.expand(descale_shape),
+                            v_descale=layer._v_scale.expand(descale_shape),
+                            seq_threshold_3D=d3.get("seq_threshold_3D"),
+                            num_par_softmax_segments=d3.get(
+                                "num_par_softmax_segments"
+                            ),
+                            softmax_segm_output=d3.get("softmax_segm_output"),
+                            softmax_segm_max=d3.get("softmax_segm_max"),
+                            softmax_segm_expsum=d3.get("softmax_segm_expsum"),
+                            kv_quant_mode=KVQuantMode.INT8_PER_TENSOR,
+                        )
+                    else:
+                        decode_wrapper.run(
+                            decode_query,
+                            kv_cache_permute,
+                            k_scale=_kv_scale[0],
+                            v_scale=_kv_scale[1],
+                            out=out_decode,
+                            kv_cache_sf=kv_cache_sf,
+                        )
 
                 if needs_fp8_out:
                     output[:num_decode_tokens].copy_(out_decode.to(output.dtype))

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -292,11 +292,12 @@ class BatchDCPPrefillWrapper:
         prefill_query_across_dcp = get_dcp_group().all_gather(
             prefill_query.contiguous(), dim=1
         )
+        _is_i8 = getattr(layer, "kv_cache_dtype", "") == "int8_per_tensor"
         output_context_tmp, lse_context_tmp = self._context.run(
             prefill_query_across_dcp,
             kv_cache_permute,
-            k_scale=layer._k_scale_float,
-            v_scale=layer._v_scale_float,
+            k_scale=(1.0 if _is_i8 else layer._k_scale_float),
+            v_scale=(1.0 if _is_i8 else layer._v_scale_float),
             return_lse=True,
         )
         output_context, lse_context = self._dcp_combine(
@@ -335,6 +336,9 @@ class FlashInferBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "nvfp4",
+        # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支, 在 forward 里
+        # 反量化成 fp16 临时 buffer 再喂内核 (KV 存储仍减半, 反量化开销 ~带宽)
+        "int8_per_tensor",
     ]
 
     @staticmethod
@@ -627,7 +631,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
-            if self.is_kvcache_nvfp4:
+            if self.cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 0.6.8 内核无 int8 分支,
+                # forward 里反量化成 fp16 临时 buffer 再喂内核; 这里告知
+                # FlashInfer 数据是 fp16 (plan 的 kv_data_type)。
+                self.kv_cache_dtype = torch.float16
+            elif self.is_kvcache_nvfp4:
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
                 # which is passed to FlashInferImpl
                 self.kv_cache_dtype = self.cache_dtype
@@ -1416,14 +1425,20 @@ class FlashInferImpl(AttentionImpl):
             f"got {query.dtype}"
         )
 
+        # [FORK] int8_per_tensor 走反量化路径 (数据已含 scale), 不折叠进 bmm
+        _is_int8_dequant = self.kv_cache_dtype == "int8_per_tensor"
+        # [FORK] int8_per_tensor: KV 已反量化为 fp16 真实值, 不能再传
+        # k_scale/v_scale 给 FlashInfer (否则双重 scale 导致乱码)
+        _kv_scale = (1.0, 1.0) if _is_int8_dequant else (
+            layer._k_scale_float, layer._v_scale_float)
         if self.bmm1_scale is None:
             self.bmm1_scale = self.scale
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
 
         if self.bmm2_scale is None:
             self.bmm2_scale = 1.0
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm2_scale *= layer._v_scale_float
 
         prefill_use_trtllm = isinstance(attn_metadata.prefill, TRTLLMPrefill)
@@ -1479,10 +1494,25 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
-            torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
-                self.kv_cache_dtype
-            )
-            kv_cache = kv_cache.view(torch_dtype)
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
+                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
+                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
+                # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
+                # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
+                # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
+                    torch.float16
+                )
+                _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
+                    torch.float16
+                )
+                kv_cache = torch.stack((_k, _v), dim=1)
+            else:
+                torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                    self.kv_cache_dtype
+                )
+                kv_cache = kv_cache.view(torch_dtype)
 
         # Inputs and outputs may be padded for CUDA graphs
         query = query[:num_actual_tokens]
@@ -1595,8 +1625,8 @@ class FlashInferImpl(AttentionImpl):
                     prefill_wrapper.run(
                         prefill_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_prefill,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1746,8 +1776,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=output_tmp,
                         lse=lse,
                         return_lse=True,
@@ -1762,8 +1792,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_decode,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1865,16 +1895,33 @@ class FlashInferImpl(AttentionImpl):
             # actual tokens.
             k_cache = kv_cache[:, 0]
             v_cache = kv_cache[:, 1]
-            torch.ops._C_cache_ops.reshape_and_cache_flash(
-                key,
-                value,
-                k_cache,
-                v_cache,
-                slot_mapping,
-                self.kv_cache_dtype,
-                layer._k_scale,
-                layer._v_scale,
-            )
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash 无 int8
+                # 分支, 改用 Triton 版 (与 TRITON_ATTN 后端同款, 支持 int8+scale)
+                from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+                    triton_reshape_and_cache_flash,
+                )
+                triton_reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
+            else:
+                torch.ops._C_cache_ops.reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
 
 
 def fast_plan_decode(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,8 +1292,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
-    # [FORK] int8_per_tensor 未校准警告去重标志
-    _warned_uncalibrated = False
+    # [FORK] int8_per_tensor 未校准警告去重 (按层记录, 每层最多一次)
+    _warned_uncalibrated_layers: set = set()
 
     def __init__(
         self,
@@ -1507,14 +1507,18 @@ class FlashInferImpl(AttentionImpl):
                 if layer._k_scale_float == 1.0:
                     # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
                     # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。每层只提示一次。
-                    if not FlashInferImpl._warned_uncalibrated:
+                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
+                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
+                    if layer.layer_name not in \
+                            FlashInferImpl._warned_uncalibrated_layers:
                         logger.warning(
-                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
-                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
+                            "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
                             layer.layer_name,
                         )
-                        FlashInferImpl._warned_uncalibrated = True
+                        FlashInferImpl._warned_uncalibrated_layers.add(
+                            layer.layer_name
+                        )
                 # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
                 # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
                 # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1536,6 +1536,8 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
+            # [FORK] decode 是否走 Triton 快速路径 (int8 且每请求 1 token 无 padding)
+            _use_triton_decode = False
             if self.kv_cache_dtype == "int8_per_tensor":
                 # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
                 # 枚举有但模板无, 直接喂会 illegal address)。prefill 反量化成
@@ -1545,8 +1547,15 @@ class FlashInferImpl(AttentionImpl):
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                # [FORK] 仅当 decode 为"每请求 1 token 且无 padding rows"
+                # (num_decode_tokens == num_decodes) 时走 Triton 快速路径;
+                # 推测解码或多 token 时回退 FlashInfer, 此时必须反量化
+                # (decode-only 回退也反量化, 否则 int8 cache 喂 FlashInfer 崩)。
+                _use_triton_decode = (
+                    attn_metadata.num_decode_tokens == attn_metadata.num_decodes
+                )
                 _kv_cache_int8 = kv_cache
-                if attn_metadata.num_prefill_tokens > 0:
+                if attn_metadata.num_prefill_tokens > 0 or not _use_triton_decode:
                     if layer._k_scale_float == 1.0:
                         # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA
                         # graph) 时校准被跳过 (calc_kv_scales 零值跳过 + graph
@@ -1859,7 +1868,7 @@ class FlashInferImpl(AttentionImpl):
                 else:
                     if self.kv_cache_dtype == "int8_per_tensor" and (
                         _kv_cache_int8 is not None
-                    ) and num_decode_tokens == attn_metadata.num_decodes:
+                    ) and _use_triton_decode:
                         # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
                         # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
                         # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -1211,6 +1211,12 @@ def get_kernel_options(
         block_m_candidate = max(block_m_candidate, block_lower_bound)
         block_n_candidate = max(block_n_candidate, block_lower_bound)
 
+        # [FORK 兼容] triton 的 tl.arange 要求 2 幂;视觉 BLOCK_N 会取到
+        # 784(图像 28x28 patches,非 2 幂)导致 'arange range must be power of 2'。
+        # 向上取 2 幂(1024),代价是共享内存略增,但避免崩
+        block_m_candidate = 2 ** max(1, (block_m_candidate - 1).bit_length())
+        block_n_candidate = 2 ** max(1, (block_n_candidate - 1).bit_length())
+
         kernel_options["BLOCK_M"] = block_m_candidate
         kernel_options["BLOCK_N"] = block_n_candidate
 

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -1113,8 +1113,8 @@ class FlexAttentionImpl(AttentionImpl):
             key_cache, value_cache = kv_cache.unbind(0)
 
             # View out the block_size dim
-            key_cache = key_cache.view(-1, self.num_kv_heads, self.head_size)
-            value_cache = value_cache.view(-1, self.num_kv_heads, self.head_size)
+            key_cache = key_cache.reshape(-1, self.num_kv_heads, self.head_size)
+            value_cache = value_cache.reshape(-1, self.num_kv_heads, self.head_size)
             query, key_tensor, value_tensor = map(
                 lambda x: self.view_as_4d(x).permute(0, 2, 1, 3),
                 (query, key_cache, value_cache),

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -517,6 +517,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "int8_per_tensor",  # [FORK-PORT] PR#41505
         "int8_per_token_head",
         "fp8_per_token_head",
     ]
@@ -1822,10 +1823,14 @@ class TritonAttentionImpl(AttentionImpl):
             v_descale = None
             k_scale_cache = self._k_scale_cache
             v_scale_cache = self._v_scale_cache
-        # FP8 per-tensor / auto path (original flow).
+        # FP8 per-tensor / INT8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if (
+                is_quantized_kv_cache(self.kv_cache_dtype)
+                # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8, 无需 fp8 view
+                and self.kv_cache_dtype != "int8_per_tensor"
+            ):
                 if key_cache.dtype != self.fp8_dtype:
                     key_cache = key_cache.view(self.fp8_dtype)
                     value_cache = value_cache.view(self.fp8_dtype)
@@ -1991,7 +1996,11 @@ class TritonAttentionImpl(AttentionImpl):
             return
         # For decoder and cross-attention, use KV cache as before.
         key_cache, value_cache = kv_cache.unbind(1)
-        if is_quantized_kv_cache(self.kv_cache_dtype):
+        if (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8
+            and self.kv_cache_dtype != "int8_per_tensor"
+        ):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
         triton_reshape_and_cache_flash(

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -38,6 +38,10 @@ def reshape_and_cache_kernel_flash(
     USE_HEAD_MAJOR_LAYOUT: tl.constexpr,
     # FP8 flags
     FP8_KV_CACHE: tl.constexpr,
+    # [FORK-PORT] PR#41505: INT8 per-tensor flag + platform flags
+    INT8_KV_CACHE: tl.constexpr,
+    IS_ROCM: tl.constexpr,
+    IS_CUDA: tl.constexpr,
     # tune parameters
     TILE_SIZE: tl.constexpr,
 ):
@@ -90,7 +94,18 @@ def reshape_and_cache_kernel_flash(
     key_load = tl.load(
         key_ptr + src_key_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        k_scale_val = tl.load(k_scale)
+        k_scaled = key_load.to(tl.float32) / k_scale_val
+        if IS_ROCM:
+            k_rounded = tl.extra.hip.libdevice.nearbyint(k_scaled)
+        elif IS_CUDA:
+            k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
+        else:
+            k_rounded = tl.floor(k_scaled + 0.5)
+        key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,
         # based on the key_cache_ptr.dtype.element_ty
         key_tile = key_load if key_load.dtype.is_fp8() else key_load / tl.load(k_scale)
@@ -101,7 +116,18 @@ def reshape_and_cache_kernel_flash(
     value_load = tl.load(
         value_ptr + src_value_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        v_scale_val = tl.load(v_scale)
+        v_scaled = value_load.to(tl.float32) / v_scale_val
+        if IS_ROCM:
+            v_rounded = tl.extra.hip.libdevice.nearbyint(v_scaled)
+        elif IS_CUDA:
+            v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
+        else:
+            v_rounded = tl.floor(v_scaled + 0.5)
+        value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():
             value_tile = value_load
         else:
@@ -353,14 +379,20 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    kv_cache_torch_dtype = (
-        current_platform.fp8_dtype()
-        if is_quantized_kv_cache(kv_cache_dtype)
-        else key_cache.dtype
-    )
+    # [FORK-PORT] PR#41505: int8_per_tensor 走 torch.int8, 不做 fp8 view
+    is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
+    is_int8 = kv_cache_dtype.startswith("int8")
+    if is_int8:
+        kv_cache_torch_dtype = torch.int8
+    elif is_quantized_kv_cache(kv_cache_dtype):
+        kv_cache_torch_dtype = current_platform.fp8_dtype()
+    else:
+        kv_cache_torch_dtype = key_cache.dtype
 
-    if key_cache.dtype != kv_cache_torch_dtype and is_quantized_kv_cache(
-        kv_cache_dtype
+    if (
+        not is_int8
+        and key_cache.dtype != kv_cache_torch_dtype
+        and is_quantized_kv_cache(kv_cache_dtype)
     ):
         # to avoid erounous implicit cast in triton kernel (tl.store to uint8)
         # (e.g. explicit cast to fp8e4m3fnuz is not supported in triton 3.4)
@@ -371,7 +403,8 @@ def triton_reshape_and_cache_flash(
         "uint8 is not supported by triton reshape_and_cache_flash"
     )
 
-    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype)
+    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype) and not is_int8
+    INT8_KV_CACHE = is_int8_per_tensor
     assert (not FP8_KV_CACHE) or kv_cache_torch_dtype in [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -379,8 +412,8 @@ def triton_reshape_and_cache_flash(
         torch.float8_e4m3fnuz,
     ], (
         "unsupported dtype of KV cache tensor, got "
-        "{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
-        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz."
+        f"{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
+        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz, int8."
     )
 
     # heuristics instead of autotuning
@@ -423,6 +456,10 @@ def triton_reshape_and_cache_flash(
         x=x,
         USE_HEAD_MAJOR_LAYOUT=use_head_major_layout,
         FP8_KV_CACHE=FP8_KV_CACHE,
+        # [FORK-PORT] PR#41505
+        INT8_KV_CACHE=INT8_KV_CACHE,
+        IS_ROCM=current_platform.is_rocm(),
+        IS_CUDA=current_platform.is_cuda(),
         # autotune parameters
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -46,11 +46,16 @@ def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
       their scales separately on S/P inside the loop.
     - ``KV_QUANT_MODE == 1`` (FP8 per-tensor): dequantize using the
       tensor-wide scale.
+    - ``KV_QUANT_MODE == 5`` (INT8 per-tensor): plain cast.  Scale applied
+      post-matmul via folding into softmax_scale / acc.  [FORK-PORT] PR#41505
     """
     if KV_QUANT_MODE == 1:
         if Q.dtype.is_fp8():
             return data.to(Q.dtype)
         return (data.to(tl.float32) * tl.load(tensor_scale)).to(Q.dtype)
+    if KV_QUANT_MODE == 5:
+        # INT8 per-tensor: plain cast, scale folded into S and acc post-matmul
+        return data.to(Q.dtype)
     return data.to(Q.dtype)
 
 
@@ -131,7 +136,7 @@ def kernel_unified_attention(
     IS_3D: tl.constexpr,
     # KV cache quantization mode handled inside this kernel via constexpr
     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
-    # FP8_PER_TOKEN_HEAD (3).
+    # FP8_PER_TOKEN_HEAD (3), INT8_PER_TENSOR (5).  [FORK-PORT] PR#41505
     KV_QUANT_MODE: tl.constexpr = 0,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
@@ -141,7 +146,10 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
+    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) 不是 per-token-head
+    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
+        KV_QUANT_MODE == 3
+    )
 
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -227,6 +235,13 @@ def kernel_unified_attention(
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
     )
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — fold k_scale into softmax
+    # scale (zero inner-loop overhead), apply v_scale once post-loop
+    if KV_QUANT_MODE == 5:
+        int8_k_scale_val = tl.load(k_scale)
+        int8_v_scale_val = tl.load(v_scale)
+        scale = scale * int8_k_scale_val
 
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
@@ -338,6 +353,10 @@ def kernel_unified_attention(
             acc += tl.dot(P_v, V)
         else:
             acc += tl.dot(P.to(V.dtype), V)
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — apply v_scale once on output
+    if KV_QUANT_MODE == 5:
+        acc = acc * int8_v_scale_val
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -611,8 +611,8 @@ def resolve_kv_cache_block_sizes(
 
     # Mamba groups with block_size != cache_config.block_size
     # (mamba_cache_mode != "align") break divisibility; back off to the
-    # scheduler block size.
-    if any(
+    # scheduler block size. In align mode hashing by GCD is safe.
+    if cache_config.mamba_cache_mode != "align" and any(
         isinstance(g.kv_cache_spec, MambaSpec)
         and g.kv_cache_spec.block_size != cache_config.block_size
         for g in groups
@@ -1032,6 +1032,13 @@ def unify_kv_cache_spec_page_size(
         else:
             layer_page_size = layer_spec.page_size_bytes
             if max_page_size % layer_page_size != 0:
+                # 不能通过 block_size 整除时:对支持 padding 的层(state-based
+                # 如 Mamba)直接把页填充到 max_page_size
+                if hasattr(layer_spec, "page_size_padded"):
+                    new_kv_cache_spec[layer_name] = replace(
+                        layer_spec, page_size_padded=max_page_size
+                    )
+                    continue
                 raise NotImplementedError(
                     "The page size of the layer is not divisible by the "
                     "maximum page size. Cannot unify by adjusting block_size."
@@ -1168,6 +1175,8 @@ def _get_kv_cache_groups_uniform_page_size(
         # instead of layers[i * group_size: (i + 1) * group_size]
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
+    for _gl in grouped_layers:
+        print(f"[KVGROUP] layers={_gl}", flush=True)
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1176,7 +1176,7 @@ def _get_kv_cache_groups_uniform_page_size(
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
     for _gl in grouped_layers:
-        print(f"[KVGROUP] layers={_gl}", flush=True)
+        logger.debug("kv cache group layers: %s", _gl)
     return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -46,6 +46,9 @@ class KVQuantMode(IntEnum):
     INT8_PER_TOKEN_HEAD = 2  # per-token-head dynamic scales for int8
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
+    # [FORK-PORT] PR#41505 int8_per_tensor: 5 = symmetric INT8 per-tensor scale KV
+    # (原生 int→float 转换, sm_75 无 FP8 硬件时唯一 8bit KV 路径; 上游未合并, 见研究文档)
+    INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property
     def is_per_token_head(self) -> bool:
@@ -69,6 +72,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.FP8_PER_TOKEN_HEAD
     if kv_cache_dtype == "nvfp4":
         return KVQuantMode.NVFP4
+    if kv_cache_dtype == "int8_per_tensor":
+        return KVQuantMode.INT8_PER_TENSOR
     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
         return KVQuantMode.FP8_PER_TENSOR
     return KVQuantMode.NONE

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6091,6 +6091,34 @@ class GPUModelRunner(
 
     @torch.inference_mode()
     def profile_cudagraph_memory(self) -> int:
+        # [FORK] 128K 长上下文 + custom all-reduce 时 IPC handle 泄漏崩溃
+        # (官方 #46515), profiling 期间临时禁用 custom AR 实例
+        _ca_comm = None
+        try:
+            from vllm.distributed.parallel_state import get_world_group
+            _world = get_world_group()
+            _ca_comm = getattr(_world.device_communicator, "ca_comm", None)
+            # 独立设置模块级标志 (cuda_communicator.all_reduce 检查它)
+            import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+            _car_mod._PROFILING_CAR_DISABLED = True
+            print(f"[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm={_ca_comm}", flush=True)
+            if _ca_comm is not None:
+                _ca_comm.disabled = True
+        except Exception as e:
+            print(f"[FORK-PROFILE] 设置失败: {e}", flush=True)
+            pass
+        try:
+            return self._profile_cudagraph_memory_impl()
+        finally:
+            if _ca_comm is not None:
+                try:
+                    _ca_comm.disabled = False
+                    import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+                    _car_mod._PROFILING_CAR_DISABLED = False
+                except Exception:
+                    pass
+
+    def _profile_cudagraph_memory_impl(self) -> int:
         with set_current_vllm_config(self.vllm_config):
             self._init_minimal_kv_cache_for_profiling()
 


### PR DESCRIPTION
$(cat /tmp/pr_body.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds symmetric `int8_per_tensor` KV cache and a dual GGUF/AWQ path on `sm_75`, fixing packed decode v→k mapping and keeping `flashinfer` for prefill while switching INT8 decode to Triton for speed. Old behavior: FP8/FP16‑only KV and a single layout with mapping errors. New behavior: 8‑bit KV with per‑tensor scales, unified single‑token decode guard, safe dequant fallbacks, and robust GGUF load. Side effects: first real long prefill calibrates scales; INT8 uncalibrated warnings fire once per layer; profiling temporarily disables custom all‑reduce.

- Key changes
  - `int8_per_tensor` KV: per‑tensor scales with k/v range 127; skips zero‑value warmups and CUDA‑graph captures; `flashinfer` prefill dequantizes on‑the‑fly to fp16; Triton `unified_attention` adds INT8 mode with 3D segmented softmax and a unified guard that uses Triton only when `num_decode_tokens == num_decodes`; when padding or speculative multi‑token decode occurs, decode falls back to `flashinfer` with explicit dequant to prevent illegal int8 paths; `triton_reshape_and_cache_flash` adds an INT8 store path.
  - Dual GGUF/AWQ layout: switch via `VLLM_GDN_GGUF_LAYOUT`; correct packed decode v→k mapping (GGUF: `% H`, AWQ: `// (HV // H)`); GGUF path all‑gathers q/k across TP and passes `v_start` to fused kernels; fixes sigmoid‑gating double‑beta; core attention runs FP32 with optional `VLLM_GGUF_FP32=1`.
  - GGUF load/quant: robust text/vision name remap, multi‑shard `qkvz`/`z` ordering, lm_head/embed dequant to FP16, conv/pos‑embed shape fixes, `A_log` log back‑conversion, RoPE defaults; `RMSNorm` selected by load format; `Qwen3_5ForCausalLM` marked `IsHybrid` with SSM state helpers.
  - Profiling/tuning/misc: fixed GDN kernel configs; Flex Attention rounds block sizes to powers of two; CLI `--compilation-config` accepts JSON strings; KV page‑size unification pads state‑based layers; profiling temporarily disables custom all‑reduce.

- Rollout
  - To use 8‑bit KV, set cache dtype to `int8_per_tensor` and calibrate on a real long prefill; scale calc is skipped during warmup and CUDA graph capture.
  - For GGUF models, set `VLLM_GDN_GGUF_LAYOUT=1`; optionally set `VLLM_GGUF_FP32=1`; ensure the mmproj file is present for multimodal.
  - AWQ and other formats need no flags; `lm_head` and `embed_tokens` load dequantized automatically.

<sup>Written for commit 9b4880d91bcd72e2bf612dedc2bbc3f942848049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

