### PR TITLE
fix: bound Qwen reasoning blocks without dropping split markers

### DIFF
--- a/tests/v1/sample/test_thinking_budget_state.py
+++ b/tests/v1/sample/test_thinking_budget_state.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
+
+
+def test_reset_retains_split_start_marker_after_end_marker():
+    holder = object.__new__(ThinkingBudgetStateHolder)
+    holder.think_start_token_ids = [10, 11, 12]
+    holder.think_end_token_ids = [20, 21]
+    state = {
+        "output_tok_ids": [1, 2, 20, 21, 10, 11],
+        "end_thinking": 2,
+        "thinking_token_budget": 32,
+        "in_think": True,
+        "think_count": 7,
+        "continue_thinking": False,
+        "start_thinking": 0,
+    }
+
+    holder._reset_after_thinking_block(state)
+
+    # Keep the two-token prefix of the next <think> marker, but start after
+    # the completed </think> marker so it cannot be rediscovered.
+    assert state["scan_offset"] == 4
+    assert state["prev_output_length"] == len(state["output_tok_ids"])
+    assert state["start_thinking"] == -1
+    assert state["end_thinking"] == -1
+

--- a/vllm/v1/sample/thinking_budget_state.py
+++ b/vllm/v1/sample/thinking_budget_state.py
@@ -185,6 +185,57 @@ class ThinkingBudgetStateHolder:
                 return i
         return -1
 
+    @staticmethod
+    def _longest_marker_prefix_suffix(
+        output_tokens: list[int], marker_tokens: list[int]
+    ) -> int:
+        """Return the marker prefix retained at the end of ``output_tokens``.
+
+        A multi-token ``<think>`` marker can be split across two accepted
+        batches.  Keep enough of its prefix in the next scan window so the
+        completed marker is still recognized.
+        """
+        max_overlap = min(len(output_tokens), max(len(marker_tokens) - 1, 0))
+        for overlap in range(max_overlap, 0, -1):
+            if output_tokens[-overlap:] == marker_tokens[:overlap]:
+                return overlap
+        return 0
+
+    def _reset_after_thinking_block(self, state: dict[str, Any]) -> None:
+        """Reset block-local state without losing a marker split at the edge."""
+        output_tokens = state.get("output_tok_ids", [])
+        output_length = len(output_tokens)
+        start_overlap = self._longest_marker_prefix_suffix(
+            output_tokens, self.think_start_token_ids
+        )
+
+        # Do not move the scan window back into the completed end marker when
+        # retaining a prefix of a following start marker.  Otherwise the old
+        # ``</think>`` can be rediscovered as the next block's end marker.
+        previous_end = state.get("end_thinking", -1)
+        end_boundary = (
+            previous_end + len(self.think_end_token_ids)
+            if previous_end >= 0
+            else 0
+        )
+
+        state.update(
+            {
+                "in_think": False,
+                "think_count": 0,
+                "continue_thinking": False,
+                "start_thinking": -1,
+                "end_thinking": -1,
+                "scan_offset": max(
+                    end_boundary, output_length - start_overlap
+                ),
+                # The end marker and any non-thinking gap are not part of the
+                # next block's budget delta.
+                "prev_output_length": output_length,
+                "check_count_down": state["thinking_token_budget"],
+            }
+        )
+
     def _init_state_entry(
         self, prompt_tok_ids: list[int] | None, thinking_token_budget: int
     ) -> dict[str, Any]:
@@ -241,6 +292,7 @@ class ThinkingBudgetStateHolder:
             "in_spec_mode": False,
             "bonus_token_forced": False,
             "continue_thinking": continue_thinking,
+            "scan_offset": 0,
         }
 
     def _update_think_state(self, state: dict[str, Any]) -> None:
@@ -253,15 +305,36 @@ class ThinkingBudgetStateHolder:
             return
 
         if state["start_thinking"] == -1:
+            scan_offset = state.get("scan_offset", 0)
+            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             start_thinking = self._find_last_sequence_index(
-                state.get("output_tok_ids", []), self.think_start_token_ids
+                output_slice, self.think_start_token_ids
             )
+            if start_thinking >= 0:
+                start_thinking += scan_offset
             state["start_thinking"] = start_thinking
         if state["end_thinking"] == -1:
+            scan_offset = state.get("scan_offset", 0)
+            output_slice = state.get("output_tok_ids", [])[scan_offset:]
             end_thinking = self._find_last_sequence_index(
-                state.get("output_tok_ids", []), self.think_end_token_ids
+                output_slice, self.think_end_token_ids
             )
+            if end_thinking >= 0:
+                end_thinking += scan_offset
             state["end_thinking"] = end_thinking
+
+        # A natural </think> ends the current block. Reset the scan window so
+        # a later <think> block cannot reuse the first block's offsets or
+        # silently escape the request budget.
+        if (
+            not state.get("in_end", False)
+            and state["start_thinking"] >= 0
+            and state["end_thinking"] >= 0
+            and state["end_thinking"] > state["start_thinking"]
+            and not state.get("continue_thinking", False)
+        ):
+            self._reset_after_thinking_block(state)
+            return
 
         if state["start_thinking"] == -1:
             return
@@ -285,10 +358,14 @@ class ThinkingBudgetStateHolder:
         predicted_countdown = current_step_countdown - len(state["spec_token_ids"]) - 1
         # We only proceed further if we have counted down the thinking budget
         # to 0 or less and when we are in the "in think" mode.
+        natural_end_with_continue = (
+            state.get("continue_thinking", False) and state["end_thinking"] != -1
+        )
         if (
             not state.get("in_end", False)
             and predicted_countdown >= 0
             and state["start_thinking"] > -1
+            and not natural_end_with_continue
         ):
             state["check_count_down"] = current_step_countdown
             state["prev_output_length"] = len(state.get("output_tok_ids", []))
@@ -358,8 +435,7 @@ class ThinkingBudgetStateHolder:
                     state["think_count"] = new_think_count
                 else:
                     # Case: ...<start>...<end>... - exiting think mode
-                    state["in_think"] = False
-                    state["think_count"] = 0
+                    self._reset_after_thinking_block(state)
 
             elif absolute_start_pos >= 0 and not state["continue_thinking"]:
                 # Found think start - entering think mode
@@ -369,8 +445,7 @@ class ThinkingBudgetStateHolder:
 
             elif absolute_end_pos >= 0:
                 # Found think end - exiting think mode
-                state["in_think"] = False
-                state["think_count"] = 0
+                self._reset_after_thinking_block(state)
 
             elif state["in_think"]:
                 # Continue thinking mode, increment count by new tokens
@@ -440,13 +515,9 @@ class ThinkingBudgetStateHolder:
                 state["end_count"] += 1
                 state["force_index"] = [0]
             if state["end_count"] >= len(self.think_end_token_ids):
-                state.update(
-                    {
-                        "in_end": False,
-                        "end_count": 0,
-                        "check_count_down": state["thinking_token_budget"],
-                    }
-                )
+                state["in_end"] = False
+                state["end_count"] = 0
+                self._reset_after_thinking_block(state)
 
     def _apply_forcing_to_logits(
         self,


### PR DESCRIPTION
## Summary

This focused PR fixes Qwen3.8-27B reasoning-budget state tracking when a natural </think> transition and the prefix of a later multi-token <think> marker arrive in the same accepted batch.

## Changes

- Preserve the longest incomplete <think> marker prefix when advancing the incremental scan window.
- Keep the scan start after the completed </think> marker so the previous end marker is not rediscovered.
- Refresh prev_output_length on every reasoning-block reset, preventing end-marker/non-thinking tokens from being charged to the next block's budget.
- Cover the split-marker boundary with a focused unit test.

This is intentionally limited to Qwen reasoning-state handling. CPU KV offload and Mamba/MTP cache changes are in separate PRs as requested.

## Validation

- Python compilation of modified files passed.
- git diff --check passed.
- Full pytest was not available in the local Windows environment (pytest is not installed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds Qwen3.8-27B reasoning blocks when a natural </think> and the prefix of the next multi-token <think> land in the same accepted batch. Previously we advanced the scan window past the split start marker and could re-detect the prior </think>, miscounting budget; now we retain the longest start-marker prefix and move the scan start past the completed </think> so each block is charged correctly.

- Preserve the longest incomplete `<think>` prefix at the edge of the scan and set `scan_offset` after the completed `</think>`.
- Reset `prev_output_length` and countdown at block boundaries so end-marker and non-thinking gaps don’t bill the next block.
- Respect natural end-of-block even when continuing from prompt; keep logits forcing behavior and APIs unchanged.
- Add a focused unit test for the split-marker boundary.

<sup>Written for commit 45b3b2ec4181d958dddaa42862419df4093646a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

