### PR TITLE
fix: stabilize Qwen3.8-27B reasoning and cache stability on RTX 2080 Ti

### DIFF
--- a/tests/config/test_expandable_segments_cpu_offload.py
+++ b/tests/config/test_expandable_segments_cpu_offload.py
@@ -8,13 +8,24 @@ import pytest
 from vllm.config import VllmConfig
 
 
-def _verify_connector(monkeypatch: pytest.MonkeyPatch, connector: str) -> None:
-    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+def _verify_connector(
+    monkeypatch: pytest.MonkeyPatch,
+    connector: str,
+    extra_config: dict[str, str] | None = None,
+    allocator_env: str = "PYTORCH_CUDA_ALLOC_CONF",
+    allocator_value: str = "expandable_segments:True",
+) -> None:
+    monkeypatch.delenv("PYTORCH_CUDA_ALLOC_CONF", raising=False)
+    monkeypatch.delenv("PYTORCH_ALLOC_CONF", raising=False)
+    monkeypatch.setenv(allocator_env, allocator_value)
     config = object.__new__(VllmConfig)
     object.__setattr__(
         config,
         "kv_transfer_config",
-        SimpleNamespace(kv_connector=connector),
+        SimpleNamespace(
+            kv_connector=connector,
+            kv_connector_extra_config=extra_config,
+        ),
     )
     object.__setattr__(
         config,
@@ -38,3 +49,34 @@ def test_expandable_segments_still_rejects_registered_transport(
 ) -> None:
     with pytest.raises(ValueError, match="NixlConnector"):
         _verify_connector(monkeypatch, "NixlConnector")
+
+
+def test_expandable_segments_rejects_custom_offloading_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="NixlConnector"):
+        _verify_connector(
+            monkeypatch,
+            "OffloadingConnector",
+            extra_config={"spec_name": "CustomOffloadingSpec"},
+        )
+
+
+@pytest.mark.parametrize(
+    ("allocator_env", "allocator_value"),
+    [
+        ("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:true"),
+        ("PYTORCH_ALLOC_CONF", "foo:bar, expandable_segments:1"),
+    ],
+)
+def test_expandable_segments_detection_is_shared_and_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+    allocator_env: str,
+    allocator_value: str,
+) -> None:
+    _verify_connector(
+        monkeypatch,
+        "SimpleCPUOffloadConnector",
+        allocator_env=allocator_env,
+        allocator_value=allocator_value,
+    )

--- a/tests/config/test_expandable_segments_cpu_offload.py
+++ b/tests/config/test_expandable_segments_cpu_offload.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import VllmConfig
+
+
+def _verify_connector(monkeypatch: pytest.MonkeyPatch, connector: str) -> None:
+    monkeypatch.setenv("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+    config = object.__new__(VllmConfig)
+    object.__setattr__(
+        config,
+        "kv_transfer_config",
+        SimpleNamespace(kv_connector=connector),
+    )
+    object.__setattr__(
+        config,
+        "model_config",
+        SimpleNamespace(enable_sleep_mode=False),
+    )
+    config._verify_kv_transfer_compat()
+
+
+@pytest.mark.parametrize(
+    "connector", ["OffloadingConnector", "SimpleCPUOffloadConnector"]
+)
+def test_expandable_segments_allows_local_cpu_offload(
+    monkeypatch: pytest.MonkeyPatch, connector: str
+) -> None:
+    _verify_connector(monkeypatch, connector)
+
+
+def test_expandable_segments_still_rejects_registered_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="NixlConnector"):
+        _verify_connector(monkeypatch, "NixlConnector")

--- a/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
+++ b/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
 )
+from vllm.v1.core.kv_cache_coordinator import KVCacheCoordinator
 from vllm.v1.core.sched.scheduler import Scheduler
 
 
@@ -62,3 +63,66 @@ def test_hybrid_mamba_external_hit_is_aligned_and_does_not_crash():
         )
         == 16
     )
+
+
+def test_mamba_align_mtp_can_retain_final_cache_boundary():
+    """An uncached tail supplies MTP state without dropping a full block."""
+    request = SimpleNamespace(
+        num_computed_tokens=0,
+        num_prompt_tokens=14,
+        num_tokens=14,
+    )
+    legacy_scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=4),
+        use_eagle=True,
+        retain_mamba_align_mtp_cache_block=False,
+    )
+    fixed_scheduler = SimpleNamespace(
+        cache_config=SimpleNamespace(block_size=4),
+        use_eagle=True,
+        retain_mamba_align_mtp_cache_block=True,
+    )
+
+    assert (
+        Scheduler._mamba_block_aligned_split(legacy_scheduler, request, 14) == 8
+    )
+    assert (
+        Scheduler._mamba_block_aligned_split(fixed_scheduler, request, 14) == 12
+    )
+
+
+def test_hybrid_local_hits_are_touched_before_any_external_allocation():
+    """External allocation must not evict another group's untouched local hit."""
+    events = []
+
+    class _Manager:
+        num_cached_block = {}
+
+        def __init__(self, group):
+            self.group = group
+
+        def add_local_computed_blocks(self, *args):
+            events.append(("local", self.group))
+
+        def allocate_external_computed_blocks(self, *args):
+            events.append(("external", self.group))
+
+    coordinator = SimpleNamespace(
+        single_type_managers=(_Manager(0), _Manager(1), _Manager(2))
+    )
+    KVCacheCoordinator.allocate_new_computed_blocks(
+        coordinator,
+        "request",
+        ([object()], [object()], [object()]),
+        num_local_computed_tokens=16,
+        num_external_computed_tokens=32,
+    )
+
+    assert events == [
+        ("local", 0),
+        ("local", 1),
+        ("local", 2),
+        ("external", 0),
+        ("external", 1),
+        ("external", 2),
+    ]

--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
+
+
+def _sync_one_request(holder: ThinkingBudgetStateHolder) -> None:
+    holder.sync_batch(
+        SimpleNamespace(
+            removed=[],
+            moved=[],
+            added=[
+                (
+                    0,
+                    SimpleNamespace(thinking_token_budget=32),
+                    [],
+                    [],
+                )
+            ],
+        )
+    )
+
+
+def test_natural_end_preserves_next_think_prefix() -> None:
+    holder = ThinkingBudgetStateHolder(
+        SimpleNamespace(
+            reasoning_start_token_ids=[10, 11],
+            reasoning_end_token_ids=[20],
+        ),
+        max_num_seqs=1,
+        num_spec_tokens=0,
+        device=torch.device("cpu"),
+        is_pin_memory=False,
+    )
+    _sync_one_request(holder)
+
+    # The same accepted batch contains a complete block and the first token of
+    # the next multi-token <think> marker.
+    holder.update_state([[10, 11, 1, 20, 10]], None)
+    state = holder._state[0]
+    assert state["in_think"] is False
+    assert state["scan_offset"] == 4
+    assert state["prev_output_length"] == 5
+
+    # The second token arrives later; scanning from the end-marker boundary
+    # must retain the prefix from the previous batch.
+    holder.update_state([[10, 11, 1, 20, 10, 11, 2]], None)
+    state = holder._state[0]
+    assert state["in_think"] is True
+    assert state["start_thinking"] == 4

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -736,9 +736,7 @@ class VllmConfig:
         # expandable_segments off around its pool (see #40812), so the KV
         # cache allocated within that context lands on stable physical pages
         # even when the env var is set.
-        if "expandable_segments:True" not in os.environ.get(
-            "PYTORCH_CUDA_ALLOC_CONF", ""
-        ):
+        if not envs.is_expandable_segments_enabled():
             return
         if self.model_config is not None and self.model_config.enable_sleep_mode:
             return
@@ -749,10 +747,15 @@ class VllmConfig:
         # is pinned. Expandable segments are therefore safe for these local
         # connectors and are useful for avoiding activation-pool fragmentation
         # during large chunked-prefill batches.
-        if self.kv_transfer_config.kv_connector in {
-            "OffloadingConnector",
+        connector = self.kv_transfer_config.kv_connector
+        extra_config = self.kv_transfer_config.kv_connector_extra_config or {}
+        if connector in {
             "SimpleCPUOffloadConnector",
-        }:
+        } or (
+            connector == "OffloadingConnector"
+            and extra_config.get("spec_name", "CPUOffloadingSpec")
+            == "CPUOffloadingSpec"
+        ):
             return
 
         raise ValueError(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -743,6 +743,18 @@ class VllmConfig:
         if self.model_config is not None and self.model_config.enable_sleep_mode:
             return
 
+        # The in-process CPU offload connectors do not register GPU memory
+        # with an external transport. They resolve the persistent KV tensor
+        # addresses for each local CUDA copy, while only the CPU backing store
+        # is pinned. Expandable segments are therefore safe for these local
+        # connectors and are useful for avoiding activation-pool fragmentation
+        # during large chunked-prefill batches.
+        if self.kv_transfer_config.kv_connector in {
+            "OffloadingConnector",
+            "SimpleCPUOffloadConnector",
+        }:
+            return
+
         raise ValueError(
             f"KV connector {self.kv_transfer_config.kv_connector} is "
             "incompatible with PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True "

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -10,13 +10,13 @@
 # the only successful approach is to call cuda driver API in C.
 import dataclasses
 import gc
-import os
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any
 
 import torch
 
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.system_utils import find_loaded_library
@@ -262,8 +262,7 @@ class CuMemAllocator:
         # If the user has enabled expandable segments via
         # PYTORCH_CUDA_ALLOC_CONF, temporarily disable them for the duration
         # of the memory pool context and restore on exit.
-        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
-        expandable_was_enabled = "expandable_segments:True" in conf
+        expandable_was_enabled = envs.is_expandable_segments_enabled()
         if expandable_was_enabled:
             torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -303,16 +302,7 @@ class CustomAllreduce:
         # cudaErrorInvalidValue). Keep the custom all-reduce kernel enabled,
         # but route graph inputs through its pre-registered cudaMalloc staging
         # buffer. Explicit "registered" mode above remains an opt-in override.
-        allocator_conf = ",".join(
-            filter(
-                None,
-                (
-                    os.environ.get("PYTORCH_CUDA_ALLOC_CONF"),
-                    os.environ.get("PYTORCH_ALLOC_CONF"),
-                ),
-            )
-        )
-        if "expandable_segments:true" in allocator_conf.replace(" ", "").lower():
+        if envs.is_expandable_segments_enabled():
             return False
 
         # Full decode graphs keep the fast registered-input path. SM75

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from contextlib import contextmanager
 from typing import cast
 
@@ -296,6 +297,23 @@ class CustomAllreduce:
                 "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE must be one of "
                 f"auto, registered, or staging. Got {graph_input_mode!r}."
             )
+
+        # CUDA IPC cannot export graph-private tensors allocated from
+        # PyTorch expandable segments (cudaIpcGetMemHandle returns
+        # cudaErrorInvalidValue). Keep the custom all-reduce kernel enabled,
+        # but route graph inputs through its pre-registered cudaMalloc staging
+        # buffer. Explicit "registered" mode above remains an opt-in override.
+        allocator_conf = ",".join(
+            filter(
+                None,
+                (
+                    os.environ.get("PYTORCH_CUDA_ALLOC_CONF"),
+                    os.environ.get("PYTORCH_ALLOC_CONF"),
+                ),
+            )
+        )
+        if "expandable_segments:true" in allocator_conf.replace(" ", "").lower():
+            return False
 
         # Full decode graphs keep the fast registered-input path. SM75
         # piecewise/prefill captures may allocate graph-private large buffers

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -249,8 +249,14 @@ class OffloadingConnectorScheduler:
 
     def _remove_pending_job(self, job_id: int, block_ids: list[int] | None) -> None:
         for bid in block_ids or ():
-            pending = self._block_id_to_pending_jobs[bid]
-            pending.remove(job_id)
+            # A block can be reallocated and its pending-store entry flushed
+            # before the worker completion arrives. Completion is still
+            # valid; do not take down EngineCore while cleaning up that stale
+            # bookkeeping entry.
+            pending = self._block_id_to_pending_jobs.get(bid)
+            if pending is None:
+                continue
+            pending.discard(job_id)
             if not pending:
                 del self._block_id_to_pending_jobs[bid]
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
     VLLM_TURBOQUANT_DECODE_BLOCK_KV: int = 2
     VLLM_TURBOQUANT_K8V4_FP8_FORMAT: str = "auto"
     VLLM_TURBOQUANT_CUDAGRAPH_SPEC_DECODE_SAFE: bool = False
+    VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK: bool = False
     VLLM_TURBOQUANT_SKIP_PREFILL_STORE: bool = False
     VLLM_PP_LAYER_PARTITION: str | None = None
     VLLM_CPU_KVCACHE_SPACE: int | None = 0
@@ -538,6 +539,26 @@ def get_env_or_set_default(
 # --8<-- [start:env-vars-definition]
 
 logger = logging.getLogger(__name__)
+
+
+def is_expandable_segments_enabled() -> bool:
+    """Return whether PyTorch expandable CUDA segments are enabled.
+
+    PyTorch accepts both allocator environment variable names.  Keep the
+    spelling and boolean parsing in one place so config validation, allocator
+    setup, and CUDA-graph handling cannot disagree.
+    """
+    for env_name in ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_ALLOC_CONF"):
+        allocator_conf = os.environ.get(env_name, "")
+        for item in allocator_conf.split(","):
+            key, separator, value = item.partition(":")
+            if (
+                separator
+                and key.strip().lower() == "expandable_segments"
+                and value.strip().lower() in {"1", "true", "yes", "on"}
+            ):
+                return True
+    return False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # ================== Installation Time Env Vars ==================
@@ -1131,6 +1152,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE": lambda: os.getenv(
         "VLLM_CUSTOM_ALLREDUCE_GRAPH_INPUT_MODE", "auto"
     ).lower(),
+    "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK": lambda: os.getenv(
+        "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
+    ).strip().lower()
+    in {"1", "true", "yes", "on"},
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -152,13 +152,33 @@ class KVCacheCoordinator(ABC):
             num_local_computed_tokens: The number of local computed tokens.
             num_external_computed_tokens: The number of external computed tokens.
         """
+        # A running request is already tracked and cannot acquire new prefix
+        # hits. Keep the old fast path coordinator-wide so every group agrees
+        # whether this is a first allocation.
+        if any(
+            request_id in manager.num_cached_block
+            for manager in self.single_type_managers
+        ):
+            assert all(len(blocks) == 0 for blocks in new_computed_blocks)
+            return
+
+        # Two phases are required for hybrid caches. Touch every group's local
+        # hits before any external allocation can evict an as-yet untouched hit
+        # owned by another group (vLLM #43884 / #44409).
         for i, manager in enumerate(self.single_type_managers):
-            manager.allocate_new_computed_blocks(
+            manager.add_local_computed_blocks(
                 request_id,
                 new_computed_blocks[i],
                 num_local_computed_tokens,
                 num_external_computed_tokens,
             )
+        if num_external_computed_tokens > 0:
+            for manager in self.single_type_managers:
+                manager.allocate_external_computed_blocks(
+                    request_id,
+                    num_local_computed_tokens,
+                    num_external_computed_tokens,
+                )
 
     def allocate_new_blocks(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
-import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -257,10 +256,7 @@ class Scheduler(SchedulerInterface):
             speculative_config is not None
             and speculative_config.method == "mtp"
             and self.need_mamba_block_aligned_split
-            and os.getenv(
-                "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
-            ).strip().lower()
-            in {"1", "true", "yes", "on"}
+            and envs.VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK
         )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import itertools
+import os
 import time
 from collections import defaultdict, deque
 from collections.abc import Iterable
@@ -252,6 +253,15 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        self.retain_mamba_align_mtp_cache_block = (
+            speculative_config is not None
+            and speculative_config.method == "mtp"
+            and self.need_mamba_block_aligned_split
+            and os.getenv(
+                "VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK", "0"
+            ).strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -282,7 +292,15 @@ class Scheduler(SchedulerInterface):
             # reusable Mamba boundary one block earlier so all hybrid groups
             # describe the same prefix length.
             last_cache_position = round_down(request.num_tokens, block_size)
-            if self.use_eagle:
+            # MTP follows the EAGLE scheduler path, but an uncached prompt tail
+            # still runs and produces the hidden states needed by the proposer.
+            # In that case the final aligned Mamba state is valid and retaining
+            # it avoids throwing away a full prefix block.
+            retain_final_mtp_block = (
+                getattr(self, "retain_mamba_align_mtp_cache_block", False)
+                and last_cache_position < request.num_tokens
+            )
+            if self.use_eagle and not retain_final_mtp_block:
                 last_cache_position = max(last_cache_position - block_size, 0)
 
             chunk_end = num_computed_tokens + num_new_tokens

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -166,7 +166,7 @@ class SingleTypeKVCacheManager(ABC):
         )
         return num_new_blocks + num_evictable_blocks
 
-    def allocate_new_computed_blocks(
+    def add_local_computed_blocks(
         self,
         request_id: str,
         new_computed_blocks: Sequence[KVCacheBlock],
@@ -174,12 +174,10 @@ class SingleTypeKVCacheManager(ABC):
         num_external_computed_tokens: int,
     ) -> None:
         """
-        Add the new computed blocks to the request. This involves three steps:
+        Add locally cached blocks to a new request. This involves three steps:
         1. Touch the computed blocks to make sure they won't be evicted.
         1.5. (Optional) For sliding window, skip blocks are padded with null blocks.
         2. Add the remaining computed blocks.
-        3. (Optional) For KV connectors, allocate new blocks for external computed
-            tokens (if any).
 
         Args:
             request_id: The request ID.
@@ -189,13 +187,8 @@ class SingleTypeKVCacheManager(ABC):
             num_external_computed_tokens: The number of external computed tokens.
         """
 
-        if request_id in self.num_cached_block:
-            # Fast-path: a running request won't have any new prefix-cache hits.
-            # It should not have any new computed blocks.
-            assert len(new_computed_blocks) == 0
-            return
-
-        # A new request.
+        # The coordinator handles the running-request fast path before entering
+        # either phase, so every cache group sees the same request state.
         req_blocks = self.req_to_blocks[request_id]
         assert len(req_blocks) == 0
         num_total_computed_tokens = (
@@ -207,11 +200,6 @@ class SingleTypeKVCacheManager(ABC):
             # It is possible that all new computed blocks are skipped when
             # num_skipped_blocks > len(new_computed_blocks).
             new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
-            # Some external computed tokens may be skipped too.
-            num_external_computed_tokens = min(
-                num_total_computed_tokens - num_skipped_tokens,
-                num_external_computed_tokens,
-            )
 
         # Touch the computed blocks to make sure they won't be evicted.
         if self.enable_caching:
@@ -230,14 +218,32 @@ class SingleTypeKVCacheManager(ABC):
         # have a block_hash set.
         self.num_cached_block[request_id] = len(req_blocks)
 
-        if num_external_computed_tokens > 0:
-            # Allocate new blocks for external computed tokens.
-            allocated_blocks = self.block_pool.get_new_blocks(
-                cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """Allocate connector-hit blocks after all groups touched local hits."""
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        )
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        if num_skipped_tokens > 0:
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
             )
-            req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
-                self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+        if num_external_computed_tokens <= 0:
+            return
+
+        req_blocks = self.req_to_blocks[request_id]
+        allocated_blocks = self.block_pool.get_new_blocks(
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+        )
+        req_blocks.extend(allocated_blocks)
+        if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
         self, request_id: str, num_tokens: int, num_tokens_main_model: int
@@ -1069,7 +1075,7 @@ class MambaManager(SingleTypeKVCacheManager):
 class CrossAttentionManager(SingleTypeKVCacheManager):
     """Manager for cross-attention KV cache in encoder-decoder models."""
 
-    def allocate_new_computed_blocks(
+    def add_local_computed_blocks(
         self,
         request_id: str,
         new_computed_blocks: Sequence[KVCacheBlock],
@@ -1079,6 +1085,16 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         # We do not cache blocks for cross-attention to be shared between
         # requests, so  `new_computed_blocks` should always be empty.
         assert len(new_computed_blocks) == 0
+
+    def allocate_external_computed_blocks(
+        self,
+        request_id: str,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        # Cross-attention states are request-specific and are never loaded as
+        # reusable external prefix KV.
+        return
 
     def cache_blocks(self, request: Request, num_tokens: int) -> None:
         # We do not cache blocks for cross-attention to be shared between

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -241,6 +241,7 @@ class ThinkingBudgetStateHolder:
             "in_spec_mode": False,
             "bonus_token_forced": False,
             "continue_thinking": continue_thinking,
+            "scan_offset": 0,
         }
 
     def _update_think_state(self, state: dict[str, Any]) -> None:
@@ -253,15 +254,42 @@ class ThinkingBudgetStateHolder:
             return
 
         if state["start_thinking"] == -1:
+            scan_offset = state.get("scan_offset", 0)
+            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             start_thinking = self._find_last_sequence_index(
-                state.get("output_tok_ids", []), self.think_start_token_ids
+                output_slice, self.think_start_token_ids
             )
+            if start_thinking >= 0:
+                start_thinking += scan_offset
             state["start_thinking"] = start_thinking
         if state["end_thinking"] == -1:
+            scan_offset = state.get("scan_offset", 0)
+            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             end_thinking = self._find_last_sequence_index(
-                state.get("output_tok_ids", []), self.think_end_token_ids
+                output_slice, self.think_end_token_ids
             )
+            if end_thinking >= 0:
+                end_thinking += scan_offset
             state["end_thinking"] = end_thinking
+
+        # A natural </think> ends the current block. Reset the scan window so
+        # a later <think> block cannot reuse the first block's offsets or
+        # silently escape the request budget.
+        if (
+            not state.get("in_end", False)
+            and state["start_thinking"] >= 0
+            and state["end_thinking"] >= 0
+            and state["end_thinking"] > state["start_thinking"]
+            and not state.get("continue_thinking", False)
+        ):
+            state["in_think"] = False
+            state["think_count"] = 0
+            state["continue_thinking"] = False
+            state["start_thinking"] = -1
+            state["end_thinking"] = -1
+            state["scan_offset"] = len(state.get("output_tok_ids", []))
+            state["check_count_down"] = state["thinking_token_budget"]
+            return
 
         if state["start_thinking"] == -1:
             return
@@ -285,10 +313,14 @@ class ThinkingBudgetStateHolder:
         predicted_countdown = current_step_countdown - len(state["spec_token_ids"]) - 1
         # We only proceed further if we have counted down the thinking budget
         # to 0 or less and when we are in the "in think" mode.
+        natural_end_with_continue = (
+            state.get("continue_thinking", False) and state["end_thinking"] != -1
+        )
         if (
             not state.get("in_end", False)
             and predicted_countdown >= 0
             and state["start_thinking"] > -1
+            and not natural_end_with_continue
         ):
             state["check_count_down"] = current_step_countdown
             state["prev_output_length"] = len(state.get("output_tok_ids", []))
@@ -360,6 +392,10 @@ class ThinkingBudgetStateHolder:
                     # Case: ...<start>...<end>... - exiting think mode
                     state["in_think"] = False
                     state["think_count"] = 0
+                    state["continue_thinking"] = False
+                    state["start_thinking"] = -1
+                    state["end_thinking"] = -1
+                    state["scan_offset"] = len(state.get("output_tok_ids", []))
 
             elif absolute_start_pos >= 0 and not state["continue_thinking"]:
                 # Found think start - entering think mode
@@ -371,6 +407,10 @@ class ThinkingBudgetStateHolder:
                 # Found think end - exiting think mode
                 state["in_think"] = False
                 state["think_count"] = 0
+                state["continue_thinking"] = False
+                state["start_thinking"] = -1
+                state["end_thinking"] = -1
+                state["scan_offset"] = len(state.get("output_tok_ids", []))
 
             elif state["in_think"]:
                 # Continue thinking mode, increment count by new tokens
@@ -445,6 +485,11 @@ class ThinkingBudgetStateHolder:
                         "in_end": False,
                         "end_count": 0,
                         "check_count_down": state["thinking_token_budget"],
+                        "start_thinking": -1,
+                        "end_thinking": -1,
+                        "think_count": 0,
+                        "continue_thinking": False,
+                        "scan_offset": len(state.get("output_tok_ids", [])),
                     }
                 )
 

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -282,12 +282,22 @@ class ThinkingBudgetStateHolder:
             and state["end_thinking"] > state["start_thinking"]
             and not state.get("continue_thinking", False)
         ):
+            output_length = len(state.get("output_tok_ids", []))
+            end_boundary = state["end_thinking"] + len(
+                self.think_end_token_ids
+            )
             state["in_think"] = False
             state["think_count"] = 0
             state["continue_thinking"] = False
             state["start_thinking"] = -1
             state["end_thinking"] = -1
-            state["scan_offset"] = len(state.get("output_tok_ids", []))
+            # Resume scanning immediately after this end marker.  The tail
+            # may already contain a complete next <think> marker or only its
+            # prefix; advancing to the output length would lose either case.
+            state["scan_offset"] = min(
+                output_length, max(0, end_boundary)
+            )
+            state["prev_output_length"] = output_length
             state["check_count_down"] = state["thinking_token_budget"]
             return
 
@@ -395,7 +405,11 @@ class ThinkingBudgetStateHolder:
                     state["continue_thinking"] = False
                     state["start_thinking"] = -1
                     state["end_thinking"] = -1
-                    state["scan_offset"] = len(state.get("output_tok_ids", []))
+                    state["scan_offset"] = min(
+                        current_length,
+                        max(0, absolute_end_pos + len(self.think_end_token_ids)),
+                    )
+                    state["prev_output_length"] = current_length
 
             elif absolute_start_pos >= 0 and not state["continue_thinking"]:
                 # Found think start - entering think mode
@@ -410,7 +424,11 @@ class ThinkingBudgetStateHolder:
                 state["continue_thinking"] = False
                 state["start_thinking"] = -1
                 state["end_thinking"] = -1
-                state["scan_offset"] = len(state.get("output_tok_ids", []))
+                state["scan_offset"] = min(
+                    current_length,
+                    max(0, absolute_end_pos + len(self.think_end_token_ids)),
+                )
+                state["prev_output_length"] = current_length
 
             elif state["in_think"]:
                 # Continue thinking mode, increment count by new tokens


### PR DESCRIPTION
## Summary

This PR contains runtime fixes specifically validated for serving Qwen3.8-27B GPTQ 4-bit Safetensors with vLLM on a dual NVIDIA RTX 2080 Ti setup.

Target production profile:

- Tensor parallelism across 2x RTX 2080 Ti
- MTP speculative decoding with 3 speculative tokens
- TurboQuant KV cache and local CPU KV offloading
- Hybrid Mamba/attention cache layout with prefix caching
- Qwen/Froggeric chat template
- Qwen3 reasoning parser and XML tool-call parser

The goal is to improve reasoning-state correctness, long-context stability, and prefix-cache behavior for Qwen3.8-27B coding, debugging, and multi-turn tool-use workloads without changing model weights or the MTP setting.

## Problems addressed

### 1. Repeated Qwen thinking blocks could escape the intended reasoning budget

After a natural </think> transition, the thinking-budget state could retain stale scan offsets and start/end positions. A later <think> block could then rescan old output, causing repeated Wait/Actually/Let us reconsider loops and reasoning far beyond the requested budget.

The fix resets the scan window and block positions after a natural reasoning transition, so later reasoning blocks are tracked independently.

### 2. Local CPU KV offload and expandable segments

Long Qwen3.8-27B agent histories can require substantial KV memory during prefill. The local CPU offloading connector was incorrectly rejected together with expandable segments.

This PR allows the supported local OffloadingConnector and SimpleCPUOffloadConnector paths with expandable segments, while preserving rejection for unsupported external KV transports.

### 3. Hybrid Mamba prefix-cache retention under MTP

When a cached prefix is followed by an uncached tail, the Mamba boundary block must be retained correctly. Under MTP this boundary could be touched or allocated in the wrong phase, reducing cache reuse or risking incorrect alignment.

This PR adds two-phase local-hit touch followed by external allocation and an opt-in VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK path for retaining the final Mamba boundary when an uncached tail follows.

## Validation

- 6 targeted pytest tests passed:
  - tests/config/test_expandable_segments_cpu_offload.py
  - tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
- Python compileall passed for all modified Python files.
- Thinking-state smoke test passed for natural <think>...</think> termination followed by a later reasoning block.
- git diff --check passed.
- No Qwen3.8-27B model weights, tokenizer files, or chat-template files were modified.

## Non-goals and boundaries

- MTP remains at 3 speculative tokens; this PR does not change MTP configuration.
- No sampling downgrade is introduced.
- The Mamba/MTP boundary-retention behavior remains opt-in.
- MTP acceptance rate and throughput still depend on prompt shape, cache locality, and workload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Qwen3.8-27B reasoning and KV cache reuse on dual RTX 2080 Ti with `vllm`. Fixes runaway <think> loops, allows safe CPU KV offload with expandable segments, and retains hybrid Mamba prefix cache under MTP.

- Reasoning-state tracking now resets the scan window at a natural </think>, preserving any partial next-<think> prefix and preventing repeated “wait/reconsider” loops beyond the requested budget.
- Expandable segments are detected via a shared, case-insensitive parser for both allocator env vars; local in-process CPU offload connectors are allowed (`SimpleCPUOffloadConnector`, and `OffloadingConnector` with the default `CPUOffloadingSpec`), while external transports and custom offloading specs are rejected early. When expandable segments are enabled, custom all-reduce automatically routes graph inputs through its registered cudaMalloc staging buffer; the memory-pool context temporarily disables segments to keep stable pages during allocation. This mitigates long-prefill OOM and fragmentation.
- Under MTP, an uncached tail no longer forces dropping the final aligned Mamba boundary from a cached prefix when enabled. Hybrid caches first touch all groups’ local hits before any external allocation to avoid cross-group eviction; late worker completions no longer crash cleanup if a block was reallocated.

**Rollout**
- To retain the final Mamba boundary under MTP, set VLLM_MAMBA_ALIGN_RETAIN_MTP_CACHE_BLOCK=1.
- You can safely enable PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True (or PYTORCH_ALLOC_CONF) with local CPU offload connectors; other connectors fail early with a clear error.

<sup>Written for commit 7ec89ca10e6b49a586a5cf2b35299814ad30a532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

