### PR TITLE
feat: int8 per-tensor KV cache with FlashInfer dequant bridge (SM75)

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -28,6 +28,7 @@ CacheDType = Literal[
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
     "turboquant_3bit_nc",
+    "int8_per_tensor",  # [FORK-PORT] PR#41505 symmetric int8 per-tensor KV
     "int8_per_token_head",
     "fp8_per_token_head",
     "nvfp4",
@@ -256,6 +257,13 @@ class CacheConfig:
                 "memory footprint and boosts the performance. "
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
+            )
+        elif cache_dtype == "int8_per_tensor":  # [FORK-PORT] PR#41505
+            logger.info(
+                "Using int8_per_tensor data type to store kv cache. "
+                "It reduces the GPU memory footprint and boosts the "
+                "performance. Meanwhile, it may cause accuracy drop "
+                "without a proper scaling factor",
             )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -258,13 +258,6 @@ class CacheConfig:
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
             )
-        elif cache_dtype == "int8_per_tensor":  # [FORK-PORT] PR#41505
-            logger.info(
-                "Using int8_per_tensor data type to store kv cache. "
-                "It reduces the GPU memory footprint and boosts the "
-                "performance. Meanwhile, it may cause accuracy drop "
-                "without a proper scaling factor",
-            )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(
                 "Using %s data type to store kv cache. It reduces the GPU "

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -159,13 +159,11 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
-    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
-        # [FORK-PORT] PR#41505: symmetric quantization range for int8_per_tensor
-        # is +-127 (fp8 defaults to envs K/V_SCALE_CONSTANT=200/100; int8 must
-        # use 127). Enforced again after quant weight loading below in case a
-        # checkpoint ships fp8-style k/v_scale values.
-        layer.k_range.fill_(127.0)
-        layer.v_range.fill_(127.0)
+    # [FORK-PORT] PR#41505: int8_per_tensor uses a symmetric range of +-127,
+    # which set_default_quant_scales already initializes (fp8 defaults to envs
+    # K/V_SCALE_CONSTANT=200/100). The range is re-asserted after
+    # create_weights below in case a checkpoint ships fp8-style k/v_scale
+    # values (review #106 round 7 P3).
 
     # The output scale on host memory. This should be the input scale of
     # the quant op after this attention layer.
@@ -533,7 +531,7 @@ class Attention(nn.Module, AttentionLayerBase):
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
-            if k_absmax == 0.0 or v_absmax == 0.0:
+            if k_absmax == 0.0 and v_absmax == 0.0:
                 logger.debug(
                     "[FORK-INT8SCALE] %s skip zero-value calibration "
                     "(k_absmax=%.6f v_absmax=%.6f), waiting for real request",
@@ -543,9 +541,13 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         if self.kv_cache_dtype == "int8_per_tensor":
             # Reuse the k_absmax/v_absmax computed above instead of re-running
-            # two full reductions (review #106 round 6 P2).
-            self._k_scale.copy_(k_absmax / self.k_range)
-            self._v_scale.copy_(v_absmax / self.v_range)
+            # two full reductions (review #106 round 6 P2). Calibrate each
+            # tensor independently: a zero K (or V) keeps its previous scale
+            # while the nonzero one is calibrated (review #106 round 7 P2).
+            if k_absmax > 0.0:
+                self._k_scale.copy_(k_absmax / self.k_range)
+            if v_absmax > 0.0:
+                self._v_scale.copy_(v_absmax / self.v_range)
         else:
             self._k_scale.copy_(torch.abs(key).max() / self.k_range)
             self._v_scale.copy_(torch.abs(value).max() / self.v_range)
@@ -715,6 +717,15 @@ def maybe_calc_kv_scales(
                     "shape mismatch, falling back to unfiltered seq_lens_cpu",
                     layer_name, _is_prefilling.numel(), _seq_lens_cpu.numel(),
                 )
+            if _seq_lens_cpu is None:
+                # FlashInfer TRTLLM prefill has no seq_lens_cpu (the TRTLLM
+                # path keeps seq lengths on GPU only); its seq_lens covers
+                # prefill requests exclusively, which is exactly the
+                # population this gate wants (review #106 round 7 P1).
+                _seq_lens_t = getattr(getattr(_md, "prefill", None), "seq_lens",
+                                      None)
+                if _seq_lens_t is not None and _seq_lens_t.numel() > 0:
+                    _seq_lens_cpu = _seq_lens_t
         _max_seq_len = 0
         if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
             _max_seq_len = int(_seq_lens_cpu.max().item())

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -657,14 +657,14 @@ def maybe_calc_kv_scales(
     if torch.cuda.is_current_stream_capturing():
         return
 
-    # [FORK] int8_per_tensor: defer calibration until a real long prefill —
-    # a short first request (dummy/graph warmup) underestimates long-context
-    # ranges and clips later K/V values (review #106 P1, hybrid recurrent
-    # state garbage is nonzero so the zero-value check below cannot catch it).
-    # Keep calculate_kv_scales set so the next long request calibrates.
-    if query.shape[0] < 2048:
-        return
-
+    # [FORK] int8_per_tensor calibration runs on the first real eager prefill
+    # (the capture guard above already skipped dummy/graph-warmup runs).
+    # No query.shape[0] gate here: chunked prefill schedules long prompts in
+    # chunks smaller than 2048 tokens, and gating on chunk length would defer
+    # calibration forever (review #106). Short requests are CUDA-graph
+    # captured, so they also return at the guard above — calibration only
+    # happens on a genuine non-captured prefill. Other quantized KV dtypes
+    # (fp8 etc.) keep upstream first-forward calibration.
     self.calc_kv_scales(query, key, value)
 
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -565,8 +565,16 @@ class Attention(nn.Module, AttentionLayerBase):
                 self.layer_name, self._k_scale_float, self._v_scale_float,
                 k_absmax, v_absmax,
             )
-        # We only calculate the scales once
-        self.calculate_kv_scales = False
+        # We only calculate the scales once. If one tensor was still zero
+        # (its scale left at the default), keep calibration pending so a
+        # later nonzero value is not clipped by a stale 1.0 scale; only
+        # finish when both K and V have nonzero maxima (review #106 round 8
+        # P1).
+        if (
+            self.kv_cache_dtype != "int8_per_tensor"
+            or (k_absmax > 0.0 and v_absmax > 0.0)
+        ):
+            self.calculate_kv_scales = False
 
     def extra_repr(self) -> str:
         s = f"head_size={self.impl.head_size}"  # type: ignore

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -113,9 +113,18 @@ def set_default_quant_scales(layer: nn.Module, register_buffer: bool = False) ->
     layer._prob_scale_float = 1.0
 
     # Initialize q/k/v range constants used by calc_kv_scales
-    layer.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)
-    layer.k_range = torch.tensor(envs.K_SCALE_CONSTANT, dtype=torch.float32)
-    layer.v_range = torch.tensor(envs.V_SCALE_CONSTANT, dtype=torch.float32)
+    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        # [FORK-PORT] PR#41505: symmetric int8 quantization range is ±127,
+        # NOT the fp8 defaults (envs K/V_SCALE_CONSTANT = 200/100). Without
+        # this, process_weights_after_loading resets the ranges to 200/100
+        # before calibration and int8 K/V values clip (review #106 P1).
+        layer.q_range = torch.tensor(127.0, dtype=torch.float32)
+        layer.k_range = torch.tensor(127.0, dtype=torch.float32)
+        layer.v_range = torch.tensor(127.0, dtype=torch.float32)
+    else:
+        layer.q_range = torch.tensor(envs.Q_SCALE_CONSTANT, dtype=torch.float32)
+        layer.k_range = torch.tensor(envs.K_SCALE_CONSTANT, dtype=torch.float32)
+        layer.v_range = torch.tensor(envs.V_SCALE_CONSTANT, dtype=torch.float32)
 
 
 def _init_kv_cache_quant(
@@ -640,6 +649,20 @@ def maybe_calc_kv_scales(
     # calibrate.
     _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
     if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
+        return
+    # [FORK] FULL CUDA-graph capture passes cudagraph_runtime_mode=NONE, so the
+    # mode guard above is insufficient — detect an active stream capture instead
+    # (review #106 P1). torch.cuda.is_current_stream_capturing() is cheap and
+    # returns True only on the capturing stream.
+    if torch.cuda.is_current_stream_capturing():
+        return
+
+    # [FORK] int8_per_tensor: defer calibration until a real long prefill —
+    # a short first request (dummy/graph warmup) underestimates long-context
+    # ranges and clips later K/V values (review #106 P1, hybrid recurrent
+    # state garbage is nonzero so the zero-value check below cannot catch it).
+    # Keep calculate_kv_scales set so the next long request calibrates.
+    if query.shape[0] < 2048:
         return
 
     self.calc_kv_scales(query, key, value)

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -541,8 +541,14 @@ class Attention(nn.Module, AttentionLayerBase):
                 )
                 return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
-        self._k_scale.copy_(torch.abs(key).max() / self.k_range)
-        self._v_scale.copy_(torch.abs(value).max() / self.v_range)
+        if self.kv_cache_dtype == "int8_per_tensor":
+            # Reuse the k_absmax/v_absmax computed above instead of re-running
+            # two full reductions (review #106 round 6 P2).
+            self._k_scale.copy_(k_absmax / self.k_range)
+            self._v_scale.copy_(v_absmax / self.v_range)
+        else:
+            self._k_scale.copy_(torch.abs(key).max() / self.k_range)
+            self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
@@ -651,16 +657,16 @@ def maybe_calc_kv_scales(
     # calc_kv_scales contains .item() CPU sync, which triggers
     # cudaErrorStreamCaptureInvalidated during capture. Keep the flag until the
     # first real eager prefill (long chunk exceeds graph capture size) to
-    # calibrate.
-    _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
-    if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
-        return
-    # [FORK] FULL CUDA-graph capture passes cudagraph_runtime_mode=NONE, so the
-    # mode guard above is insufficient — detect an active stream capture instead
-    # (review #106 P1). torch.cuda.is_current_stream_capturing() is cheap and
-    # returns True only on the capturing stream.
-    if torch.cuda.is_current_stream_capturing():
-        return
+    # calibrate. Scoped to int8_per_tensor so other quantized KV dtypes (fp8
+    # etc.) keep upstream first-forward calibration timing (review #106 round
+    # 6 P2). The capture checks are only evaluated on the int8 path.
+    if self.kv_cache_dtype == "int8_per_tensor":
+        _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+        _in_cudagraph = (
+            _cudagraph_mode is not None and _cudagraph_mode.name != "NONE"
+        ) or torch.cuda.is_current_stream_capturing()
+        if _in_cudagraph:
+            return
 
     # [FORK] int8_per_tensor: defer calibration until a calibration-ready
     # prefill — the first execute_model runs with cudagraph_mode=NONE, so a
@@ -699,6 +705,16 @@ def maybe_calc_kv_scales(
                 and _is_prefilling.numel() == _seq_lens_cpu.numel()
             ):
                 _seq_lens_cpu = _seq_lens_cpu[_is_prefilling]
+            elif (
+                _seq_lens_cpu is not None
+                and _is_prefilling is not None
+                and _is_prefilling.numel() != _seq_lens_cpu.numel()
+            ):
+                logger.debug(
+                    "[FORK-INT8SCALE] %s is_prefilling(%d) vs seq_lens_cpu(%d) "
+                    "shape mismatch, falling back to unfiltered seq_lens_cpu",
+                    layer_name, _is_prefilling.numel(), _seq_lens_cpu.numel(),
+                )
         _max_seq_len = 0
         if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
             _max_seq_len = int(_seq_lens_cpu.max().item())

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -667,8 +667,20 @@ def maybe_calc_kv_scales(
     # calibration forever (review #106 P2). Other quantized KV dtypes (fp8
     # etc.) keep upstream first-forward calibration.
     if self.kv_cache_dtype == "int8_per_tensor":
+        # Resolve the per-layer metadata entry (mirror get_attention_context):
+        # forward_context.attn_metadata is dict[layer_name] or, for
+        # speculative decoding, list[dict[layer_name]]. Read the backend's
+        # actual per-request total sequence length (FIPrefill.seq_lens_cpu
+        # includes context, not just the current chunk).
         _md = getattr(forward_context, "attn_metadata", None)
-        _max_seq_len = getattr(getattr(_md, "prefill", None), "max_seq_len", 0)
+        if isinstance(_md, dict):
+            _md = _md.get(layer_name)
+        elif isinstance(_md, list) and _md:
+            _md = _md[0].get(layer_name)
+        _seq_lens_cpu = getattr(getattr(_md, "prefill", None), "seq_lens_cpu", None)
+        _max_seq_len = 0
+        if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
+            _max_seq_len = int(_seq_lens_cpu.max().item())
         if _max_seq_len < 2048:
             return
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,8 +150,8 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
-    # [FORK-PORT] PR#41505: int8_per_tensor 的对称量化范围是 ±127
-    # (fp8 默认用 envs K/V_SCALE_CONSTANT=200/100; int8 必须用 127)
+    # [FORK-PORT] PR#41505: symmetric quantization range for int8_per_tensor is ±127
+    # (fp8 defaults to envs K/V_SCALE_CONSTANT=200/100; int8 must use 127)
     if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
         layer.k_range.fill_(127.0)
         layer.v_range.fill_(127.0)
@@ -506,9 +506,11 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
-        # [FORK] int8_per_tensor: warmup/dummy 前向的 K/V 全零 → scale=0 垃圾缓存
-        # (hybrid #37554 实锤: 校准期 recurrent state 未初始化)。跳过零值校准,
-        # 保持 calculate_kv_scales 标志, 等第一个真实请求 (长 prefill) 再校准。
+        # [FORK] int8_per_tensor: warmup/dummy forward has all-zero K/V →
+        # scale=0 garbage cache (hybrid #37554 confirmed: recurrent state is
+        # uninitialized during calibration). Skip zero-value calibration, keep
+        # the calculate_kv_scales flag, and calibrate on the first real request
+        # (long prefill).
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
@@ -525,7 +527,7 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor 调试: 打印实际校准的 scale 值
+        # [FORK] int8_per_tensor debug: print the actually calibrated scales
         if self.kv_cache_dtype == "int8_per_tensor":
             print(
                 f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
@@ -624,9 +626,11 @@ def maybe_calc_kv_scales(
     if not self.calculate_kv_scales:
         return
 
-    # [FORK] int8_per_tensor: CUDA graph 捕获/回放期间跳过 — calc_kv_scales 里有
-    # .item() CPU 同步, 在 capture 中触发 cudaErrorStreamCaptureInvalidated。
-    # 标志保留到第一个真实 eager prefill (长 chunk 超图捕获尺寸) 再校准。
+    # [FORK] int8_per_tensor: skip during CUDA graph capture/replay —
+    # calc_kv_scales contains .item() CPU sync, which triggers
+    # cudaErrorStreamCaptureInvalidated during capture. Keep the flag until the
+    # first real eager prefill (long chunk exceeds graph capture size) to
+    # calibrate.
     _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
     if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
         return

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -678,6 +678,10 @@ def maybe_calc_kv_scales(
         elif isinstance(_md, list) and _md:
             _md = _md[0].get(layer_name)
         _seq_lens_cpu = getattr(getattr(_md, "prefill", None), "seq_lens_cpu", None)
+        if _seq_lens_cpu is None:
+            # Triton attention backend stores seq_lens_cpu on the metadata
+            # object itself rather than under .prefill (review #106).
+            _seq_lens_cpu = getattr(_md, "seq_lens_cpu", None)
         _max_seq_len = 0
         if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
             _max_seq_len = int(_seq_lens_cpu.max().item())

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -531,7 +531,12 @@ class Attention(nn.Module, AttentionLayerBase):
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
-            if k_absmax == 0.0 and v_absmax == 0.0:
+            if k_absmax == 0.0 or v_absmax == 0.0:
+                # All-or-nothing calibration: with either tensor still zero,
+                # update neither scale and wait for the next eligible batch
+                # (review #106 round 8 P1 — partial updates corrupt the cache
+                # because values written under the old scale would later be
+                # dequantized with the new one).
                 logger.debug(
                     "[FORK-INT8SCALE] %s skip zero-value calibration "
                     "(k_absmax=%.6f v_absmax=%.6f), waiting for real request",
@@ -541,13 +546,18 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         if self.kv_cache_dtype == "int8_per_tensor":
             # Reuse the k_absmax/v_absmax computed above instead of re-running
-            # two full reductions (review #106 round 6 P2). Calibrate each
-            # tensor independently: a zero K (or V) keeps its previous scale
-            # while the nonzero one is calibrated (review #106 round 7 P2).
-            if k_absmax > 0.0:
-                self._k_scale.copy_(k_absmax / self.k_range)
-            if v_absmax > 0.0:
-                self._v_scale.copy_(v_absmax / self.v_range)
+            # two full reductions (review #106 round 6 P2). Calibration is
+            # all-or-nothing: when one tensor is still zero, update neither
+            # scale and stay pending. Partially updating (round 8 P1) leaves
+            # the zero side at the default 1.0 while calibration finishes, so
+            # values already written to the cache under 1.0 are later
+            # dequantized with a different scale, corrupting prior context.
+            # A zero K (or V) on a real prefill is degenerate (both come from
+            # the same input projection), so waiting for the next batch is
+            # safe; both scales are calibrated together once both tensors
+            # have nonzero maxima.
+            self._k_scale.copy_(k_absmax / self.k_range)
+            self._v_scale.copy_(v_absmax / self.v_range)
         else:
             self._k_scale.copy_(torch.abs(key).max() / self.k_range)
             self._v_scale.copy_(torch.abs(value).max() / self.v_range)
@@ -565,16 +575,11 @@ class Attention(nn.Module, AttentionLayerBase):
                 self.layer_name, self._k_scale_float, self._v_scale_float,
                 k_absmax, v_absmax,
             )
-        # We only calculate the scales once. If one tensor was still zero
-        # (its scale left at the default), keep calibration pending so a
-        # later nonzero value is not clipped by a stale 1.0 scale; only
-        # finish when both K and V have nonzero maxima (review #106 round 8
-        # P1).
-        if (
-            self.kv_cache_dtype != "int8_per_tensor"
-            or (k_absmax > 0.0 and v_absmax > 0.0)
-        ):
-            self.calculate_kv_scales = False
+        # We only calculate the scales once. By the time we reach this point
+        # the all-or-nothing guard above has returned for any batch with a
+        # zero tensor, so both scales are freshly calibrated here and it is
+        # safe to finish (review #106 round 8 P1).
+        self.calculate_kv_scales = False
 
     def extra_repr(self) -> str:
         s = f"head_size={self.impl.head_size}"  # type: ignore

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,9 +150,11 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
-    # [FORK-PORT] PR#41505: symmetric quantization range for int8_per_tensor is ±127
-    # (fp8 defaults to envs K/V_SCALE_CONSTANT=200/100; int8 must use 127)
     if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        # [FORK-PORT] PR#41505: symmetric quantization range for int8_per_tensor
+        # is +-127 (fp8 defaults to envs K/V_SCALE_CONSTANT=200/100; int8 must
+        # use 127). Enforced again after quant weight loading below in case a
+        # checkpoint ships fp8-style k/v_scale values.
         layer.k_range.fill_(127.0)
         layer.v_range.fill_(127.0)
 
@@ -177,6 +179,12 @@ def _init_kv_cache_quant(
         # values after weight loading.
         layer.quant_method = quant_method
         layer.quant_method.create_weights(layer)
+    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        # [FORK-PORT] Re-assert the int8 symmetric range after quant weight
+        # loading: fp8-style checkpoints may carry k/v_scale weights that
+        # would otherwise overwrite the 127 range set above.
+        layer.k_range.fill_(127.0)
+        layer.v_range.fill_(127.0)
 
 
 class Attention(nn.Module, AttentionLayerBase):
@@ -515,10 +523,10 @@ class Attention(nn.Module, AttentionLayerBase):
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
             if k_absmax == 0.0 or v_absmax == 0.0:
-                print(
-                    f"[FORK-INT8SCALE] {self.layer_name} 跳过零值校准 "
-                    f"(k_absmax={k_absmax:.6f} v_absmax={v_absmax:.6f}), 等真实请求",
-                    flush=True,
+                logger.debug(
+                    "[FORK-INT8SCALE] %s skip zero-value calibration "
+                    "(k_absmax=%.6f v_absmax=%.6f), waiting for real request",
+                    self.layer_name, k_absmax, v_absmax,
                 )
                 return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
@@ -527,14 +535,13 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor debug: print the actually calibrated scales
+        # [FORK] int8_per_tensor debug: log the actually calibrated scales
         if self.kv_cache_dtype == "int8_per_tensor":
-            print(
-                f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
-                f"v_scale={self._v_scale_float:.6f} "
-                f"k_absmax={torch.abs(key).max().item():.4f} "
-                f"v_absmax={torch.abs(value).max().item():.4f}",
-                flush=True,
+            logger.debug(
+                "[FORK-INT8SCALE] %s k_scale=%.6f v_scale=%.6f "
+                "k_absmax=%.4f v_absmax=%.4f",
+                self.layer_name, self._k_scale_float, self._v_scale_float,
+                torch.abs(key).max().item(), torch.abs(value).max().item(),
             )
         # We only calculate the scales once
         self.calculate_kv_scales = False

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,6 +150,11 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
+    # [FORK-PORT] PR#41505: int8_per_tensor 的对称量化范围是 ±127
+    # (fp8 默认用 envs K/V_SCALE_CONSTANT=200/100; int8 必须用 127)
+    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        layer.k_range.fill_(127.0)
+        layer.v_range.fill_(127.0)
 
     # The output scale on host memory. This should be the input scale of
     # the quant op after this attention layer.
@@ -501,12 +506,34 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
+        # [FORK] int8_per_tensor: warmup/dummy 前向的 K/V 全零 → scale=0 垃圾缓存
+        # (hybrid #37554 实锤: 校准期 recurrent state 未初始化)。跳过零值校准,
+        # 保持 calculate_kv_scales 标志, 等第一个真实请求 (长 prefill) 再校准。
+        if self.kv_cache_dtype == "int8_per_tensor":
+            k_absmax = torch.abs(key).max().item()
+            v_absmax = torch.abs(value).max().item()
+            if k_absmax == 0.0 or v_absmax == 0.0:
+                print(
+                    f"[FORK-INT8SCALE] {self.layer_name} 跳过零值校准 "
+                    f"(k_absmax={k_absmax:.6f} v_absmax={v_absmax:.6f}), 等真实请求",
+                    flush=True,
+                )
+                return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         self._k_scale.copy_(torch.abs(key).max() / self.k_range)
         self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
+        # [FORK] int8_per_tensor 调试: 打印实际校准的 scale 值
+        if self.kv_cache_dtype == "int8_per_tensor":
+            print(
+                f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
+                f"v_scale={self._v_scale_float:.6f} "
+                f"k_absmax={torch.abs(key).max().item():.4f} "
+                f"v_absmax={torch.abs(value).max().item():.4f}",
+                flush=True,
+            )
         # We only calculate the scales once
         self.calculate_kv_scales = False
 
@@ -595,6 +622,13 @@ def maybe_calc_kv_scales(
     # Only calculate if the layer's calculate_kv_scales flag is True
     # This flag gets set to False after the first forward pass
     if not self.calculate_kv_scales:
+        return
+
+    # [FORK] int8_per_tensor: CUDA graph 捕获/回放期间跳过 — calc_kv_scales 里有
+    # .item() CPU 同步, 在 capture 中触发 cudaErrorStreamCaptureInvalidated。
+    # 标志保留到第一个真实 eager prefill (长 chunk 超图捕获尺寸) 再校准。
+    _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+    if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
         return
 
     self.calc_kv_scales(query, key, value)

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -523,11 +523,13 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
-        # [FORK] int8_per_tensor: warmup/dummy forward has all-zero K/V →
-        # scale=0 garbage cache (hybrid #37554 confirmed: recurrent state is
-        # uninitialized during calibration). Skip zero-value calibration, keep
-        # the calculate_kv_scales flag, and calibrate on the first real request
-        # (long prefill).
+        # [FORK] int8_per_tensor: warmup/dummy forward passes have all-zero K/V
+        # → scale=0 garbage cache (hybrid #37554 confirmed: recurrent state is
+        # uninitialized during calibration). Skip zero-value calibration and keep
+        # the calculate_kv_scales flag; calibrate on the first real request
+        # (long prefill) instead.
+        k_absmax = 0.0
+        v_absmax = 0.0
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
@@ -544,13 +546,16 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor debug: log the actually calibrated scales
+        # [FORK] int8_per_tensor debug: log the actually calibrated scales.
+        # k_absmax/v_absmax are already computed above for the zero-value
+        # check; reuse them instead of re-running two full reductions
+        # (logger.debug args are evaluated unconditionally, review #106 P3).
         if self.kv_cache_dtype == "int8_per_tensor":
             logger.debug(
                 "[FORK-INT8SCALE] %s k_scale=%.6f v_scale=%.6f "
                 "k_absmax=%.4f v_absmax=%.4f",
                 self.layer_name, self._k_scale_float, self._v_scale_float,
-                torch.abs(key).max().item(), torch.abs(value).max().item(),
+                k_absmax, v_absmax,
             )
         # We only calculate the scales once
         self.calculate_kv_scales = False
@@ -661,11 +666,14 @@ def maybe_calc_kv_scales(
     # prefill — the first execute_model runs with cudagraph_mode=NONE, so a
     # short first request (e.g. "12*8") would reach this point and freeze
     # undersized int8 scales, clipping larger K/V values later (review #106
-    # P1). Gate on the request's TOTAL sequence length (max_seq_len, includes
-    # context) instead of the chunk length: chunked prefill schedules long
-    # prompts in chunks < 2048 tokens, and gating on chunk length would defer
-    # calibration forever (review #106 P2). Other quantized KV dtypes (fp8
-    # etc.) keep upstream first-forward calibration.
+    # P1). Gate on a prefill request's TOTAL sequence length (max_seq_len,
+    # includes context) instead of the chunk length: chunked prefill schedules
+    # long prompts in chunks < 2048 tokens, and gating on chunk length would
+    # defer calibration forever (review #106 P2). Decode-only batches never
+    # calibrate (they carry no new prompt tokens), and in a mixed batch only
+    # the prefill rows' total lengths are considered (review #106 round 5 P1).
+    # Other quantized KV dtypes (fp8 etc.) keep upstream first-forward
+    # calibration.
     if self.kv_cache_dtype == "int8_per_tensor":
         # Resolve the per-layer metadata entry (mirror get_attention_context):
         # forward_context.attn_metadata is dict[layer_name] or, for
@@ -680,8 +688,17 @@ def maybe_calc_kv_scales(
         _seq_lens_cpu = getattr(getattr(_md, "prefill", None), "seq_lens_cpu", None)
         if _seq_lens_cpu is None:
             # Triton attention backend stores seq_lens_cpu on the metadata
-            # object itself rather than under .prefill (review #106).
+            # object itself rather than under .prefill (review #106). Restrict
+            # to prefill rows so an unrelated long decode in the same batch
+            # does not satisfy the gate (review #106 round 5 P1).
             _seq_lens_cpu = getattr(_md, "seq_lens_cpu", None)
+            _is_prefilling = getattr(_md, "is_prefilling", None)
+            if (
+                _seq_lens_cpu is not None
+                and _is_prefilling is not None
+                and _is_prefilling.numel() == _seq_lens_cpu.numel()
+            ):
+                _seq_lens_cpu = _seq_lens_cpu[_is_prefilling]
         _max_seq_len = 0
         if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
             _max_seq_len = int(_seq_lens_cpu.max().item())

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -657,14 +657,21 @@ def maybe_calc_kv_scales(
     if torch.cuda.is_current_stream_capturing():
         return
 
-    # [FORK] int8_per_tensor calibration runs on the first real eager prefill
-    # (the capture guard above already skipped dummy/graph-warmup runs).
-    # No query.shape[0] gate here: chunked prefill schedules long prompts in
-    # chunks smaller than 2048 tokens, and gating on chunk length would defer
-    # calibration forever (review #106). Short requests are CUDA-graph
-    # captured, so they also return at the guard above — calibration only
-    # happens on a genuine non-captured prefill. Other quantized KV dtypes
-    # (fp8 etc.) keep upstream first-forward calibration.
+    # [FORK] int8_per_tensor: defer calibration until a calibration-ready
+    # prefill — the first execute_model runs with cudagraph_mode=NONE, so a
+    # short first request (e.g. "12*8") would reach this point and freeze
+    # undersized int8 scales, clipping larger K/V values later (review #106
+    # P1). Gate on the request's TOTAL sequence length (max_seq_len, includes
+    # context) instead of the chunk length: chunked prefill schedules long
+    # prompts in chunks < 2048 tokens, and gating on chunk length would defer
+    # calibration forever (review #106 P2). Other quantized KV dtypes (fp8
+    # etc.) keep upstream first-forward calibration.
+    if self.kv_cache_dtype == "int8_per_tensor":
+        _md = getattr(forward_context, "attn_metadata", None)
+        _max_seq_len = getattr(getattr(_md, "prefill", None), "max_seq_len", 0)
+        if _max_seq_len < 2048:
+            return
+
     self.calc_kv_scales(query, key, value)
 
 

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -212,10 +212,12 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # See issue: https://github.com/vllm-project/vllm/issues/37554
 
         if cache_config.calculate_kv_scales:
-            # [FORK-PORT] PR#41505: int8_per_tensor 保留动态 scale。
-            # fp8 对 hybrid 禁用是 issue #37554 (校准期 recurrent state 未初始化
-            # 会污染 fp8 scale); int8 路径同样受此影响, 但测试需要真实 scale,
-            # 校准请求用真实长文本 prefill 来规避。fp8 维持官方禁用行为。
+            # [FORK-PORT] PR#41505: int8_per_tensor keeps dynamic scales.
+            # fp8 is disabled for hybrid due to issue #37554 (uninitialized
+            # recurrent state during calibration corrupts fp8 scales); the int8
+            # path is affected the same way, but tests need real scales, so
+            # calibration requests use real long-text prefills to work around
+            # it. fp8 keeps the official disabled behavior.
             if cache_config.cache_dtype == "int8_per_tensor":
                 logger.info(
                     "Keeping calculate_kv_scales for int8_per_tensor KV on "

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -212,15 +212,27 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # See issue: https://github.com/vllm-project/vllm/issues/37554
 
         if cache_config.calculate_kv_scales:
-            logger.warning(
-                "Disabling calculate_kv_scales for hybrid model '%s'. "
-                "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
-                "produce unreliable KV cache scales during the "
-                "calibration pass because recurrent state is "
-                "uninitialized. Using default scale of 1.0 instead.",
-                vllm_config.model_config.model,
-            )
-            cache_config.calculate_kv_scales = False
+            # [FORK-PORT] PR#41505: int8_per_tensor 保留动态 scale。
+            # fp8 对 hybrid 禁用是 issue #37554 (校准期 recurrent state 未初始化
+            # 会污染 fp8 scale); int8 路径同样受此影响, 但测试需要真实 scale,
+            # 校准请求用真实长文本 prefill 来规避。fp8 维持官方禁用行为。
+            if cache_config.cache_dtype == "int8_per_tensor":
+                logger.info(
+                    "Keeping calculate_kv_scales for int8_per_tensor KV on "
+                    "hybrid model '%s' (FORK-PORT PR#41505; calibrate on real "
+                    "long prefill).",
+                    vllm_config.model_config.model,
+                )
+            else:
+                logger.warning(
+                    "Disabling calculate_kv_scales for hybrid model '%s'. "
+                    "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
+                    "produce unreliable KV cache scales during the "
+                    "calibration pass because recurrent state is "
+                    "uninitialized. Using default scale of 1.0 instead.",
+                    vllm_config.model_config.model,
+                )
+                cache_config.calculate_kv_scales = False
 
         # Enable FULL_AND_PIECEWISE by default
         MambaModelConfig.verify_and_update_config(vllm_config)

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -39,6 +39,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
     "int8": torch.int8,
+    "int8_per_tensor": torch.int8,  # [FORK-PORT] PR#41505
     "int8_per_token_head": torch.int8,
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
@@ -76,6 +77,8 @@ PIN_MEMORY = "microsoft" not in " ".join(platform.uname()).lower()
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
+        # [FORK-PORT] PR#41505: int8_per_tensor 也是量化 KV (torch_utils 版)
+        or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"
     )

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -77,7 +77,8 @@ PIN_MEMORY = "microsoft" not in " ".join(platform.uname()).lower()
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
-        # [FORK-PORT] PR#41505: int8_per_tensor 也是量化 KV (torch_utils 版)
+        # [FORK-PORT] PR#41505: int8_per_tensor is also a quantized KV cache
+        # (torch_utils variant)
         or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -191,8 +191,15 @@ class FlashAttentionBackend(AttentionBackend):
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is None:
             return True
-        if is_quantized_kv_cache(kv_cache_dtype):
+        if kv_cache_dtype.startswith("fp8") or kv_cache_dtype == "nvfp4":
             return flash_attn_supports_fp8()
+        if is_quantized_kv_cache(kv_cache_dtype):
+            # [FORK-PORT] PR#41505: int8_per_tensor (and int8 per-token-head)
+            # are NOT supported by FlashAttention kernels. They would be
+            # misrouted to the FP8 path and hit ValueError in
+            # get_fp8_dtype_for_flashattn. Restrict backend selection to
+            # int8-aware implementations (FlashInfer/Triton).
+            return False
         return kv_cache_dtype in ["auto", "float16", "bfloat16"]
 
     @classmethod

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -336,8 +336,9 @@ class FlashInferBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "nvfp4",
-        # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支, 在 forward 里
-        # 反量化成 fp16 临时 buffer 再喂内核 (KV 存储仍减半, 反量化开销 ~带宽)
+        # [FORK] int8_per_tensor: FlashInfer kernels have no int8 path, so we
+        # dequantize to a temporary fp16 buffer in forward before feeding the
+        # kernel (KV storage is still halved; dequantization is ~bandwidth-bound)
         "int8_per_tensor",
     ]
 
@@ -632,9 +633,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
             if self.cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: FlashInfer 0.6.8 内核无 int8 分支,
-                # forward 里反量化成 fp16 临时 buffer 再喂内核; 这里告知
-                # FlashInfer 数据是 fp16 (plan 的 kv_data_type)。
+                # [FORK] int8_per_tensor: FlashInfer 0.6.8 kernels have no int8
+                # path; we dequantize to a temporary fp16 buffer in forward
+                # before feeding the kernel; tell FlashInfer the data is fp16
+                # here (the plan's kv_data_type).
                 self.kv_cache_dtype = torch.float16
             elif self.is_kvcache_nvfp4:
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
@@ -1292,7 +1294,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
-    # [FORK] int8_per_tensor 未校准警告去重 (按层记录, 每层最多一次)
+    # [FORK] int8_per_tensor: dedupe uncalibrated warnings (tracked per layer,
+    # at most once per layer)
     _warned_uncalibrated_layers: set = set()
 
     def __init__(
@@ -1428,10 +1431,12 @@ class FlashInferImpl(AttentionImpl):
             f"got {query.dtype}"
         )
 
-        # [FORK] int8_per_tensor 走反量化路径 (数据已含 scale), 不折叠进 bmm
+        # [FORK] int8_per_tensor: use the dequantized path (data already
+        # includes scale), do not fold into bmm
         _is_int8_dequant = self.kv_cache_dtype == "int8_per_tensor"
-        # [FORK] int8_per_tensor: KV 已反量化为 fp16 真实值, 不能再传
-        # k_scale/v_scale 给 FlashInfer (否则双重 scale 导致乱码)
+        # [FORK] int8_per_tensor: KV has already been dequantized to real fp16
+        # values, so k_scale/v_scale must NOT be passed to FlashInfer (double
+        # scaling corrupts the output)
         _kv_scale = (1.0, 1.0) if _is_int8_dequant else (
             layer._k_scale_float, layer._v_scale_float)
         if self.bmm1_scale is None:
@@ -1498,17 +1503,23 @@ class FlashInferImpl(AttentionImpl):
             self.kv_cache_dtype
         ):
             if self.kv_cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
-                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
-                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
-                # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
-                # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
-                # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                # [FORK] int8_per_tensor: FlashInfer kernels have no int8 path
+                # (0.6.8 lists it in the enum but has no template; feeding int8
+                # directly causes illegal address). Dequantize to a temporary
+                # fp16 buffer (separate K/V scales); storage remains int8 and
+                # halved.
+                # Note: must use the tensor _k_scale/_v_scale (graph inputs,
+                # replay reads the calibrated values); using _k_scale_float
+                # (Python float) gets folded into a constant at CUDA graph
+                # capture (uncalibrated = 1.0 at startup) → wrong data on
+                # replay.
                 if layer._k_scale_float == 1.0:
-                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
-                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
-                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
+                    # [FORK] when the first request is short (<2048 tokens,
+                    # fully covered by CUDA graph), calibration is skipped
+                    # (calc_kv_scales zero-value skip + graph-mode return) and
+                    # scale stays 1.0 → data corruption. Dedupe per layer (at
+                    # most once per layer) to avoid spamming during graph
+                    # capture while still showing the hint on real requests.
                     if layer.layer_name not in \
                             FlashInferImpl._warned_uncalibrated_layers:
                         logger.warning(
@@ -1519,10 +1530,13 @@ class FlashInferImpl(AttentionImpl):
                         FlashInferImpl._warned_uncalibrated_layers.add(
                             layer.layer_name
                         )
-                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
-                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
-                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
-                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
+                # Dequantization (per-layer temporary allocation, naturally
+                # freed as layers execute serially; measured peak ~700MB per
+                # layer, verified with 256K context). Tensor scales are graph
+                # inputs, replay reads the calibrated values; using
+                # _k_scale_float (Python float) gets folded into a constant at
+                # CUDA graph capture (uncalibrated = 1.0 at startup) → wrong
+                # data on replay.
                 _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
                     torch.float16
                 )
@@ -1918,8 +1932,9 @@ class FlashInferImpl(AttentionImpl):
             k_cache = kv_cache[:, 0]
             v_cache = kv_cache[:, 1]
             if self.kv_cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash 无 int8
-                # 分支, 改用 Triton 版 (与 TRITON_ATTN 后端同款, 支持 int8+scale)
+                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash has no
+                # int8 path; use the Triton version instead (same as the
+                # TRITON_ATTN backend, supports int8 + scale)
                 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
                     triton_reshape_and_cache_flash,
                 )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,6 +1292,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
+    # [FORK] int8_per_tensor 未校准警告去重标志
+    _warned_uncalibrated = False
+
     def __init__(
         self,
         num_heads: int,
@@ -1501,6 +1504,21 @@ class FlashInferImpl(AttentionImpl):
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                if layer._k_scale_float == 1.0:
+                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
+                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
+                    # scale 保持 1.0 → 数据错误。每层只提示一次。
+                    if not FlashInferImpl._warned_uncalibrated:
+                        logger.warning(
+                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
+                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            layer.layer_name,
+                        )
+                        FlashInferImpl._warned_uncalibrated = True
+                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
+                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
+                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
+                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
                 _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
                     torch.float16
                 )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -292,11 +292,12 @@ class BatchDCPPrefillWrapper:
         prefill_query_across_dcp = get_dcp_group().all_gather(
             prefill_query.contiguous(), dim=1
         )
+        _is_i8 = getattr(layer, "kv_cache_dtype", "") == "int8_per_tensor"
         output_context_tmp, lse_context_tmp = self._context.run(
             prefill_query_across_dcp,
             kv_cache_permute,
-            k_scale=layer._k_scale_float,
-            v_scale=layer._v_scale_float,
+            k_scale=(1.0 if _is_i8 else layer._k_scale_float),
+            v_scale=(1.0 if _is_i8 else layer._v_scale_float),
             return_lse=True,
         )
         output_context, lse_context = self._dcp_combine(
@@ -335,6 +336,9 @@ class FlashInferBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "nvfp4",
+        # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支, 在 forward 里
+        # 反量化成 fp16 临时 buffer 再喂内核 (KV 存储仍减半, 反量化开销 ~带宽)
+        "int8_per_tensor",
     ]
 
     @staticmethod
@@ -627,7 +631,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
-            if self.is_kvcache_nvfp4:
+            if self.cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 0.6.8 内核无 int8 分支,
+                # forward 里反量化成 fp16 临时 buffer 再喂内核; 这里告知
+                # FlashInfer 数据是 fp16 (plan 的 kv_data_type)。
+                self.kv_cache_dtype = torch.float16
+            elif self.is_kvcache_nvfp4:
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
                 # which is passed to FlashInferImpl
                 self.kv_cache_dtype = self.cache_dtype
@@ -1416,14 +1425,20 @@ class FlashInferImpl(AttentionImpl):
             f"got {query.dtype}"
         )
 
+        # [FORK] int8_per_tensor 走反量化路径 (数据已含 scale), 不折叠进 bmm
+        _is_int8_dequant = self.kv_cache_dtype == "int8_per_tensor"
+        # [FORK] int8_per_tensor: KV 已反量化为 fp16 真实值, 不能再传
+        # k_scale/v_scale 给 FlashInfer (否则双重 scale 导致乱码)
+        _kv_scale = (1.0, 1.0) if _is_int8_dequant else (
+            layer._k_scale_float, layer._v_scale_float)
         if self.bmm1_scale is None:
             self.bmm1_scale = self.scale
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
 
         if self.bmm2_scale is None:
             self.bmm2_scale = 1.0
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm2_scale *= layer._v_scale_float
 
         prefill_use_trtllm = isinstance(attn_metadata.prefill, TRTLLMPrefill)
@@ -1479,10 +1494,25 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
-            torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
-                self.kv_cache_dtype
-            )
-            kv_cache = kv_cache.view(torch_dtype)
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
+                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
+                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
+                # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
+                # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
+                # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
+                    torch.float16
+                )
+                _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
+                    torch.float16
+                )
+                kv_cache = torch.stack((_k, _v), dim=1)
+            else:
+                torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                    self.kv_cache_dtype
+                )
+                kv_cache = kv_cache.view(torch_dtype)
 
         # Inputs and outputs may be padded for CUDA graphs
         query = query[:num_actual_tokens]
@@ -1595,8 +1625,8 @@ class FlashInferImpl(AttentionImpl):
                     prefill_wrapper.run(
                         prefill_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_prefill,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1746,8 +1776,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=output_tmp,
                         lse=lse,
                         return_lse=True,
@@ -1762,8 +1792,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_decode,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1865,16 +1895,33 @@ class FlashInferImpl(AttentionImpl):
             # actual tokens.
             k_cache = kv_cache[:, 0]
             v_cache = kv_cache[:, 1]
-            torch.ops._C_cache_ops.reshape_and_cache_flash(
-                key,
-                value,
-                k_cache,
-                v_cache,
-                slot_mapping,
-                self.kv_cache_dtype,
-                layer._k_scale,
-                layer._v_scale,
-            )
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash 无 int8
+                # 分支, 改用 Triton 版 (与 TRITON_ATTN 后端同款, 支持 int8+scale)
+                from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+                    triton_reshape_and_cache_flash,
+                )
+                triton_reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
+            else:
+                torch.ops._C_cache_ops.reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
 
 
 def fast_plan_decode(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,8 +1292,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
-    # [FORK] int8_per_tensor 未校准警告去重标志
-    _warned_uncalibrated = False
+    # [FORK] int8_per_tensor 未校准警告去重 (按层记录, 每层最多一次)
+    _warned_uncalibrated_layers: set = set()
 
     def __init__(
         self,
@@ -1507,14 +1507,18 @@ class FlashInferImpl(AttentionImpl):
                 if layer._k_scale_float == 1.0:
                     # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
                     # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。每层只提示一次。
-                    if not FlashInferImpl._warned_uncalibrated:
+                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
+                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
+                    if layer.layer_name not in \
+                            FlashInferImpl._warned_uncalibrated_layers:
                         logger.warning(
-                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
-                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
+                            "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
                             layer.layer_name,
                         )
-                        FlashInferImpl._warned_uncalibrated = True
+                        FlashInferImpl._warned_uncalibrated_layers.add(
+                            layer.layer_name
+                        )
                 # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
                 # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
                 # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -297,6 +297,7 @@ class TritonAttentionMetadata:
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
     num_computed_tokens_cpu: torch.Tensor | None
+    is_prefilling: torch.Tensor | None
 
     seq_threshold_3D: int
     num_par_softmax_segments: int
@@ -489,6 +490,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             block_table=block_table_tensor,
             slot_mapping=slot_mapping,
             num_computed_tokens_cpu=num_computed_tokens_cpu,
+            is_prefilling=common_attn_metadata.is_prefilling,
             use_cascade=use_cascade,
             common_prefix_len=common_prefix_len,
             cu_prefix_query_lens=cu_prefix_query_lens,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -1828,7 +1828,8 @@ class TritonAttentionImpl(AttentionImpl):
             key_cache, value_cache = kv_cache.unbind(1)
             if (
                 is_quantized_kv_cache(self.kv_cache_dtype)
-                # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8, 无需 fp8 view
+                # [FORK-PORT] PR#41505: int8_per_tensor is already int8,
+                # no fp8 view needed
                 and self.kv_cache_dtype != "int8_per_tensor"
             ):
                 if key_cache.dtype != self.fp8_dtype:
@@ -1998,7 +1999,7 @@ class TritonAttentionImpl(AttentionImpl):
         key_cache, value_cache = kv_cache.unbind(1)
         if (
             is_quantized_kv_cache(self.kv_cache_dtype)
-            # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8
+            # [FORK-PORT] PR#41505: int8_per_tensor is already int8
             and self.kv_cache_dtype != "int8_per_tensor"
         ):
             key_cache = key_cache.view(self.fp8_dtype)

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -517,6 +517,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "int8_per_tensor",  # [FORK-PORT] PR#41505
         "int8_per_token_head",
         "fp8_per_token_head",
     ]
@@ -1822,10 +1823,14 @@ class TritonAttentionImpl(AttentionImpl):
             v_descale = None
             k_scale_cache = self._k_scale_cache
             v_scale_cache = self._v_scale_cache
-        # FP8 per-tensor / auto path (original flow).
+        # FP8 per-tensor / INT8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if (
+                is_quantized_kv_cache(self.kv_cache_dtype)
+                # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8, 无需 fp8 view
+                and self.kv_cache_dtype != "int8_per_tensor"
+            ):
                 if key_cache.dtype != self.fp8_dtype:
                     key_cache = key_cache.view(self.fp8_dtype)
                     value_cache = value_cache.view(self.fp8_dtype)
@@ -1991,7 +1996,11 @@ class TritonAttentionImpl(AttentionImpl):
             return
         # For decoder and cross-attention, use KV cache as before.
         key_cache, value_cache = kv_cache.unbind(1)
-        if is_quantized_kv_cache(self.kv_cache_dtype):
+        if (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8
+            and self.kv_cache_dtype != "int8_per_tensor"
+        ):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
         triton_reshape_and_cache_flash(

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -38,6 +38,10 @@ def reshape_and_cache_kernel_flash(
     USE_HEAD_MAJOR_LAYOUT: tl.constexpr,
     # FP8 flags
     FP8_KV_CACHE: tl.constexpr,
+    # [FORK-PORT] PR#41505: INT8 per-tensor flag + platform flags
+    INT8_KV_CACHE: tl.constexpr,
+    IS_ROCM: tl.constexpr,
+    IS_CUDA: tl.constexpr,
     # tune parameters
     TILE_SIZE: tl.constexpr,
 ):
@@ -90,7 +94,18 @@ def reshape_and_cache_kernel_flash(
     key_load = tl.load(
         key_ptr + src_key_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        k_scale_val = tl.load(k_scale)
+        k_scaled = key_load.to(tl.float32) / k_scale_val
+        if IS_ROCM:
+            k_rounded = tl.extra.hip.libdevice.nearbyint(k_scaled)
+        elif IS_CUDA:
+            k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
+        else:
+            k_rounded = tl.floor(k_scaled + 0.5)
+        key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,
         # based on the key_cache_ptr.dtype.element_ty
         key_tile = key_load if key_load.dtype.is_fp8() else key_load / tl.load(k_scale)
@@ -101,7 +116,18 @@ def reshape_and_cache_kernel_flash(
     value_load = tl.load(
         value_ptr + src_value_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        v_scale_val = tl.load(v_scale)
+        v_scaled = value_load.to(tl.float32) / v_scale_val
+        if IS_ROCM:
+            v_rounded = tl.extra.hip.libdevice.nearbyint(v_scaled)
+        elif IS_CUDA:
+            v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
+        else:
+            v_rounded = tl.floor(v_scaled + 0.5)
+        value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():
             value_tile = value_load
         else:
@@ -353,14 +379,20 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    kv_cache_torch_dtype = (
-        current_platform.fp8_dtype()
-        if is_quantized_kv_cache(kv_cache_dtype)
-        else key_cache.dtype
-    )
+    # [FORK-PORT] PR#41505: int8_per_tensor 走 torch.int8, 不做 fp8 view
+    is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
+    is_int8 = kv_cache_dtype.startswith("int8")
+    if is_int8:
+        kv_cache_torch_dtype = torch.int8
+    elif is_quantized_kv_cache(kv_cache_dtype):
+        kv_cache_torch_dtype = current_platform.fp8_dtype()
+    else:
+        kv_cache_torch_dtype = key_cache.dtype
 
-    if key_cache.dtype != kv_cache_torch_dtype and is_quantized_kv_cache(
-        kv_cache_dtype
+    if (
+        not is_int8
+        and key_cache.dtype != kv_cache_torch_dtype
+        and is_quantized_kv_cache(kv_cache_dtype)
     ):
         # to avoid erounous implicit cast in triton kernel (tl.store to uint8)
         # (e.g. explicit cast to fp8e4m3fnuz is not supported in triton 3.4)
@@ -371,7 +403,8 @@ def triton_reshape_and_cache_flash(
         "uint8 is not supported by triton reshape_and_cache_flash"
     )
 
-    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype)
+    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype) and not is_int8
+    INT8_KV_CACHE = is_int8_per_tensor
     assert (not FP8_KV_CACHE) or kv_cache_torch_dtype in [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -379,8 +412,8 @@ def triton_reshape_and_cache_flash(
         torch.float8_e4m3fnuz,
     ], (
         "unsupported dtype of KV cache tensor, got "
-        "{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
-        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz."
+        f"{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
+        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz, int8."
     )
 
     # heuristics instead of autotuning
@@ -423,6 +456,10 @@ def triton_reshape_and_cache_flash(
         x=x,
         USE_HEAD_MAJOR_LAYOUT=use_head_major_layout,
         FP8_KV_CACHE=FP8_KV_CACHE,
+        # [FORK-PORT] PR#41505
+        INT8_KV_CACHE=INT8_KV_CACHE,
+        IS_ROCM=current_platform.is_rocm(),
+        IS_CUDA=current_platform.is_cuda(),
         # autotune parameters
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -379,7 +379,7 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    # [FORK-PORT] PR#41505: int8_per_tensor 走 torch.int8, 不做 fp8 view
+    # [FORK-PORT] PR#41505: int8_per_tensor uses torch.int8, no fp8 view
     is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
     is_int8 = kv_cache_dtype.startswith("int8")
     if is_int8:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -46,11 +46,16 @@ def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
       their scales separately on S/P inside the loop.
     - ``KV_QUANT_MODE == 1`` (FP8 per-tensor): dequantize using the
       tensor-wide scale.
+    - ``KV_QUANT_MODE == 5`` (INT8 per-tensor): plain cast.  Scale applied
+      post-matmul via folding into softmax_scale / acc.  [FORK-PORT] PR#41505
     """
     if KV_QUANT_MODE == 1:
         if Q.dtype.is_fp8():
             return data.to(Q.dtype)
         return (data.to(tl.float32) * tl.load(tensor_scale)).to(Q.dtype)
+    if KV_QUANT_MODE == 5:
+        # INT8 per-tensor: plain cast, scale folded into S and acc post-matmul
+        return data.to(Q.dtype)
     return data.to(Q.dtype)
 
 
@@ -131,7 +136,7 @@ def kernel_unified_attention(
     IS_3D: tl.constexpr,
     # KV cache quantization mode handled inside this kernel via constexpr
     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
-    # FP8_PER_TOKEN_HEAD (3).
+    # FP8_PER_TOKEN_HEAD (3), INT8_PER_TENSOR (5).  [FORK-PORT] PR#41505
     KV_QUANT_MODE: tl.constexpr = 0,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
@@ -141,7 +146,10 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
+    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) 不是 per-token-head
+    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
+        KV_QUANT_MODE == 3
+    )
 
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -227,6 +235,13 @@ def kernel_unified_attention(
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
     )
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — fold k_scale into softmax
+    # scale (zero inner-loop overhead), apply v_scale once post-loop
+    if KV_QUANT_MODE == 5:
+        int8_k_scale_val = tl.load(k_scale)
+        int8_v_scale_val = tl.load(v_scale)
+        scale = scale * int8_k_scale_val
 
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
@@ -338,6 +353,10 @@ def kernel_unified_attention(
             acc += tl.dot(P_v, V)
         else:
             acc += tl.dot(P.to(V.dtype), V)
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — apply v_scale once on output
+    if KV_QUANT_MODE == 5:
+        acc = acc * int8_v_scale_val
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -146,7 +146,7 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) 不是 per-token-head
+    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) is not per-token-head
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
         KV_QUANT_MODE == 3
     )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -47,7 +47,8 @@ class KVQuantMode(IntEnum):
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
     # [FORK-PORT] PR#41505 int8_per_tensor: 5 = symmetric INT8 per-tensor scale KV
-    # (原生 int→float 转换, sm_75 无 FP8 硬件时唯一 8bit KV 路径; 上游未合并, 见研究文档)
+    # (native int→float conversion, the only 8-bit KV path on sm_75 without FP8
+    # hardware; not merged upstream, see research docs)
     INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -46,6 +46,9 @@ class KVQuantMode(IntEnum):
     INT8_PER_TOKEN_HEAD = 2  # per-token-head dynamic scales for int8
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
+    # [FORK-PORT] PR#41505 int8_per_tensor: 5 = symmetric INT8 per-tensor scale KV
+    # (原生 int→float 转换, sm_75 无 FP8 硬件时唯一 8bit KV 路径; 上游未合并, 见研究文档)
+    INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property
     def is_per_token_head(self) -> bool:
@@ -69,6 +72,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.FP8_PER_TOKEN_HEAD
     if kv_cache_dtype == "nvfp4":
         return KVQuantMode.NVFP4
+    if kv_cache_dtype == "int8_per_tensor":
+        return KVQuantMode.INT8_PER_TENSOR
     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
         return KVQuantMode.FP8_PER_TENSOR
     return KVQuantMode.NONE


### PR DESCRIPTION
## Summary
Symmetric int8 per-tensor KV cache for Turing (sm_75, no FP8 hardware), port of upstream PR#41505 plus a FlashInfer dequantization bridge:

- int8 KV storage halves KV memory (128K context: ~8GB -> ~4GB per GPU)
- Dynamic scale calibration (`--calculate-kv-scales`) with **tensor** scales (graph inputs) so CUDA-graph replay reads calibrated values (float scales get folded to 1.0 at capture)
- FlashInfer 0.6.8 has no int8 kernel template -> forward dequantizes KV to fp16 temp buffers before feeding kernels (K/V separate scales); storage stays int8
- Zero-value calibration skip (warmup/dummy fwd has all-zero K/V -> scale garbage); first real long prefill calibrates
- Per-layer uncalibrated warning dedup

## Benchmark (dual RTX 2080Ti, TP2, int8_per_tensor)
| metric | value |
|--------|-------|
| prefill 128K | 125.8s / 1018 tok/s |
| prefill 256K | 343.5s / 746 tok/s |
| quality (12*8) | 96 |
| KV memory | halved vs fp16 |

## Notes
- First request must be a long prompt (>=2048 tokens) to trigger calibration
- Triton reshape_and_cache used (C++ path has no int8 branch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds symmetric `int8_per_tensor` KV cache on SM75 with a `flashinfer` dequant bridge, halving KV memory vs fp16/fp8. Old: KV in fp16/fp8; New: KV stored as int8 with per‑tensor dynamic scales, dequantized to fp16 for `flashinfer` or handled natively by `triton`; `flash_attn` now rejects int8 to avoid FP8 misrouting.

- Enable with `--cache-dtype int8_per_tensor --calculate-kv-scales`. Calibration skips CUDA graph capture and all‑zero K/V, gates on the first eager prefill whose total request length ≥2048 tokens, and updates scales all‑or‑nothing (neither scale updates until both K and V have nonzero maxima). Uses tensor `_k_scale`/`_v_scale` so CUDA‑graph replay reads calibrated values; per‑layer deduped warnings if scales remain 1.0.
- Sets K/V range to 127 at init and re‑asserts after quant weight load to prevent fp8‑style checkpoints from overwriting int8 ranges.
- `flashinfer`: dequantizes int8 KV to temporary fp16 before kernels, passes `k_scale`/`v_scale=1.0` to avoid double scaling, and uses `triton_reshape_and_cache_flash` for int8 cache updates; KV storage stays int8.
- `triton`: adds `KV_QUANT_MODE=5` (INT8 per‑tensor), folds k_scale into softmax and applies v_scale once post‑matmul, uses platform rounding/clamp intrinsics, and skips fp8 views for `int8_per_tensor`.
- Plumbing: maps `int8_per_tensor` to `torch.int8`, treats it as a quantized KV cache, adds `KVQuantMode.INT8_PER_TENSOR=5`, keeps `calculate_kv_scales` enabled for int8 on hybrid models, and limits `flash_attn` selection to fp8/`nvfp4`.

- Rollout: Start with a ≥2048‑token first prompt to calibrate; `flash_attn` cannot be used with `int8_per_tensor`.

<sup>Written for commit 0bb2873a71ec72627da8aca127f1faf5223c5ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## ⚠️ Applying this PR alone (important)

This PR is one of a **4-PR series** (one concern per PR, per the maintainer's review guidance). The four together form the complete feature set the SM75 serving stack depends on:

| PR | concern | dependency |
|----|---------|------------|
| #106 | int8 per-tensor KV cache | foundation |
| #107 | GDN GGUF/AWQ dual-layout | REQUIRED to serve GDN models |
| #108 | disable custom AR during profiling | independent |
| #109 | Triton decode fast path | depends on #106 |

**Applying only a subset leaves the tree incomplete and unsafe for the production serve environment:**

- **Without #107**, serving a GDN (Qwen3.5-style) model fails at engine init ( / worker exception during CUDA-graph capture). On the reference hardware this produced a systemd  loop; the repeated load window escalated into a GPU **Xid 154 (recovery action 0x2, Node Reboot Required)**. The incomplete tree is NOT a safe state.
- **Without #106**, #109 has no int8 KV infrastructure to accelerate.
- **Merge order: #106 → #107 → #108 → #109** (or merge all four together).
