### PR TITLE
fix: disable custom all-reduce during CUDA-graph profiling (128K IPC leak)

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -201,8 +201,12 @@ class CudaCommunicator(DeviceCommunicatorBase):
             assert out is not None
             return out
         ca_comm = self.ca_comm
+        # [FORK] profiling 期间禁用 custom AR (128K IPC 泄漏, 官方 #46515)
+        import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+        _profiling_disabled = getattr(_car_mod, "_PROFILING_CAR_DISABLED", False)
         if (
             ca_comm is not None
+            and not _profiling_disabled
             and not ca_comm.disabled
             and ca_comm.should_custom_ar(input_)
         ):

--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -201,7 +201,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
             assert out is not None
             return out
         ca_comm = self.ca_comm
-        # [FORK] profiling 期间禁用 custom AR (128K IPC 泄漏, 官方 #46515)
+        # [FORK] disable custom AR during profiling (128K IPC leak, upstream #46515)
         import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
         _profiling_disabled = getattr(_car_mod, "_PROFILING_CAR_DISABLED", False)
         if (

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -235,9 +235,6 @@ class CustomAllreduce:
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
     def should_custom_ar(self, inp: torch.Tensor):
-        # [FORK] profiling debug log (printed during profile_cudagraph_memory)
-        if _PROFILING_CAR_DISABLED:
-            logger.debug("[FORK-CAR] should_custom_ar: disabled=%s size=%s", self.disabled, inp.numel() * inp.element_size())
         if self.disabled:
             return False
         inp_size = inp.numel() * inp.element_size()

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -4,7 +4,7 @@
 from contextlib import contextmanager
 from typing import cast
 
-# [FORK] profiling 期间 custom AR 禁用标志 (128K IPC 泄漏调试)
+# [FORK] custom AR disable flag during profiling (128K IPC leak debug)
 _PROFILING_CAR_DISABLED = False
 
 import torch
@@ -235,7 +235,7 @@ class CustomAllreduce:
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
     def should_custom_ar(self, inp: torch.Tensor):
-        # [FORK] profiling 调试日志 (profile_cudagraph_memory 期间打印)
+        # [FORK] profiling debug log (printed during profile_cudagraph_memory)
         if _PROFILING_CAR_DISABLED:
             print(f"[FORK-CAR] should_custom_ar: disabled={self.disabled} size={inp.numel()*inp.element_size()}", flush=True)
         if self.disabled:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -4,9 +4,6 @@
 from contextlib import contextmanager
 from typing import cast
 
-# [FORK] custom AR disable flag during profiling (128K IPC leak debug)
-_PROFILING_CAR_DISABLED = False
-
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -31,6 +28,10 @@ except Exception:
     custom_ar = False
 
 logger = init_logger(__name__)
+
+# [FORK] custom AR disable flag during profiling (128K IPC leak debug).
+# Defined after all imports to satisfy Ruff E402 (review #108 round 7 P3).
+_PROFILING_CAR_DISABLED = False
 
 
 def _can_p2p(rank: int, world_size: int) -> bool:

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -4,6 +4,9 @@
 from contextlib import contextmanager
 from typing import cast
 
+# [FORK] profiling 期间 custom AR 禁用标志 (128K IPC 泄漏调试)
+_PROFILING_CAR_DISABLED = False
+
 import torch
 import torch.distributed as dist
 from torch.distributed import ProcessGroup
@@ -232,6 +235,9 @@ class CustomAllreduce:
         ops.register_graph_buffers(self._ptr, handles, offsets)
 
     def should_custom_ar(self, inp: torch.Tensor):
+        # [FORK] profiling 调试日志 (profile_cudagraph_memory 期间打印)
+        if _PROFILING_CAR_DISABLED:
+            print(f"[FORK-CAR] should_custom_ar: disabled={self.disabled} size={inp.numel()*inp.element_size()}", flush=True)
         if self.disabled:
             return False
         inp_size = inp.numel() * inp.element_size()

--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -237,7 +237,7 @@ class CustomAllreduce:
     def should_custom_ar(self, inp: torch.Tensor):
         # [FORK] profiling debug log (printed during profile_cudagraph_memory)
         if _PROFILING_CAR_DISABLED:
-            print(f"[FORK-CAR] should_custom_ar: disabled={self.disabled} size={inp.numel()*inp.element_size()}", flush=True)
+            logger.debug("[FORK-CAR] should_custom_ar: disabled=%s size=%s", self.disabled, inp.numel() * inp.element_size())
         if self.disabled:
             return False
         inp_size = inp.numel() * inp.element_size()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6091,21 +6091,21 @@ class GPUModelRunner(
 
     @torch.inference_mode()
     def profile_cudagraph_memory(self) -> int:
-        # [FORK] 128K 长上下文 + custom all-reduce 时 IPC handle 泄漏崩溃
-        # (官方 #46515), profiling 期间临时禁用 custom AR 实例
+        # [FORK] IPC handle leak crash with 128K context + custom all-reduce
+        # (upstream #46515), temporarily disable custom AR instance during profiling
         _ca_comm = None
         try:
             from vllm.distributed.parallel_state import get_world_group
             _world = get_world_group()
             _ca_comm = getattr(_world.device_communicator, "ca_comm", None)
-            # 独立设置模块级标志 (cuda_communicator.all_reduce 检查它)
+            # set module-level flag independently (checked by cuda_communicator.all_reduce)
             import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
             _car_mod._PROFILING_CAR_DISABLED = True
             print(f"[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm={_ca_comm}", flush=True)
             if _ca_comm is not None:
                 _ca_comm.disabled = True
         except Exception as e:
-            print(f"[FORK-PROFILE] 设置失败: {e}", flush=True)
+            print(f"[FORK-PROFILE] disable failed: {e}", flush=True)
             pass
         try:
             return self._profile_cudagraph_memory_impl()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6091,6 +6091,34 @@ class GPUModelRunner(
 
     @torch.inference_mode()
     def profile_cudagraph_memory(self) -> int:
+        # [FORK] 128K 长上下文 + custom all-reduce 时 IPC handle 泄漏崩溃
+        # (官方 #46515), profiling 期间临时禁用 custom AR 实例
+        _ca_comm = None
+        try:
+            from vllm.distributed.parallel_state import get_world_group
+            _world = get_world_group()
+            _ca_comm = getattr(_world.device_communicator, "ca_comm", None)
+            # 独立设置模块级标志 (cuda_communicator.all_reduce 检查它)
+            import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+            _car_mod._PROFILING_CAR_DISABLED = True
+            print(f"[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm={_ca_comm}", flush=True)
+            if _ca_comm is not None:
+                _ca_comm.disabled = True
+        except Exception as e:
+            print(f"[FORK-PROFILE] 设置失败: {e}", flush=True)
+            pass
+        try:
+            return self._profile_cudagraph_memory_impl()
+        finally:
+            if _ca_comm is not None:
+                try:
+                    _ca_comm.disabled = False
+                    import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+                    _car_mod._PROFILING_CAR_DISABLED = False
+                except Exception:
+                    pass
+
+    def _profile_cudagraph_memory_impl(self) -> int:
         with set_current_vllm_config(self.vllm_config):
             self._init_minimal_kv_cache_for_profiling()
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6110,13 +6110,17 @@ class GPUModelRunner(
         try:
             return self._profile_cudagraph_memory_impl()
         finally:
-            if _ca_comm is not None:
-                try:
+            # [FORK] Restore unconditionally: the module-level flag was set
+            # independently of _ca_comm, so re-enable must not be nested under
+            # `if _ca_comm is not None` (review #108 P2) or the flag leaks as
+            # permanently disabled when no custom AR instance exists.
+            try:
+                import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+                _car_mod._PROFILING_CAR_DISABLED = False
+                if _ca_comm is not None:
                     _ca_comm.disabled = False
-                    import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
-                    _car_mod._PROFILING_CAR_DISABLED = False
-                except Exception:
-                    pass
+            except Exception:
+                pass
 
     def _profile_cudagraph_memory_impl(self) -> int:
         with set_current_vllm_config(self.vllm_config):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6094,10 +6094,14 @@ class GPUModelRunner(
         # [FORK] IPC handle leak crash with 128K context + custom all-reduce
         # (upstream #46515), temporarily disable custom AR instance during profiling
         _ca_comm = None
+        _ca_comm_disabled_orig = None
         try:
-            from vllm.distributed.parallel_state import get_world_group
-            _world = get_world_group()
-            _ca_comm = getattr(_world.device_communicator, "ca_comm", None)
+            # Custom all-reduce lives on the TP group's communicator, not the
+            # world group's, so resolve it via get_tp_group() (review #108).
+            from vllm.distributed.parallel_state import get_tp_group
+            _tp = get_tp_group()
+            _ca_comm = getattr(_tp.device_communicator, "ca_comm", None)
+            _ca_comm_disabled_orig = getattr(_ca_comm, "disabled", None)
             # set module-level flag independently (checked by cuda_communicator.all_reduce)
             import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
             _car_mod._PROFILING_CAR_DISABLED = True
@@ -6106,19 +6110,22 @@ class GPUModelRunner(
                 _ca_comm.disabled = True
         except Exception as e:
             logger.info("[FORK-PROFILE] disable failed: %s", e)
-            pass
         try:
             return self._profile_cudagraph_memory_impl()
         finally:
             # [FORK] Restore unconditionally: the module-level flag was set
             # independently of _ca_comm, so re-enable must not be nested under
             # `if _ca_comm is not None` (review #108 P2) or the flag leaks as
-            # permanently disabled when no custom AR instance exists.
+            # permanently disabled when no custom AR instance exists. Restore
+            # the communicator's previous state instead of force-enabling it:
+            # CustomAllreduce is created even when it self-disables (missing
+            # _custom_ar lib, unsupported world size, failed P2P) and returns
+            # early with disabled=True.
             try:
                 import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
                 _car_mod._PROFILING_CAR_DISABLED = False
-                if _ca_comm is not None:
-                    _ca_comm.disabled = False
+                if _ca_comm is not None and _ca_comm_disabled_orig is not None:
+                    _ca_comm.disabled = _ca_comm_disabled_orig
             except Exception:
                 pass
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6101,11 +6101,11 @@ class GPUModelRunner(
             # set module-level flag independently (checked by cuda_communicator.all_reduce)
             import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
             _car_mod._PROFILING_CAR_DISABLED = True
-            print(f"[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm={_ca_comm}", flush=True)
+            logger.info("[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm=%s", _ca_comm)
             if _ca_comm is not None:
                 _ca_comm.disabled = True
         except Exception as e:
-            print(f"[FORK-PROFILE] disable failed: {e}", flush=True)
+            logger.info("[FORK-PROFILE] disable failed: %s", e)
             pass
         try:
             return self._profile_cudagraph_memory_impl()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6095,6 +6095,7 @@ class GPUModelRunner(
         # (upstream #46515), temporarily disable custom AR instance during profiling
         _ca_comm = None
         _ca_comm_disabled_orig = None
+        _car_profiling_disabled_orig = None
         try:
             # Custom all-reduce lives on the TP group's communicator, not the
             # world group's, so resolve it via get_tp_group() (review #108).
@@ -6104,6 +6105,9 @@ class GPUModelRunner(
             _ca_comm_disabled_orig = getattr(_ca_comm, "disabled", None)
             # set module-level flag independently (checked by cuda_communicator.all_reduce)
             import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
+            _car_profiling_disabled_orig = getattr(
+                _car_mod, "_PROFILING_CAR_DISABLED", False
+            )
             _car_mod._PROFILING_CAR_DISABLED = True
             logger.info("[FORK-PROFILE] _PROFILING_CAR_DISABLED=True, ca_comm=%s", _ca_comm)
             if _ca_comm is not None:
@@ -6120,10 +6124,15 @@ class GPUModelRunner(
             # the communicator's previous state instead of force-enabling it:
             # CustomAllreduce is created even when it self-disables (missing
             # _custom_ar lib, unsupported world size, failed P2P) and returns
-            # early with disabled=True.
+            # early with disabled=True. Restore the module flag to its prior
+            # value as well so re-entrant profiling does not silently re-enable
+            # custom AR mid-profiling; None means it was never set in this call
+            # (module default False), so restoring is a no-op (review #108
+            # round 6 P3).
             try:
                 import vllm.distributed.device_communicators.custom_all_reduce as _car_mod
-                _car_mod._PROFILING_CAR_DISABLED = False
+                if _car_profiling_disabled_orig is not None:
+                    _car_mod._PROFILING_CAR_DISABLED = _car_profiling_disabled_orig
                 if _ca_comm is not None and _ca_comm_disabled_orig is not None:
                     _ca_comm.disabled = _ca_comm_disabled_orig
             except Exception:


### PR DESCRIPTION
## Summary
CUDA-graph profiling with 128K context + custom all-reduce crashes with IPC handle leak (upstream #46515). This PR disables custom AR during profiling:

- Module-level disable flag checked by `cuda_communicator.all_reduce`
- Set independently in `gpu_model_runner` during `profile_cudagraph_memory`, restored in `finally`
- Debug log while profiling; clean re-enable after profiling

## Verification / benchmark (dual RTX 2080Ti, TP2, maxlen 131072)
| scenario | before | after |
|----------|--------|-------|
| CUDA-graph profiling @128K context | IPC handle leak crash (upstream #46515) | completes normally, memory released |
| normal serving (custom AR active) | ok | unaffected (throughput unchanged) |

- 128K profiling completes without crash on real hardware; custom all-reduce re-enabled after profiling
- No throughput impact outside profiling (custom AR path untouched in serving)


---

## ⚠️ Applying this PR alone (important)

This PR is one of a **4-PR series** (one concern per PR, per the maintainer's review guidance). The four together form the complete feature set the SM75 serving stack depends on:

| PR | concern | dependency |
|----|---------|------------|
| #106 | int8 per-tensor KV cache | foundation |
| #107 | GDN GGUF/AWQ dual-layout | REQUIRED to serve GDN models |
| #108 | disable custom AR during profiling | independent |
| #109 | Triton decode fast path | depends on #106 |

**Applying only a subset leaves the tree incomplete and unsafe for the production serve environment:**

- **Without #107**, serving a GDN (Qwen3.5-style) model fails at engine init ( / worker exception during CUDA-graph capture). On the reference hardware this produced a systemd  loop; the repeated load window escalated into a GPU **Xid 154 (recovery action 0x2, Node Reboot Required)**. The incomplete tree is NOT a safe state.
- **Without #106**, #109 has no int8 KV infrastructure to accelerate.
- **Merge order: #106 → #107 → #108 → #109** (or merge all four together).
