### PR TITLE
perf: int8 decode via Triton kernel (FlashInfer prefill + Triton decode hybrid)

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -28,6 +28,7 @@ CacheDType = Literal[
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
     "turboquant_3bit_nc",
+    "int8_per_tensor",  # [FORK-PORT] PR#41505 symmetric int8 per-tensor KV
     "int8_per_token_head",
     "fp8_per_token_head",
     "nvfp4",
@@ -256,6 +257,13 @@ class CacheConfig:
                 "memory footprint and boosts the performance. "
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
+            )
+        elif cache_dtype == "int8_per_tensor":  # [FORK-PORT] PR#41505
+            logger.info(
+                "Using int8_per_tensor data type to store kv cache. "
+                "It reduces the GPU memory footprint and boosts the "
+                "performance. Meanwhile, it may cause accuracy drop "
+                "without a proper scaling factor",
             )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -258,13 +258,6 @@ class CacheConfig:
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
             )
-        elif cache_dtype == "int8_per_tensor":  # [FORK-PORT] PR#41505
-            logger.info(
-                "Using int8_per_tensor data type to store kv cache. "
-                "It reduces the GPU memory footprint and boosts the "
-                "performance. Meanwhile, it may cause accuracy drop "
-                "without a proper scaling factor",
-            )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(
                 "Using %s data type to store kv cache. It reduces the GPU "

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -672,6 +672,18 @@ def maybe_calc_kv_scales(
                                 None)
         if _seq_lens_cpu is None:
             _seq_lens_cpu = getattr(_md, "seq_lens_cpu", None)
+            if _seq_lens_cpu is not None:
+                # TritonAttentionMetadata: seq_lens_cpu mixes prefill and
+                # decode rows. A pure decode batch must NOT qualify — its
+                # seq_lens_cpu rows carry the full context length (>=2K for
+                # long conversations), so the gate would pass and calibrate
+                # from single-token decode K/V, missing the prompt
+                # distribution (review #109 round 8 P1). Detect it via
+                # num_actual_tokens == num_seqs (one token per request) and
+                # defer to the next prefill batch.
+                _num_tok = getattr(_md, "num_actual_tokens", None)
+                if _num_tok is not None and _num_tok == _seq_lens_cpu.numel():
+                    _seq_lens_cpu = None
         if _seq_lens_cpu is None:
             # FlashInfer TRTLLM prefill has no seq_lens_cpu (seq lengths stay
             # on GPU only); TRTLLMPrefill.seq_lens covers prefill requests

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -516,7 +516,7 @@ class Attention(nn.Module, AttentionLayerBase):
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
-            if k_absmax == 0.0 or v_absmax == 0.0:
+            if k_absmax == 0.0 and v_absmax == 0.0:
                 logger.debug(
                     "[FORK-INT8SCALE] %s skip zero-value calibration "
                     "(k_absmax=%.6f v_absmax=%.6f), waiting for real request",
@@ -526,9 +526,13 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         if self.kv_cache_dtype == "int8_per_tensor":
             # Reuse the k_absmax/v_absmax computed above instead of re-running
-            # two full reductions (review #109 round 6).
-            self._k_scale.copy_(k_absmax / self.k_range)
-            self._v_scale.copy_(v_absmax / self.v_range)
+            # two full reductions (review #109 round 6). Calibrate each tensor
+            # independently: a zero K (or V) keeps its previous scale while
+            # the nonzero one is calibrated (review #106 round 7 P2).
+            if k_absmax > 0.0:
+                self._k_scale.copy_(k_absmax / self.k_range)
+            if v_absmax > 0.0:
+                self._v_scale.copy_(v_absmax / self.v_range)
         else:
             self._k_scale.copy_(torch.abs(key).max() / self.k_range)
             self._v_scale.copy_(torch.abs(value).max() / self.v_range)
@@ -641,15 +645,50 @@ def maybe_calc_kv_scales(
     # cudaErrorStreamCaptureInvalidated during capture. Keep the flag until the
     # first real eager prefill (long chunk exceeding the graph capture size)
     # calibrates. FULL CUDA-graph capture passes cudagraph_runtime_mode=NONE,
-    # so an active stream capture is also detected. Scoped to int8_per_tensor
-    # so other quantized KV dtypes (fp8 etc.) keep upstream first-forward
-    # calibration timing (review #109 round 6 P2).
-    _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
-    _in_cudagraph = (
-        _cudagraph_mode is not None and _cudagraph_mode.name != "NONE"
-    ) or torch.cuda.is_current_stream_capturing()
-    if self.kv_cache_dtype == "int8_per_tensor" and _in_cudagraph:
-        return
+    # so an active stream capture is also detected. The mode check is scoped
+    # inside the int8 dtype guard so non-int8 paths evaluate no CUDA API and
+    # keep upstream first-forward calibration timing (review #109 round 7 P2).
+    if self.kv_cache_dtype == "int8_per_tensor":
+        _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+        _in_cudagraph = (
+            _cudagraph_mode is not None and _cudagraph_mode.name != "NONE"
+        ) or torch.cuda.is_current_stream_capturing()
+        if _in_cudagraph:
+            return
+        # [FORK] int8_per_tensor: gate calibration on a long prefill (>=2K
+        # tokens) so a warmup or short decode pass does not permanently lock
+        # scales calibrated from a tiny key/value batch (review #109 round 7
+        # P1). Read the backend's per-request total sequence lengths:
+        # FlashInfer FIPrefill.seq_lens_cpu / TRTLLMPrefill.seq_lens cover
+        # prefill requests only; TritonAttentionMetadata stores seq_lens_cpu
+        # on the metadata object (mixed rows). is_prefilling filtering lands
+        # with PR #106 (this branch predates it).
+        _md = getattr(forward_context, "attn_metadata", None)
+        if isinstance(_md, dict):
+            _md = _md.get(layer_name)
+        elif isinstance(_md, list) and _md:
+            _md = _md[0].get(layer_name)
+        _seq_lens_cpu = getattr(getattr(_md, "prefill", None), "seq_lens_cpu",
+                                None)
+        if _seq_lens_cpu is None:
+            _seq_lens_cpu = getattr(_md, "seq_lens_cpu", None)
+        if _seq_lens_cpu is None:
+            # FlashInfer TRTLLM prefill has no seq_lens_cpu (seq lengths stay
+            # on GPU only); TRTLLMPrefill.seq_lens covers prefill requests
+            # exclusively, which is exactly the population this gate wants.
+            _seq_lens_t = getattr(getattr(_md, "prefill", None), "seq_lens",
+                                  None)
+            if _seq_lens_t is not None and _seq_lens_t.numel() > 0:
+                _seq_lens_cpu = _seq_lens_t
+        _max_seq_len = 0
+        if _seq_lens_cpu is not None and _seq_lens_cpu.numel() > 0:
+            _max_seq_len = int(_seq_lens_cpu.max().item())
+        if _max_seq_len < 2048:
+            logger.debug(
+                "[FORK-INT8SCALE] %s defer calibration: max prefill seq "
+                "len=%d < 2048", layer_name, _max_seq_len,
+            )
+            return
 
     self.calc_kv_scales(query, key, value)
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -511,6 +511,8 @@ class Attention(nn.Module, AttentionLayerBase):
         # uninitialized during calibration). Skip zero-value calibration and keep
         # the calculate_kv_scales flag; calibrate on the first real request
         # (long prefill) instead.
+        k_absmax = 0.0
+        v_absmax = 0.0
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
@@ -522,18 +524,27 @@ class Attention(nn.Module, AttentionLayerBase):
                 )
                 return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
-        self._k_scale.copy_(torch.abs(key).max() / self.k_range)
-        self._v_scale.copy_(torch.abs(value).max() / self.v_range)
+        if self.kv_cache_dtype == "int8_per_tensor":
+            # Reuse the k_absmax/v_absmax computed above instead of re-running
+            # two full reductions (review #109 round 6).
+            self._k_scale.copy_(k_absmax / self.k_range)
+            self._v_scale.copy_(v_absmax / self.v_range)
+        else:
+            self._k_scale.copy_(torch.abs(key).max() / self.k_range)
+            self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor debug: log the actually calibrated scales
+        # [FORK] int8_per_tensor debug: log the actually calibrated scales.
+        # k_absmax/v_absmax are already computed above for the zero-value
+        # check; reuse them instead of re-running two full reductions
+        # (logger.debug args are evaluated unconditionally, review #109 P3).
         if self.kv_cache_dtype == "int8_per_tensor":
             logger.debug(
                 "[FORK-INT8SCALE] %s k_scale=%.6f v_scale=%.6f "
                 "k_absmax=%.4f v_absmax=%.4f",
                 self.layer_name, self._k_scale_float, self._v_scale_float,
-                torch.abs(key).max().item(), torch.abs(value).max().item(),
+                k_absmax, v_absmax,
             )
         # We only calculate the scales once
         self.calculate_kv_scales = False
@@ -629,9 +640,15 @@ def maybe_calc_kv_scales(
     # calc_kv_scales contains .item() CPU sync, which triggers
     # cudaErrorStreamCaptureInvalidated during capture. Keep the flag until the
     # first real eager prefill (long chunk exceeding the graph capture size)
-    # calibrates.
+    # calibrates. FULL CUDA-graph capture passes cudagraph_runtime_mode=NONE,
+    # so an active stream capture is also detected. Scoped to int8_per_tensor
+    # so other quantized KV dtypes (fp8 etc.) keep upstream first-forward
+    # calibration timing (review #109 round 6 P2).
     _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
-    if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
+    _in_cudagraph = (
+        _cudagraph_mode is not None and _cudagraph_mode.name != "NONE"
+    ) or torch.cuda.is_current_stream_capturing()
+    if self.kv_cache_dtype == "int8_per_tensor" and _in_cudagraph:
         return
 
     self.calc_kv_scales(query, key, value)

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -661,8 +661,10 @@ def maybe_calc_kv_scales(
         # P1). Read the backend's per-request total sequence lengths:
         # FlashInfer FIPrefill.seq_lens_cpu / TRTLLMPrefill.seq_lens cover
         # prefill requests only; TritonAttentionMetadata stores seq_lens_cpu
-        # on the metadata object (mixed rows). is_prefilling filtering lands
-        # with PR #106 (this branch predates it).
+        # on the metadata object (mixed rows), so restrict to prefill rows
+        # via is_prefilling below (review #109 round 8 P1/P2). The
+        # is_prefilling field mirrors PR #106; keeping it identical on both
+        # branches keeps them mergeable.
         _md = getattr(forward_context, "attn_metadata", None)
         if isinstance(_md, dict):
             _md = _md.get(layer_name)
@@ -678,12 +680,23 @@ def maybe_calc_kv_scales(
                 # seq_lens_cpu rows carry the full context length (>=2K for
                 # long conversations), so the gate would pass and calibrate
                 # from single-token decode K/V, missing the prompt
-                # distribution (review #109 round 8 P1). Detect it via
-                # num_actual_tokens == num_seqs (one token per request) and
-                # defer to the next prefill batch.
-                _num_tok = getattr(_md, "num_actual_tokens", None)
-                if _num_tok is not None and _num_tok == _seq_lens_cpu.numel():
-                    _seq_lens_cpu = None
+                # distribution (review #109 round 8 P1). Restrict to actual
+                # prefill rows via is_prefilling (computed < prompt length,
+                # gpu_model_runner.py:2216); a 1-token extend is still a
+                # prefill row and stays eligible (review #109 round 8 P2).
+                _is_prefilling = getattr(_md, "is_prefilling", None)
+                if _is_prefilling is not None and _is_prefilling.numel(
+                ) == _seq_lens_cpu.numel():
+                    _seq_lens_cpu = _seq_lens_cpu[_is_prefilling]
+                    if _seq_lens_cpu.numel() == 0:
+                        # No prefill rows at all (pure decode batch).
+                        _seq_lens_cpu = None
+                elif _is_prefilling is None:
+                    # Fallback: num_actual_tokens == num_seqs implies one
+                    # token per request, i.e. no multi-token prefill.
+                    _num_tok = getattr(_md, "num_actual_tokens", None)
+                    if _num_tok is not None and _num_tok == _seq_lens_cpu.numel():
+                        _seq_lens_cpu = None
         if _seq_lens_cpu is None:
             # FlashInfer TRTLLM prefill has no seq_lens_cpu (seq lengths stay
             # on GPU only); TRTLLMPrefill.seq_lens covers prefill requests

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,8 +150,8 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
-    # [FORK-PORT] PR#41505: int8_per_tensor 的对称量化范围是 ±127
-    # (fp8 默认用 envs K/V_SCALE_CONSTANT=200/100; int8 必须用 127)
+    # [FORK-PORT] PR#41505: int8_per_tensor uses a symmetric quantization
+    # range of ±127 (fp8 defaults to envs K/V_SCALE_CONSTANT=200/100; int8 must use 127)
     if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
         layer.k_range.fill_(127.0)
         layer.v_range.fill_(127.0)
@@ -506,9 +506,11 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
-        # [FORK] int8_per_tensor: warmup/dummy 前向的 K/V 全零 → scale=0 垃圾缓存
-        # (hybrid #37554 实锤: 校准期 recurrent state 未初始化)。跳过零值校准,
-        # 保持 calculate_kv_scales 标志, 等第一个真实请求 (长 prefill) 再校准。
+        # [FORK] int8_per_tensor: warmup/dummy forward passes have all-zero K/V
+        # → scale=0 garbage cache (hybrid #37554 confirmed: recurrent state is
+        # uninitialized during calibration). Skip zero-value calibration and keep
+        # the calculate_kv_scales flag; calibrate on the first real request
+        # (long prefill) instead.
         if self.kv_cache_dtype == "int8_per_tensor":
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
@@ -525,7 +527,7 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor 调试: 打印实际校准的 scale 值
+        # [FORK] int8_per_tensor debug: print the actually calibrated scale values
         if self.kv_cache_dtype == "int8_per_tensor":
             print(
                 f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
@@ -624,9 +626,11 @@ def maybe_calc_kv_scales(
     if not self.calculate_kv_scales:
         return
 
-    # [FORK] int8_per_tensor: CUDA graph 捕获/回放期间跳过 — calc_kv_scales 里有
-    # .item() CPU 同步, 在 capture 中触发 cudaErrorStreamCaptureInvalidated。
-    # 标志保留到第一个真实 eager prefill (长 chunk 超图捕获尺寸) 再校准。
+    # [FORK] int8_per_tensor: skip during CUDA graph capture/replay —
+    # calc_kv_scales contains .item() CPU sync, which triggers
+    # cudaErrorStreamCaptureInvalidated during capture. Keep the flag until the
+    # first real eager prefill (long chunk exceeding the graph capture size)
+    # calibrates.
     _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
     if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
         return

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -515,10 +515,10 @@ class Attention(nn.Module, AttentionLayerBase):
             k_absmax = torch.abs(key).max().item()
             v_absmax = torch.abs(value).max().item()
             if k_absmax == 0.0 or v_absmax == 0.0:
-                print(
-                    f"[FORK-INT8SCALE] {self.layer_name} 跳过零值校准 "
-                    f"(k_absmax={k_absmax:.6f} v_absmax={v_absmax:.6f}), 等真实请求",
-                    flush=True,
+                logger.debug(
+                    "[FORK-INT8SCALE] %s skip zero-value calibration "
+                    "(k_absmax=%.6f v_absmax=%.6f), waiting for real request",
+                    self.layer_name, k_absmax, v_absmax,
                 )
                 return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
@@ -527,14 +527,13 @@ class Attention(nn.Module, AttentionLayerBase):
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
-        # [FORK] int8_per_tensor debug: print the actually calibrated scale values
+        # [FORK] int8_per_tensor debug: log the actually calibrated scales
         if self.kv_cache_dtype == "int8_per_tensor":
-            print(
-                f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
-                f"v_scale={self._v_scale_float:.6f} "
-                f"k_absmax={torch.abs(key).max().item():.4f} "
-                f"v_absmax={torch.abs(value).max().item():.4f}",
-                flush=True,
+            logger.debug(
+                "[FORK-INT8SCALE] %s k_scale=%.6f v_scale=%.6f "
+                "k_absmax=%.4f v_absmax=%.4f",
+                self.layer_name, self._k_scale_float, self._v_scale_float,
+                torch.abs(key).max().item(), torch.abs(value).max().item(),
             )
         # We only calculate the scales once
         self.calculate_kv_scales = False

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -150,6 +150,11 @@ def _init_kv_cache_quant(
     # wrong scales) and then load real weights (which misses scales and keeps the
     # wrong scales from dummy load).
     set_default_quant_scales(layer, register_buffer=True)
+    # [FORK-PORT] PR#41505: int8_per_tensor 的对称量化范围是 ±127
+    # (fp8 默认用 envs K/V_SCALE_CONSTANT=200/100; int8 必须用 127)
+    if getattr(layer, "kv_cache_dtype", None) == "int8_per_tensor":
+        layer.k_range.fill_(127.0)
+        layer.v_range.fill_(127.0)
 
     # The output scale on host memory. This should be the input scale of
     # the quant op after this attention layer.
@@ -501,12 +506,34 @@ class Attention(nn.Module, AttentionLayerBase):
         return output.view(-1, hidden_size)
 
     def calc_kv_scales(self, query, key, value):
+        # [FORK] int8_per_tensor: warmup/dummy 前向的 K/V 全零 → scale=0 垃圾缓存
+        # (hybrid #37554 实锤: 校准期 recurrent state 未初始化)。跳过零值校准,
+        # 保持 calculate_kv_scales 标志, 等第一个真实请求 (长 prefill) 再校准。
+        if self.kv_cache_dtype == "int8_per_tensor":
+            k_absmax = torch.abs(key).max().item()
+            v_absmax = torch.abs(value).max().item()
+            if k_absmax == 0.0 or v_absmax == 0.0:
+                print(
+                    f"[FORK-INT8SCALE] {self.layer_name} 跳过零值校准 "
+                    f"(k_absmax={k_absmax:.6f} v_absmax={v_absmax:.6f}), 等真实请求",
+                    flush=True,
+                )
+                return
         self._q_scale.copy_(torch.abs(query).max() / self.q_range)
         self._k_scale.copy_(torch.abs(key).max() / self.k_range)
         self._v_scale.copy_(torch.abs(value).max() / self.v_range)
         self._q_scale_float = self._q_scale.item()
         self._k_scale_float = self._k_scale.item()
         self._v_scale_float = self._v_scale.item()
+        # [FORK] int8_per_tensor 调试: 打印实际校准的 scale 值
+        if self.kv_cache_dtype == "int8_per_tensor":
+            print(
+                f"[FORK-INT8SCALE] {self.layer_name} k_scale={self._k_scale_float:.6f} "
+                f"v_scale={self._v_scale_float:.6f} "
+                f"k_absmax={torch.abs(key).max().item():.4f} "
+                f"v_absmax={torch.abs(value).max().item():.4f}",
+                flush=True,
+            )
         # We only calculate the scales once
         self.calculate_kv_scales = False
 
@@ -595,6 +622,13 @@ def maybe_calc_kv_scales(
     # Only calculate if the layer's calculate_kv_scales flag is True
     # This flag gets set to False after the first forward pass
     if not self.calculate_kv_scales:
+        return
+
+    # [FORK] int8_per_tensor: CUDA graph 捕获/回放期间跳过 — calc_kv_scales 里有
+    # .item() CPU 同步, 在 capture 中触发 cudaErrorStreamCaptureInvalidated。
+    # 标志保留到第一个真实 eager prefill (长 chunk 超图捕获尺寸) 再校准。
+    _cudagraph_mode = getattr(forward_context, "cudagraph_runtime_mode", None)
+    if _cudagraph_mode is not None and _cudagraph_mode.name != "NONE":
         return
 
     self.calc_kv_scales(query, key, value)

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -212,10 +212,12 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # See issue: https://github.com/vllm-project/vllm/issues/37554
 
         if cache_config.calculate_kv_scales:
-            # [FORK-PORT] PR#41505: int8_per_tensor 保留动态 scale。
-            # fp8 对 hybrid 禁用是 issue #37554 (校准期 recurrent state 未初始化
-            # 会污染 fp8 scale); int8 路径同样受此影响, 但测试需要真实 scale,
-            # 校准请求用真实长文本 prefill 来规避。fp8 维持官方禁用行为。
+            # [FORK-PORT] PR#41505: keep dynamic scale for int8_per_tensor.
+            # fp8 is disabled for hybrid models per issue #37554 (uninitialized
+            # recurrent state during calibration pollutes the fp8 scale); the
+            # int8 path is equally affected, but tests need real scales, so the
+            # calibration request uses a real long-text prefill to avoid it.
+            # fp8 keeps the official disabled behavior.
             if cache_config.cache_dtype == "int8_per_tensor":
                 logger.info(
                     "Keeping calculate_kv_scales for int8_per_tensor KV on "

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -212,15 +212,27 @@ class HybridAttentionMambaModelConfig(VerifyAndUpdateConfig):
         # See issue: https://github.com/vllm-project/vllm/issues/37554
 
         if cache_config.calculate_kv_scales:
-            logger.warning(
-                "Disabling calculate_kv_scales for hybrid model '%s'. "
-                "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
-                "produce unreliable KV cache scales during the "
-                "calibration pass because recurrent state is "
-                "uninitialized. Using default scale of 1.0 instead.",
-                vllm_config.model_config.model,
-            )
-            cache_config.calculate_kv_scales = False
+            # [FORK-PORT] PR#41505: int8_per_tensor 保留动态 scale。
+            # fp8 对 hybrid 禁用是 issue #37554 (校准期 recurrent state 未初始化
+            # 会污染 fp8 scale); int8 路径同样受此影响, 但测试需要真实 scale,
+            # 校准请求用真实长文本 prefill 来规避。fp8 维持官方禁用行为。
+            if cache_config.cache_dtype == "int8_per_tensor":
+                logger.info(
+                    "Keeping calculate_kv_scales for int8_per_tensor KV on "
+                    "hybrid model '%s' (FORK-PORT PR#41505; calibrate on real "
+                    "long prefill).",
+                    vllm_config.model_config.model,
+                )
+            else:
+                logger.warning(
+                    "Disabling calculate_kv_scales for hybrid model '%s'. "
+                    "Hybrid models with recurrent layers (GDN, Mamba, SSM) "
+                    "produce unreliable KV cache scales during the "
+                    "calibration pass because recurrent state is "
+                    "uninitialized. Using default scale of 1.0 instead.",
+                    vllm_config.model_config.model,
+                )
+                cache_config.calculate_kv_scales = False
 
         # Enable FULL_AND_PIECEWISE by default
         MambaModelConfig.verify_and_update_config(vllm_config)

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -77,7 +77,7 @@ PIN_MEMORY = "microsoft" not in " ".join(platform.uname()).lower()
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
-        # [FORK-PORT] PR#41505: int8_per_tensor 也是量化 KV (torch_utils 版)
+        # [FORK-PORT] PR#41505: int8_per_tensor is also a quantized KV dtype (torch_utils version)
         or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -39,6 +39,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
     "int8": torch.int8,
+    "int8_per_tensor": torch.int8,  # [FORK-PORT] PR#41505
     "int8_per_token_head": torch.int8,
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
@@ -76,6 +77,8 @@ PIN_MEMORY = "microsoft" not in " ".join(platform.uname()).lower()
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
+        # [FORK-PORT] PR#41505: int8_per_tensor 也是量化 KV (torch_utils 版)
+        or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"
     )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1534,13 +1534,17 @@ class FlashInferImpl(AttentionImpl):
 
         num_actual_tokens = attn_metadata.num_actual_tokens
 
+        # [FORK] Whether decode takes the Triton fast path (int8, 1 token per
+        # request, no padding rows). Initialized here (method scope) so the
+        # decode branch below never reads an unbound name; set inside the
+        # int8_per_tensor branch below.
+        _use_triton_decode = False
+
         # The FlashInfer api requires data to be in fp8_e4m3 or fp8_e5m2
         # to process the cache when the kv_cache_dtype is fp8
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
-            # [FORK] Whether decode takes the Triton fast path (int8, 1 token per request, no padding rows)
-            _use_triton_decode = False
             if self.kv_cache_dtype == "int8_per_tensor":
                 # [FORK] int8_per_tensor: FlashInfer kernels have no int8 branch
                 # (0.6.8 lists the enum but ships no template; feeding int8 raw
@@ -1875,9 +1879,7 @@ class FlashInferImpl(AttentionImpl):
                         get_dcp_group(),
                     )
                 else:
-                    if self.kv_cache_dtype == "int8_per_tensor" and (
-                        _kv_cache_int8 is not None
-                    ) and _use_triton_decode:
+                    if self.kv_cache_dtype == "int8_per_tensor" and _use_triton_decode:
                         # [FORK] int8 decode goes through the Triton kernel:
                         # FlashInfer 0.6.8 has no int8 decode template (whole-
                         # pool dequant: 5.7 tok/s); Triton unified_attention

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1859,19 +1859,15 @@ class FlashInferImpl(AttentionImpl):
                 else:
                     if self.kv_cache_dtype == "int8_per_tensor" and (
                         _kv_cache_int8 is not None
-                    ):
+                    ) and num_decode_tokens == attn_metadata.num_decodes:
                         # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
                         # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
                         # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),
                         # 只处理请求块, 实测 42.8 tok/s。prefill 仍走 FlashInfer
                         # (反量化路径, 1400+ tok/s)。用原始 int8 cache + 张量 scale。
-                        import os
-                        if os.environ.get("VLLM_INT8_DECODE_TRITON_DEBUG"):
-                            print(
-                                f"[FORK-DBG] decode Triton 路径: dtype="
-                                f"{self.kv_cache_dtype} n={num_decode_tokens}",
-                                flush=True,
-                            )
+                        # 仅限每请求 1 token 的常规 decode (num_decode_tokens ==
+                        # num_decodes); 推测解码产生多 token 时回退 FlashInfer
+                        # 路径 (per-request metadata 语义不同, 见 #99 复审)。
                         from vllm.v1.attention.ops.triton_unified_attention import (
                             unified_attention,
                         )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -336,8 +336,8 @@ class FlashInferBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "nvfp4",
-        # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支, 在 forward 里
-        # 反量化成 fp16 临时 buffer 再喂内核 (KV 存储仍减半, 反量化开销 ~带宽)
+        # [FORK] int8_per_tensor: FlashInfer kernels lack an int8 branch; the
+        # forward pass dequantizes into a temp fp16 buffer (storage halved, cost ~bandwidth)
         "int8_per_tensor",
     ]
 
@@ -632,9 +632,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
             if self.cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: FlashInfer 0.6.8 内核无 int8 分支,
-                # forward 里反量化成 fp16 临时 buffer 再喂内核; 这里告知
-                # FlashInfer 数据是 fp16 (plan 的 kv_data_type)。
+                # [FORK] int8_per_tensor: FlashInfer 0.6.8 kernels have no
+                # int8 branch; the forward pass dequantizes into a temporary
+                # fp16 buffer. Tell FlashInfer the data is fp16 (plan's kv_data_type).
                 self.kv_cache_dtype = torch.float16
             elif self.is_kvcache_nvfp4:
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
@@ -1277,10 +1277,11 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     disable_split_kv=self.disable_split_kv,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
-        # [FORK] int8_per_tensor decode 走 Triton 内核用 (FlashInfer 0.6.8
-        # 无 int8 decode 模板;全池反量化 5.7 tok/s vs Triton 42.8 tok/s)。
-        # 动态属性而非 dataclass 字段: _copy_tensor_tree 遍历 dataclass 字段
-        # 并 copy_, 视图与底层 buffer 同内存会触发 graph 捕获崩溃。
+        # [FORK] int8_per_tensor decode uses the Triton kernel (FlashInfer 0.6.8
+        # lacks an int8 decode template; whole-pool dequant 5.7 tok/s vs Triton
+        # 42.8 tok/s). Dynamic attribute, not a dataclass field: _copy_tensor_tree
+        # copy_()s dataclass fields; views aliasing the underlying buffer would
+        # crash CUDA graph capture.
         attn_metadata.seq_lens = seq_lens
         attn_metadata.block_table = block_table_tensor
         return attn_metadata
@@ -1298,7 +1299,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
-    # [FORK] int8_per_tensor 未校准警告去重 (按层记录, 每层最多一次)
+    # [FORK] Dedupe uncalibrated int8_per_tensor warnings (tracked per layer, at most once per layer)
     _warned_uncalibrated_layers: set = set()
 
     def __init__(
@@ -1366,9 +1367,10 @@ class FlashInferImpl(AttentionImpl):
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
 
-        # [FORK] int8 decode 走 Triton unified_attention 的 3D 分段参数
-        # (同 triton_attn.py): 长上下文 decode 用 3D 分段并行 softmax,
-        # 否则 2D 单段串行扫全部 KV → 32K 语境 decode 3.4 tok/s vs 26。
+        # [FORK] 3D segmented params for int8 decode via Triton unified_attention
+        # (same as triton_attn.py): long-context decode uses 3D segmented
+        # parallel softmax; otherwise the 2D single segment serially scans all
+        # KV (3.4 vs 26 tok/s at 32K context).
         self._decode_3d: dict | None = None
         if kv_cache_dtype == "int8_per_tensor":
             MIN_LAUNCH_GRID_SIZE_2D = 128
@@ -1383,7 +1385,7 @@ class FlashInferImpl(AttentionImpl):
                         capture_sizes,
                         key=lambda x: abs(x - seq_threshold),
                     )
-            headdim_padded = head_size  # 128 已是 2 的幂
+            headdim_padded = head_size  # 128 is already a power of 2
             self._decode_3d = {
                 "seq_threshold_3D": seq_threshold,
                 "num_par_softmax_segments": NUM_PAR_SOFTMAX_SEGMENTS,
@@ -1467,10 +1469,11 @@ class FlashInferImpl(AttentionImpl):
             f"got {query.dtype}"
         )
 
-        # [FORK] int8_per_tensor 走反量化路径 (数据已含 scale), 不折叠进 bmm
+        # [FORK] int8_per_tensor goes through the dequant path (data already
+        # includes the scale), so it is not folded into the bmm
         _is_int8_dequant = self.kv_cache_dtype == "int8_per_tensor"
-        # [FORK] int8_per_tensor: KV 已反量化为 fp16 真实值, 不能再传
-        # k_scale/v_scale 给 FlashInfer (否则双重 scale 导致乱码)
+        # [FORK] int8_per_tensor: KV is already dequantized to real fp16 values;
+        # do not pass k_scale/v_scale to FlashInfer (double scaling would corrupt output)
         _kv_scale = (1.0, 1.0) if _is_int8_dequant else (
             layer._k_scale_float, layer._v_scale_float)
         if self.bmm1_scale is None:
@@ -1536,32 +1539,36 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
-            # [FORK] decode 是否走 Triton 快速路径 (int8 且每请求 1 token 无 padding)
+            # [FORK] Whether decode takes the Triton fast path (int8, 1 token per request, no padding rows)
             _use_triton_decode = False
             if self.kv_cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
-                # 枚举有但模板无, 直接喂会 illegal address)。prefill 反量化成
-                # fp16 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半;
-                # decode 走 Triton 内核 (原生 int8) 用原始 cache, 不反量化
-                # (decode-only 每步省全池反量化 ~17GB 流量, 5.7 → 42 tok/s)。
-                # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
-                # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
-                # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
-                # [FORK] 仅当 decode 为"每请求 1 token 且无 padding rows"
-                # (num_decode_tokens == num_decodes) 时走 Triton 快速路径;
-                # 推测解码或多 token 时回退 FlashInfer, 此时必须反量化
-                # (decode-only 回退也反量化, 否则 int8 cache 喂 FlashInfer 崩)。
+                # [FORK] int8_per_tensor: FlashInfer kernels have no int8 branch
+                # (0.6.8 lists the enum but ships no template; feeding int8 raw
+                # hits illegal address). Prefill dequantizes into a temporary
+                # fp16 buffer (separate K/V scales); storage stays halved int8.
+                # Decode uses the Triton kernel (native int8) on the raw cache,
+                # skipping dequant (saves ~17GB whole-pool dequant traffic per
+                # step, 5.7 → 42 tok/s). NOTE: pass the tensor _k_scale/_v_scale
+                # (graph inputs; replay reads calibrated values); _k_scale_float
+                # (Python float) is folded to a constant at capture (1.0 while
+                # uncalibrated) → wrong data on replay. [FORK] The Triton fast
+                # path runs only for "1 token per request with no padding rows"
+                # (num_decode_tokens == num_decodes); speculative decode or
+                # multi-token falls back to FlashInfer and must dequant (the
+                # decode-only fallback also dequantizes, or feeding int8 cache
+                # to FlashInfer crashes).
                 _use_triton_decode = (
                     attn_metadata.num_decode_tokens == attn_metadata.num_decodes
                 )
                 _kv_cache_int8 = kv_cache
                 if attn_metadata.num_prefill_tokens > 0 or not _use_triton_decode:
                     if layer._k_scale_float == 1.0:
-                        # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA
-                        # graph) 时校准被跳过 (calc_kv_scales 零值跳过 + graph
-                        # 模式 return), scale 保持 1.0 → 数据错误。按层去重
-                        # (每层最多一次), 避免 graph 捕获阶段刷屏且真实请求
-                        # 时仍能看到提示。
+                        # [FORK] When the first request is short (<2048 tokens,
+                        # fully CUDA-graphed), calibration is skipped (zero-value
+                        # skip in calc_kv_scales + early return in graph mode)
+                        # and scale stays 1.0 → wrong data. Dedupe per layer
+                        # (at most once) to avoid spamming during graph capture
+                        # while still showing the hint on real requests.
                         if layer.layer_name not in \
                                 FlashInferImpl._warned_uncalibrated_layers:
                             logger.warning(
@@ -1572,12 +1579,14 @@ class FlashInferImpl(AttentionImpl):
                             FlashInferImpl._warned_uncalibrated_layers.add(
                                 layer.layer_name
                             )
-                    # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值
-                    # 一层 ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入,
-                    # 回放时读到校准后的值; 用 _k_scale_float (Python float)
-                    # 会被 CUDA graph 捕获折叠成常量 (启动时未校准 = 1.0) →
-                    # 数据错误。decode 分支走 Triton 内核时用 _kv_cache_int8
-                    # (原始 int8 + 张量 scale, 见 decode 分支)。
+                    # Dequantize (temporary allocation per layer; layers execute
+                    # serially so buffers are freed naturally; measured peak
+                    # ~700MB per layer at 256K context). Tensor scales are graph
+                    # inputs read back at replay; _k_scale_float (Python float)
+                    # would be folded to a constant at CUDA graph capture (1.0
+                    # while uncalibrated) → wrong data. The decode branch uses
+                    # _kv_cache_int8 (raw int8 + tensor scales, see the decode
+                    # branch) when taking the Triton kernel.
                     _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
                         torch.float16
                     )
@@ -1869,14 +1878,17 @@ class FlashInferImpl(AttentionImpl):
                     if self.kv_cache_dtype == "int8_per_tensor" and (
                         _kv_cache_int8 is not None
                     ) and _use_triton_decode:
-                        # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
-                        # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
-                        # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),
-                        # 只处理请求块, 实测 42.8 tok/s。prefill 仍走 FlashInfer
-                        # (反量化路径, 1400+ tok/s)。用原始 int8 cache + 张量 scale。
-                        # 仅限每请求 1 token 的常规 decode (num_decode_tokens ==
-                        # num_decodes); 推测解码产生多 token 时回退 FlashInfer
-                        # 路径 (per-request metadata 语义不同, 见 #99 复审)。
+                        # [FORK] int8 decode goes through the Triton kernel:
+                        # FlashInfer 0.6.8 has no int8 decode template (whole-
+                        # pool dequant: 5.7 tok/s); Triton unified_attention
+                        # handles native int8 (INT8_PER_TENSOR branch), request
+                        # blocks only, measured 42.8 tok/s. Prefill stays on
+                        # FlashInfer (dequant path, 1400+ tok/s) using the raw
+                        # int8 cache + tensor scales. Only for regular 1-token
+                        # decode (num_decode_tokens == num_decodes); speculative
+                        # decode with multiple tokens falls back to the
+                        # FlashInfer path (per-request metadata semantics differ,
+                        # see review #99).
                         from vllm.v1.attention.ops.triton_unified_attention import (
                             unified_attention,
                         )
@@ -2026,8 +2038,8 @@ class FlashInferImpl(AttentionImpl):
             k_cache = kv_cache[:, 0]
             v_cache = kv_cache[:, 1]
             if self.kv_cache_dtype == "int8_per_tensor":
-                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash 无 int8
-                # 分支, 改用 Triton 版 (与 TRITON_ATTN 后端同款, 支持 int8+scale)
+                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash lacks an
+                # int8 branch; use the Triton version (same as TRITON_ATTN backend)
                 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
                     triton_reshape_and_cache_flash,
                 )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,6 +1292,9 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
+    # [FORK] int8_per_tensor 未校准警告去重标志
+    _warned_uncalibrated = False
+
     def __init__(
         self,
         num_heads: int,
@@ -1501,6 +1504,21 @@ class FlashInferImpl(AttentionImpl):
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                if layer._k_scale_float == 1.0:
+                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
+                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
+                    # scale 保持 1.0 → 数据错误。每层只提示一次。
+                    if not FlashInferImpl._warned_uncalibrated:
+                        logger.warning(
+                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
+                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            layer.layer_name,
+                        )
+                        FlashInferImpl._warned_uncalibrated = True
+                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
+                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
+                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
+                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
                 _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
                     torch.float16
                 )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1277,6 +1277,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
                     disable_split_kv=self.disable_split_kv,
                 )
                 attn_metadata.decode = FIDecode(wrapper=decode_wrapper)
+        # [FORK] int8_per_tensor decode 走 Triton 内核用 (FlashInfer 0.6.8
+        # 无 int8 decode 模板;全池反量化 5.7 tok/s vs Triton 42.8 tok/s)。
+        # 动态属性而非 dataclass 字段: _copy_tensor_tree 遍历 dataclass 字段
+        # 并 copy_, 视图与底层 buffer 同内存会触发 graph 捕获崩溃。
+        attn_metadata.seq_lens = seq_lens
+        attn_metadata.block_table = block_table_tensor
         return attn_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
@@ -1359,6 +1365,39 @@ class FlashInferImpl(AttentionImpl):
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
+
+        # [FORK] int8 decode 走 Triton unified_attention 的 3D 分段参数
+        # (同 triton_attn.py): 长上下文 decode 用 3D 分段并行 softmax,
+        # 否则 2D 单段串行扫全部 KV → 32K 语境 decode 3.4 tok/s vs 26。
+        self._decode_3d: dict | None = None
+        if kv_cache_dtype == "int8_per_tensor":
+            MIN_LAUNCH_GRID_SIZE_2D = 128
+            NUM_PAR_SOFTMAX_SEGMENTS = 16
+            seq_threshold = MIN_LAUNCH_GRID_SIZE_2D // num_kv_heads
+            if vllm_config is not None:
+                capture_sizes = (
+                    vllm_config.compilation_config.cudagraph_capture_sizes
+                )
+                if capture_sizes:
+                    seq_threshold = min(
+                        capture_sizes,
+                        key=lambda x: abs(x - seq_threshold),
+                    )
+            headdim_padded = head_size  # 128 已是 2 的幂
+            self._decode_3d = {
+                "seq_threshold_3D": seq_threshold,
+                "num_par_softmax_segments": NUM_PAR_SOFTMAX_SEGMENTS,
+                "softmax_segm_output": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS,
+                     headdim_padded),
+                    dtype=torch.float32, device="cuda"),
+                "softmax_segm_max": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS),
+                    dtype=torch.float32, device="cuda"),
+                "softmax_segm_expsum": torch.empty(
+                    (seq_threshold, num_heads, NUM_PAR_SOFTMAX_SEGMENTS),
+                    dtype=torch.float32, device="cuda"),
+            }
 
         # Pre-allocated FP8 output buffer for NVFP4 without fused output quant.
         if self.is_kvcache_nvfp4 and vllm_config is not None:
@@ -1499,37 +1538,44 @@ class FlashInferImpl(AttentionImpl):
         ):
             if self.kv_cache_dtype == "int8_per_tensor":
                 # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
-                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
-                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
+                # 枚举有但模板无, 直接喂会 illegal address)。prefill 反量化成
+                # fp16 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半;
+                # decode 走 Triton 内核 (原生 int8) 用原始 cache, 不反量化
+                # (decode-only 每步省全池反量化 ~17GB 流量, 5.7 → 42 tok/s)。
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
-                if layer._k_scale_float == 1.0:
-                    # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
-                    # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
-                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
-                    if layer.layer_name not in \
-                            FlashInferImpl._warned_uncalibrated_layers:
-                        logger.warning(
-                            "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
-                            "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
-                            layer.layer_name,
-                        )
-                        FlashInferImpl._warned_uncalibrated_layers.add(
-                            layer.layer_name
-                        )
-                # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
-                # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
-                # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA
-                # graph 捕获折叠成常量 (启动时未校准 = 1.0) → 数据错误。
-                _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
-                    torch.float16
-                )
-                _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
-                    torch.float16
-                )
-                kv_cache = torch.stack((_k, _v), dim=1)
+                _kv_cache_int8 = kv_cache
+                if attn_metadata.num_prefill_tokens > 0:
+                    if layer._k_scale_float == 1.0:
+                        # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA
+                        # graph) 时校准被跳过 (calc_kv_scales 零值跳过 + graph
+                        # 模式 return), scale 保持 1.0 → 数据错误。按层去重
+                        # (每层最多一次), 避免 graph 捕获阶段刷屏且真实请求
+                        # 时仍能看到提示。
+                        if layer.layer_name not in \
+                                FlashInferImpl._warned_uncalibrated_layers:
+                            logger.warning(
+                                "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
+                                "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
+                                layer.layer_name,
+                            )
+                            FlashInferImpl._warned_uncalibrated_layers.add(
+                                layer.layer_name
+                            )
+                    # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值
+                    # 一层 ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入,
+                    # 回放时读到校准后的值; 用 _k_scale_float (Python float)
+                    # 会被 CUDA graph 捕获折叠成常量 (启动时未校准 = 1.0) →
+                    # 数据错误。decode 分支走 Triton 内核时用 _kv_cache_int8
+                    # (原始 int8 + 张量 scale, 见 decode 分支)。
+                    _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
+                        torch.float16
+                    )
+                    _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
+                        torch.float16
+                    )
+                    kv_cache = torch.stack((_k, _v), dim=1)
             else:
                 torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
                     self.kv_cache_dtype
@@ -1811,14 +1857,71 @@ class FlashInferImpl(AttentionImpl):
                         get_dcp_group(),
                     )
                 else:
-                    decode_wrapper.run(
-                        decode_query,
-                        kv_cache_permute,
-                        k_scale=_kv_scale[0],
-                        v_scale=_kv_scale[1],
-                        out=out_decode,
-                        kv_cache_sf=kv_cache_sf,
-                    )
+                    if self.kv_cache_dtype == "int8_per_tensor" and (
+                        _kv_cache_int8 is not None
+                    ):
+                        # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
+                        # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
+                        # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),
+                        # 只处理请求块, 实测 42.8 tok/s。prefill 仍走 FlashInfer
+                        # (反量化路径, 1400+ tok/s)。用原始 int8 cache + 张量 scale。
+                        import os
+                        if os.environ.get("VLLM_INT8_DECODE_TRITON_DEBUG"):
+                            print(
+                                f"[FORK-DBG] decode Triton 路径: dtype="
+                                f"{self.kv_cache_dtype} n={num_decode_tokens}",
+                                flush=True,
+                            )
+                        from vllm.v1.attention.ops.triton_unified_attention import (
+                            unified_attention,
+                        )
+                        from vllm.v1.kv_cache_interface import KVQuantMode
+
+                        num_seqs = num_decode_tokens
+                        key_cache_i8, value_cache_i8 = _kv_cache_int8.unbind(1)
+                        seqused_k = attn_metadata.seq_lens[:num_seqs]
+                        cu_seqlens_q = torch.arange(
+                            num_seqs + 1,
+                            device=decode_query.device,
+                            dtype=torch.int32,
+                        )
+                        descale_shape = (num_seqs, key_cache_i8.shape[2])
+                        d3 = self._decode_3d or {}
+                        unified_attention(
+                            q=decode_query,
+                            k=key_cache_i8,
+                            v=value_cache_i8,
+                            out=out_decode,
+                            cu_seqlens_q=cu_seqlens_q,
+                            max_seqlen_q=1,
+                            seqused_k=seqused_k,
+                            max_seqlen_k=seqused_k.max(),
+                            softmax_scale=self.scale,
+                            causal=True,
+                            window_size=self.sliding_window,
+                            block_table=attn_metadata.block_table[:num_seqs],
+                            softcap=self.logits_soft_cap or 0.0,
+                            q_descale=None,
+                            k_descale=layer._k_scale.expand(descale_shape),
+                            v_descale=layer._v_scale.expand(descale_shape),
+                            seq_threshold_3D=d3.get("seq_threshold_3D"),
+                            num_par_softmax_segments=d3.get(
+                                "num_par_softmax_segments"
+                            ),
+                            softmax_segm_output=d3.get("softmax_segm_output"),
+                            softmax_segm_max=d3.get("softmax_segm_max"),
+                            softmax_segm_expsum=d3.get("softmax_segm_expsum"),
+                            kv_quant_mode=KVQuantMode.INT8_PER_TENSOR,
+                        )
+                    else:
+                        decode_wrapper.run(
+                            decode_query,
+                            kv_cache_permute,
+                            k_scale=_kv_scale[0],
+                            v_scale=_kv_scale[1],
+                            out=out_decode,
+                            kv_cache_sf=kv_cache_sf,
+                        )
 
                 if needs_fp8_out:
                     output[:num_decode_tokens].copy_(out_decode.to(output.dtype))

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -292,11 +292,12 @@ class BatchDCPPrefillWrapper:
         prefill_query_across_dcp = get_dcp_group().all_gather(
             prefill_query.contiguous(), dim=1
         )
+        _is_i8 = getattr(layer, "kv_cache_dtype", "") == "int8_per_tensor"
         output_context_tmp, lse_context_tmp = self._context.run(
             prefill_query_across_dcp,
             kv_cache_permute,
-            k_scale=layer._k_scale_float,
-            v_scale=layer._v_scale_float,
+            k_scale=(1.0 if _is_i8 else layer._k_scale_float),
+            v_scale=(1.0 if _is_i8 else layer._v_scale_float),
             return_lse=True,
         )
         output_context, lse_context = self._dcp_combine(
@@ -335,6 +336,9 @@ class FlashInferBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "nvfp4",
+        # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支, 在 forward 里
+        # 反量化成 fp16 临时 buffer 再喂内核 (KV 存储仍减半, 反量化开销 ~带宽)
+        "int8_per_tensor",
     ]
 
     @staticmethod
@@ -627,7 +631,12 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             # Cannot use self.kv_cache_spec.dtype here because kv_cache_spec
             # storage dtype may not be the same as the op dtype (uint8 vs fp8_e4m3)
             self.is_kvcache_nvfp4 = self.cache_dtype == "nvfp4"
-            if self.is_kvcache_nvfp4:
+            if self.cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 0.6.8 内核无 int8 分支,
+                # forward 里反量化成 fp16 临时 buffer 再喂内核; 这里告知
+                # FlashInfer 数据是 fp16 (plan 的 kv_data_type)。
+                self.kv_cache_dtype = torch.float16
+            elif self.is_kvcache_nvfp4:
                 # For NVFP4, kv_cache_dtype stays as the string "nvfp4"
                 # which is passed to FlashInferImpl
                 self.kv_cache_dtype = self.cache_dtype
@@ -1416,14 +1425,20 @@ class FlashInferImpl(AttentionImpl):
             f"got {query.dtype}"
         )
 
+        # [FORK] int8_per_tensor 走反量化路径 (数据已含 scale), 不折叠进 bmm
+        _is_int8_dequant = self.kv_cache_dtype == "int8_per_tensor"
+        # [FORK] int8_per_tensor: KV 已反量化为 fp16 真实值, 不能再传
+        # k_scale/v_scale 给 FlashInfer (否则双重 scale 导致乱码)
+        _kv_scale = (1.0, 1.0) if _is_int8_dequant else (
+            layer._k_scale_float, layer._v_scale_float)
         if self.bmm1_scale is None:
             self.bmm1_scale = self.scale
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
 
         if self.bmm2_scale is None:
             self.bmm2_scale = 1.0
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if is_quantized_kv_cache(self.kv_cache_dtype) and not _is_int8_dequant:
                 self.bmm2_scale *= layer._v_scale_float
 
         prefill_use_trtllm = isinstance(attn_metadata.prefill, TRTLLMPrefill)
@@ -1479,10 +1494,25 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
-            torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
-                self.kv_cache_dtype
-            )
-            kv_cache = kv_cache.view(torch_dtype)
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
+                # 枚举有但模板无, 直接喂会 illegal address)。反量化成 fp16
+                # 临时 buffer (K/V 各自 scale), 存储仍为 int8 减半。
+                # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
+                # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
+                # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                _k = kv_cache[:, 0].to(torch.float16) * layer._k_scale.to(
+                    torch.float16
+                )
+                _v = kv_cache[:, 1].to(torch.float16) * layer._v_scale.to(
+                    torch.float16
+                )
+                kv_cache = torch.stack((_k, _v), dim=1)
+            else:
+                torch_dtype = FlashInferBackend.get_dtype_for_flashinfer(
+                    self.kv_cache_dtype
+                )
+                kv_cache = kv_cache.view(torch_dtype)
 
         # Inputs and outputs may be padded for CUDA graphs
         query = query[:num_actual_tokens]
@@ -1595,8 +1625,8 @@ class FlashInferImpl(AttentionImpl):
                     prefill_wrapper.run(
                         prefill_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_prefill,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1746,8 +1776,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=output_tmp,
                         lse=lse,
                         return_lse=True,
@@ -1762,8 +1792,8 @@ class FlashInferImpl(AttentionImpl):
                     decode_wrapper.run(
                         decode_query,
                         kv_cache_permute,
-                        k_scale=layer._k_scale_float,
-                        v_scale=layer._v_scale_float,
+                        k_scale=_kv_scale[0],
+                        v_scale=_kv_scale[1],
                         out=out_decode,
                         kv_cache_sf=kv_cache_sf,
                     )
@@ -1865,16 +1895,33 @@ class FlashInferImpl(AttentionImpl):
             # actual tokens.
             k_cache = kv_cache[:, 0]
             v_cache = kv_cache[:, 1]
-            torch.ops._C_cache_ops.reshape_and_cache_flash(
-                key,
-                value,
-                k_cache,
-                v_cache,
-                slot_mapping,
-                self.kv_cache_dtype,
-                layer._k_scale,
-                layer._v_scale,
-            )
+            if self.kv_cache_dtype == "int8_per_tensor":
+                # [FORK] int8_per_tensor: C++ reshape_and_cache_flash 无 int8
+                # 分支, 改用 Triton 版 (与 TRITON_ATTN 后端同款, 支持 int8+scale)
+                from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+                    triton_reshape_and_cache_flash,
+                )
+                triton_reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
+            else:
+                torch.ops._C_cache_ops.reshape_and_cache_flash(
+                    key,
+                    value,
+                    k_cache,
+                    v_cache,
+                    slot_mapping,
+                    self.kv_cache_dtype,
+                    layer._k_scale,
+                    layer._v_scale,
+                )
 
 
 def fast_plan_decode(

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1292,8 +1292,8 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 class FlashInferImpl(AttentionImpl):
     can_return_lse_for_decode: bool = True
 
-    # [FORK] int8_per_tensor 未校准警告去重标志
-    _warned_uncalibrated = False
+    # [FORK] int8_per_tensor 未校准警告去重 (按层记录, 每层最多一次)
+    _warned_uncalibrated_layers: set = set()
 
     def __init__(
         self,
@@ -1507,14 +1507,18 @@ class FlashInferImpl(AttentionImpl):
                 if layer._k_scale_float == 1.0:
                     # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA graph)
                     # 时校准被跳过 (calc_kv_scales 零值跳过 + graph 模式 return),
-                    # scale 保持 1.0 → 数据错误。每层只提示一次。
-                    if not FlashInferImpl._warned_uncalibrated:
+                    # scale 保持 1.0 → 数据错误。按层去重 (每层最多一次),
+                    # 避免 graph 捕获阶段刷屏且真实请求时仍能看到提示。
+                    if layer.layer_name not in \
+                            FlashInferImpl._warned_uncalibrated_layers:
                         logger.warning(
-                            "[FORK-INT8] int8 KV 未校准 (scale=1.0), 首个请求请用 "
-                            ">=2048 tokens 的长 prompt 触发校准 (layer=%s)",
+                            "[FORK-INT8] %s int8 KV 未校准 (scale=1.0), "
+                            "首个请求请用 >=2048 tokens 的长 prompt 触发校准",
                             layer.layer_name,
                         )
-                        FlashInferImpl._warned_uncalibrated = True
+                        FlashInferImpl._warned_uncalibrated_layers.add(
+                            layer.layer_name
+                        )
                 # 反量化 (逐层临时分配, 层间串行执行自然释放; 实测峰值一层
                 # ~700MB, 256K 场景验证过)。张量 scale 是 graph 输入, 回放时
                 # 读到校准后的值; 用 _k_scale_float (Python float) 会被 CUDA

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1536,6 +1536,8 @@ class FlashInferImpl(AttentionImpl):
         if self.kv_sharing_target_layer_name is None and is_quantized_kv_cache(
             self.kv_cache_dtype
         ):
+            # [FORK] decode 是否走 Triton 快速路径 (int8 且每请求 1 token 无 padding)
+            _use_triton_decode = False
             if self.kv_cache_dtype == "int8_per_tensor":
                 # [FORK] int8_per_tensor: FlashInfer 内核无 int8 分支 (0.6.8
                 # 枚举有但模板无, 直接喂会 illegal address)。prefill 反量化成
@@ -1545,8 +1547,15 @@ class FlashInferImpl(AttentionImpl):
                 # 注意: 必须用张量 _k_scale/_v_scale (graph 输入, 回放时读到
                 # 校准后的值); 用 _k_scale_float (Python float) 会被 CUDA graph
                 # 捕获时折叠成常量 (启动时未校准 = 1.0) → 回放时数据错误。
+                # [FORK] 仅当 decode 为"每请求 1 token 且无 padding rows"
+                # (num_decode_tokens == num_decodes) 时走 Triton 快速路径;
+                # 推测解码或多 token 时回退 FlashInfer, 此时必须反量化
+                # (decode-only 回退也反量化, 否则 int8 cache 喂 FlashInfer 崩)。
+                _use_triton_decode = (
+                    attn_metadata.num_decode_tokens == attn_metadata.num_decodes
+                )
                 _kv_cache_int8 = kv_cache
-                if attn_metadata.num_prefill_tokens > 0:
+                if attn_metadata.num_prefill_tokens > 0 or not _use_triton_decode:
                     if layer._k_scale_float == 1.0:
                         # [FORK] 首个请求为短请求 (<2048 tokens, 全走 CUDA
                         # graph) 时校准被跳过 (calc_kv_scales 零值跳过 + graph
@@ -1859,7 +1868,7 @@ class FlashInferImpl(AttentionImpl):
                 else:
                     if self.kv_cache_dtype == "int8_per_tensor" and (
                         _kv_cache_int8 is not None
-                    ) and num_decode_tokens == attn_metadata.num_decodes:
+                    ) and _use_triton_decode:
                         # [FORK] int8 decode 走 Triton 内核: FlashInfer 0.6.8
                         # 无 int8 decode 模板, 全池反量化 5.7 tok/s; Triton
                         # unified_attention 原生 int8 (INT8_PER_TENSOR 分支),

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -297,6 +297,7 @@ class TritonAttentionMetadata:
     block_table: torch.Tensor
     slot_mapping: torch.Tensor
     num_computed_tokens_cpu: torch.Tensor | None
+    is_prefilling: torch.Tensor | None
 
     seq_threshold_3D: int
     num_par_softmax_segments: int
@@ -489,6 +490,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             block_table=block_table_tensor,
             slot_mapping=slot_mapping,
             num_computed_tokens_cpu=num_computed_tokens_cpu,
+            is_prefilling=common_attn_metadata.is_prefilling,
             use_cascade=use_cascade,
             common_prefix_len=common_prefix_len,
             cu_prefix_query_lens=cu_prefix_query_lens,

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -1828,7 +1828,7 @@ class TritonAttentionImpl(AttentionImpl):
             key_cache, value_cache = kv_cache.unbind(1)
             if (
                 is_quantized_kv_cache(self.kv_cache_dtype)
-                # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8, 无需 fp8 view
+                # [FORK-PORT] PR#41505: int8_per_tensor is already int8; no fp8 view needed
                 and self.kv_cache_dtype != "int8_per_tensor"
             ):
                 if key_cache.dtype != self.fp8_dtype:
@@ -1998,7 +1998,7 @@ class TritonAttentionImpl(AttentionImpl):
         key_cache, value_cache = kv_cache.unbind(1)
         if (
             is_quantized_kv_cache(self.kv_cache_dtype)
-            # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8
+            # [FORK-PORT] PR#41505: int8_per_tensor is already int8
             and self.kv_cache_dtype != "int8_per_tensor"
         ):
             key_cache = key_cache.view(self.fp8_dtype)

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -517,6 +517,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "int8_per_tensor",  # [FORK-PORT] PR#41505
         "int8_per_token_head",
         "fp8_per_token_head",
     ]
@@ -1822,10 +1823,14 @@ class TritonAttentionImpl(AttentionImpl):
             v_descale = None
             k_scale_cache = self._k_scale_cache
             v_scale_cache = self._v_scale_cache
-        # FP8 per-tensor / auto path (original flow).
+        # FP8 per-tensor / INT8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if (
+                is_quantized_kv_cache(self.kv_cache_dtype)
+                # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8, 无需 fp8 view
+                and self.kv_cache_dtype != "int8_per_tensor"
+            ):
                 if key_cache.dtype != self.fp8_dtype:
                     key_cache = key_cache.view(self.fp8_dtype)
                     value_cache = value_cache.view(self.fp8_dtype)
@@ -1991,7 +1996,11 @@ class TritonAttentionImpl(AttentionImpl):
             return
         # For decoder and cross-attention, use KV cache as before.
         key_cache, value_cache = kv_cache.unbind(1)
-        if is_quantized_kv_cache(self.kv_cache_dtype):
+        if (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            # [FORK-PORT] PR#41505: int8_per_tensor 本身就是 int8
+            and self.kv_cache_dtype != "int8_per_tensor"
+        ):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
         triton_reshape_and_cache_flash(

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -38,6 +38,10 @@ def reshape_and_cache_kernel_flash(
     USE_HEAD_MAJOR_LAYOUT: tl.constexpr,
     # FP8 flags
     FP8_KV_CACHE: tl.constexpr,
+    # [FORK-PORT] PR#41505: INT8 per-tensor flag + platform flags
+    INT8_KV_CACHE: tl.constexpr,
+    IS_ROCM: tl.constexpr,
+    IS_CUDA: tl.constexpr,
     # tune parameters
     TILE_SIZE: tl.constexpr,
 ):
@@ -90,7 +94,18 @@ def reshape_and_cache_kernel_flash(
     key_load = tl.load(
         key_ptr + src_key_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        k_scale_val = tl.load(k_scale)
+        k_scaled = key_load.to(tl.float32) / k_scale_val
+        if IS_ROCM:
+            k_rounded = tl.extra.hip.libdevice.nearbyint(k_scaled)
+        elif IS_CUDA:
+            k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
+        else:
+            k_rounded = tl.floor(k_scaled + 0.5)
+        key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,
         # based on the key_cache_ptr.dtype.element_ty
         key_tile = key_load if key_load.dtype.is_fp8() else key_load / tl.load(k_scale)
@@ -101,7 +116,18 @@ def reshape_and_cache_kernel_flash(
     value_load = tl.load(
         value_ptr + src_value_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
+        v_scale_val = tl.load(v_scale)
+        v_scaled = value_load.to(tl.float32) / v_scale_val
+        if IS_ROCM:
+            v_rounded = tl.extra.hip.libdevice.nearbyint(v_scaled)
+        elif IS_CUDA:
+            v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
+        else:
+            v_rounded = tl.floor(v_scaled + 0.5)
+        value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():
             value_tile = value_load
         else:
@@ -353,14 +379,20 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    kv_cache_torch_dtype = (
-        current_platform.fp8_dtype()
-        if is_quantized_kv_cache(kv_cache_dtype)
-        else key_cache.dtype
-    )
+    # [FORK-PORT] PR#41505: int8_per_tensor 走 torch.int8, 不做 fp8 view
+    is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
+    is_int8 = kv_cache_dtype.startswith("int8")
+    if is_int8:
+        kv_cache_torch_dtype = torch.int8
+    elif is_quantized_kv_cache(kv_cache_dtype):
+        kv_cache_torch_dtype = current_platform.fp8_dtype()
+    else:
+        kv_cache_torch_dtype = key_cache.dtype
 
-    if key_cache.dtype != kv_cache_torch_dtype and is_quantized_kv_cache(
-        kv_cache_dtype
+    if (
+        not is_int8
+        and key_cache.dtype != kv_cache_torch_dtype
+        and is_quantized_kv_cache(kv_cache_dtype)
     ):
         # to avoid erounous implicit cast in triton kernel (tl.store to uint8)
         # (e.g. explicit cast to fp8e4m3fnuz is not supported in triton 3.4)
@@ -371,7 +403,8 @@ def triton_reshape_and_cache_flash(
         "uint8 is not supported by triton reshape_and_cache_flash"
     )
 
-    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype)
+    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype) and not is_int8
+    INT8_KV_CACHE = is_int8_per_tensor
     assert (not FP8_KV_CACHE) or kv_cache_torch_dtype in [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -379,8 +412,8 @@ def triton_reshape_and_cache_flash(
         torch.float8_e4m3fnuz,
     ], (
         "unsupported dtype of KV cache tensor, got "
-        "{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
-        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz."
+        f"{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
+        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz, int8."
     )
 
     # heuristics instead of autotuning
@@ -423,6 +456,10 @@ def triton_reshape_and_cache_flash(
         x=x,
         USE_HEAD_MAJOR_LAYOUT=use_head_major_layout,
         FP8_KV_CACHE=FP8_KV_CACHE,
+        # [FORK-PORT] PR#41505
+        INT8_KV_CACHE=INT8_KV_CACHE,
+        IS_ROCM=current_platform.is_rocm(),
+        IS_CUDA=current_platform.is_cuda(),
         # autotune parameters
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -379,7 +379,7 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    # [FORK-PORT] PR#41505: int8_per_tensor 走 torch.int8, 不做 fp8 view
+    # [FORK-PORT] PR#41505: int8_per_tensor uses torch.int8 directly; no fp8 view
     is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
     is_int8 = kv_cache_dtype.startswith("int8")
     if is_int8:

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -38,10 +38,8 @@ def reshape_and_cache_kernel_flash(
     USE_HEAD_MAJOR_LAYOUT: tl.constexpr,
     # FP8 flags
     FP8_KV_CACHE: tl.constexpr,
-    # [FORK-PORT] PR#41505: INT8 per-tensor flag + platform flags
+    # [FORK-PORT] PR#41505: INT8 per-tensor flag
     INT8_KV_CACHE: tl.constexpr,
-    IS_ROCM: tl.constexpr,
-    IS_CUDA: tl.constexpr,
     # tune parameters
     TILE_SIZE: tl.constexpr,
 ):
@@ -98,18 +96,15 @@ def reshape_and_cache_kernel_flash(
         # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
         k_scale_val = tl.load(k_scale)
         k_scaled = key_load.to(tl.float32) / k_scale_val
-        if IS_ROCM:
-            k_rounded = tl.extra.hip.libdevice.nearbyint(k_scaled)
-        elif IS_CUDA:
-            k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
-        else:
-            # Round half away from zero (floor(x+0.5) is wrong for negative
-            # half-integers: -1.5 would floor to -1 instead of -2).
-            k_rounded = tl.where(
-                k_scaled >= 0.0,
-                tl.floor(k_scaled + 0.5),
-                tl.ceil(k_scaled - 0.5),
-            )
+        # Round half away from zero on every platform. rint/nearbyint use
+        # ties-to-even (2.5 -> 2), which breaks the symmetric int8 rounding
+        # (floor(x+0.5) is also wrong for negative half-integers: -1.5 would
+        # floor to -1 instead of -2). Use explicit sign-aware floor/ceil.
+        k_rounded = tl.where(
+            k_scaled >= 0.0,
+            tl.floor(k_scaled + 0.5),
+            tl.ceil(k_scaled - 0.5),
+        )
         key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
     elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,
@@ -126,18 +121,13 @@ def reshape_and_cache_kernel_flash(
         # [FORK-PORT] PR#41505: INT8 per-tensor: quantize to [-128, 127]
         v_scale_val = tl.load(v_scale)
         v_scaled = value_load.to(tl.float32) / v_scale_val
-        if IS_ROCM:
-            v_rounded = tl.extra.hip.libdevice.nearbyint(v_scaled)
-        elif IS_CUDA:
-            v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
-        else:
-            # Round half away from zero (mirror of the K branch fix; floor(x+0.5)
-            # is wrong for negative half-integers).
-            v_rounded = tl.where(
-                v_scaled >= 0.0,
-                tl.floor(v_scaled + 0.5),
-                tl.ceil(v_scaled - 0.5),
-            )
+        # Mirror of the K branch: half away from zero on every platform
+        # (rint/nearbyint use ties-to-even; floor(x+0.5) mishandles negatives).
+        v_rounded = tl.where(
+            v_scaled >= 0.0,
+            tl.floor(v_scaled + 0.5),
+            tl.ceil(v_scaled - 0.5),
+        )
         value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
     elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():
@@ -470,8 +460,6 @@ def triton_reshape_and_cache_flash(
         FP8_KV_CACHE=FP8_KV_CACHE,
         # [FORK-PORT] PR#41505
         INT8_KV_CACHE=INT8_KV_CACHE,
-        IS_ROCM=current_platform.is_rocm(),
-        IS_CUDA=current_platform.is_cuda(),
         # autotune parameters
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -131,7 +131,13 @@ def reshape_and_cache_kernel_flash(
         elif IS_CUDA:
             v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
         else:
-            v_rounded = tl.floor(v_scaled + 0.5)
+            # Round half away from zero (mirror of the K branch fix; floor(x+0.5)
+            # is wrong for negative half-integers).
+            v_rounded = tl.where(
+                v_scaled >= 0.0,
+                tl.floor(v_scaled + 0.5),
+                tl.ceil(v_scaled - 0.5),
+            )
         value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
     elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -103,7 +103,13 @@ def reshape_and_cache_kernel_flash(
         elif IS_CUDA:
             k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
         else:
-            k_rounded = tl.floor(k_scaled + 0.5)
+            # Round half away from zero (floor(x+0.5) is wrong for negative
+            # half-integers: -1.5 would floor to -1 instead of -2).
+            k_rounded = tl.where(
+                k_scaled >= 0.0,
+                tl.floor(k_scaled + 0.5),
+                tl.ceil(k_scaled - 0.5),
+            )
         key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
     elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -46,11 +46,16 @@ def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
       their scales separately on S/P inside the loop.
     - ``KV_QUANT_MODE == 1`` (FP8 per-tensor): dequantize using the
       tensor-wide scale.
+    - ``KV_QUANT_MODE == 5`` (INT8 per-tensor): plain cast.  Scale applied
+      post-matmul via folding into softmax_scale / acc.  [FORK-PORT] PR#41505
     """
     if KV_QUANT_MODE == 1:
         if Q.dtype.is_fp8():
             return data.to(Q.dtype)
         return (data.to(tl.float32) * tl.load(tensor_scale)).to(Q.dtype)
+    if KV_QUANT_MODE == 5:
+        # INT8 per-tensor: plain cast, scale folded into S and acc post-matmul
+        return data.to(Q.dtype)
     return data.to(Q.dtype)
 
 
@@ -131,7 +136,7 @@ def kernel_unified_attention(
     IS_3D: tl.constexpr,
     # KV cache quantization mode handled inside this kernel via constexpr
     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
-    # FP8_PER_TOKEN_HEAD (3).
+    # FP8_PER_TOKEN_HEAD (3), INT8_PER_TENSOR (5).  [FORK-PORT] PR#41505
     KV_QUANT_MODE: tl.constexpr = 0,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
@@ -141,7 +146,10 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
+    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) 不是 per-token-head
+    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
+        KV_QUANT_MODE == 3
+    )
 
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -227,6 +235,13 @@ def kernel_unified_attention(
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
     )
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — fold k_scale into softmax
+    # scale (zero inner-loop overhead), apply v_scale once post-loop
+    if KV_QUANT_MODE == 5:
+        int8_k_scale_val = tl.load(k_scale)
+        int8_v_scale_val = tl.load(v_scale)
+        scale = scale * int8_k_scale_val
 
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
@@ -338,6 +353,10 @@ def kernel_unified_attention(
             acc += tl.dot(P_v, V)
         else:
             acc += tl.dot(P.to(V.dtype), V)
+
+    # [FORK-PORT] PR#41505: INT8 per-tensor — apply v_scale once on output
+    if KV_QUANT_MODE == 5:
+        acc = acc * int8_v_scale_val
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -146,7 +146,7 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) 不是 per-token-head
+    # [FORK-PORT] PR#41505: mode 5 (INT8 per-tensor) is not per-token-head
     USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
         KV_QUANT_MODE == 3
     )

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -46,6 +46,9 @@ class KVQuantMode(IntEnum):
     INT8_PER_TOKEN_HEAD = 2  # per-token-head dynamic scales for int8
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
+    # [FORK-PORT] PR#41505 int8_per_tensor: 5 = symmetric INT8 per-tensor scale KV
+    # (原生 int→float 转换, sm_75 无 FP8 硬件时唯一 8bit KV 路径; 上游未合并, 见研究文档)
+    INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property
     def is_per_token_head(self) -> bool:
@@ -69,6 +72,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.FP8_PER_TOKEN_HEAD
     if kv_cache_dtype == "nvfp4":
         return KVQuantMode.NVFP4
+    if kv_cache_dtype == "int8_per_tensor":
+        return KVQuantMode.INT8_PER_TENSOR
     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):
         return KVQuantMode.FP8_PER_TENSOR
     return KVQuantMode.NONE

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -47,7 +47,8 @@ class KVQuantMode(IntEnum):
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
     # [FORK-PORT] PR#41505 int8_per_tensor: 5 = symmetric INT8 per-tensor scale KV
-    # (原生 int→float 转换, sm_75 无 FP8 硬件时唯一 8bit KV 路径; 上游未合并, 见研究文档)
+    # (native int→float conversion, the only 8-bit KV path on sm_75 without FP8
+    # hardware; not merged upstream, see research notes)
     INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property


### PR DESCRIPTION
## Summary
int8 decode was 5.7 tok/s: whole-pool dequantization (343K tokens x 16 layers ≈ 17GB memory traffic per step) before every FlashInfer decode call. This routes decode through the Triton `unified_attention` kernel (native INT8_PER_TENSOR, processes only requested blocks) while keeping FlashInfer prefill (dequant path, 1400+ tok/s).

**Depends on #106 (int8 KV) — uses its dequant infra.**

## A/B benchmark (before/after, dual RTX 2080Ti, TP2)
| context | before (FlashInfer whole-pool dequant) | after (Triton decode) |
|---------|----------------------------------------|-----------------------|
| decode 1K | 5.7 tok/s | **42.2 tok/s** |
| decode 8K | 5.7 | 37.0 |
| decode 16K | 5.7 | 32.4 |
| decode 32K | 5.7 | 25.8 |
| decode 128K | 5.7 | 11.9 |
| decode 256K | 5.7 | 7.0 |
| prefill 8K | 1580 | 1575 tok/s (no regression) |
| prefill 32K | 1407 | 1411 |
| 128K prefill | 126.1s/1016 | 125.8s/1018 |

Quality: `12*8 = 96`, car-wash trap, 4K material — all pass.

## Implementation
- Decode-only batches skip whole-pool dequant (saves ~17GB/step)
- 3D segmented softmax (`seq_threshold_3D`, 16 softmax segments) fixes 2D serial degradation on long contexts (32K: 3.4 -> 25.8 tok/s)
- Speculative/multi-token decode (`num_decode_tokens != num_decodes`) and CUDA-graph padding rows fall back to FlashInfer with dequant (safe path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up INT8 decode by routing it through Triton unified_attention and reading native `int8_per_tensor` KV, eliminating whole‑pool dequantization (~5.7 tok/s → ~42 tok/s at 1K) while keeping FlashInfer for prefill with no regression. Old behavior dequantized the entire KV pool each step; new behavior processes only requested blocks and dequants only for prefill or fallback.

- Triton decode for `int8_per_tensor`: adds `KVQuantMode.INT8_PER_TENSOR`; folds k_scale into softmax scale and applies v_scale post‑accumulation; enables 3D segmented softmax; decodes from raw INT8 cache; `triton_reshape_and_cache_flash` quantizes with sign‑aware half‑away‑from‑zero rounding.
- FlashInfer remains for prefill: dequantizes to fp16 with tensor scales (avoids double scaling and CUDA‑graph constant folding); `flashinfer` metadata now carries `seq_lens` and `block_table` for Triton decode; decode fallback dequants before calling FlashInfer.
- Calibration (INT8 only): keep dynamic K/V scales on hybrid models; skip zero‑value warmups; guard during CUDA‑graph capture; calibrate K and V independently on the first real long prefill (>= 2048 tokens), restricted to actual prefill rows via `is_prefilling`; never calibrate on pure‑decode batches; warn once per layer when uncalibrated.
- Path selection: run Triton fast path only when each request decodes 1 token with no padding (`num_decode_tokens == num_decodes`); speculative/multi‑token decode and CUDA‑graph padding rows fall back to FlashInfer.
- Types/config: allow `int8_per_tensor` in `cache_dtype`; map to `torch.int8` and treat as quantized KV; keep `calculate_kv_scales` for `int8_per_tensor` on hybrid models (fp8 remains disabled).

**Rollout**
- Set `cache_dtype=int8_per_tensor`. Trigger calibration with a prompt >= 2048 tokens outside CUDA‑graph capture; warmups and pure‑decode batches defer calibration (single warning per layer).
- No changes for non‑INT8 models or prefill throughput; speculative/multi‑token decode and padding rows continue via the FlashInfer fallback.

<sup>Written for commit a3c381a3628db3c24e4a28504e6011babd523527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## ⚠️ Applying this PR alone (important)

This PR is one of a **4-PR series** (one concern per PR, per the maintainer's review guidance). The four together form the complete feature set the SM75 serving stack depends on:

| PR | concern | dependency |
|----|---------|------------|
| #106 | int8 per-tensor KV cache | foundation |
| #107 | GDN GGUF/AWQ dual-layout | REQUIRED to serve GDN models |
| #108 | disable custom AR during profiling | independent |
| #109 | Triton decode fast path | depends on #106 |

**Applying only a subset leaves the tree incomplete and unsafe for the production serve environment:**

- **Without #107**, serving a GDN (Qwen3.5-style) model fails at engine init ( / worker exception during CUDA-graph capture). On the reference hardware this produced a systemd  loop; the repeated load window escalated into a GPU **Xid 154 (recovery action 0x2, Node Reboot Required)**. The incomplete tree is NOT a safe state.
- **Without #106**, #109 has no int8 KV infrastructure to accelerate.
- **Merge order: #106 → #107 → #108 → #109** (or merge all four together).
