### PR TITLE
kv-cache: reserve the turboquant continuation-prefill workspace before sizing the KV cache (fixes a high-context Xid 31 crash class)

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
     VLLM_TURBOQUANT_CONTINUATION_PREFIX_COMBINE: Literal["off", "on", "auto"] = "auto"
     VLLM_TURBOQUANT_CONTINUATION_PREFIX_COMBINE_MIN_TOKENS: int = 20480
     VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS: int = 0
+    VLLM_TQ_RESERVE_PREFILL_WORKSPACE: bool = True
     VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK: int = 0
     VLLM_TURBOQUANT_CONTINUATION_SDPA_MAX_QK_CELLS: int = 0
     VLLM_TURBOQUANT_FORCE_DECODE_SDPA: bool = False
@@ -840,6 +841,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS": lambda: int(
         os.getenv("VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS", "0")
+    ),
+    # When serving a turboquant_* KV cache, reserve VRAM for the runtime
+    # continuation-prefill dequant workspace *before* the KV cache budget is
+    # sized, so max_model_len auto-caps to a value where KV + workspace fit.
+    # Default ON: it only makes sizing safer (never allocates more, only caps).
+    # Set to 0 to restore the legacy behaviour (KV cache sized ignoring the
+    # workspace, which can crash with an illegal memory access at deep prefill).
+    "VLLM_TQ_RESERVE_PREFILL_WORKSPACE": lambda: bool(
+        int(os.getenv("VLLM_TQ_RESERVE_PREFILL_WORKSPACE", "1"))
     ),
     "VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK": lambda: int(
         os.getenv("VLLM_TURBOQUANT_CONTINUATION_SDPA_Q_CHUNK", "0")

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1919,6 +1919,79 @@ def _project_kv_cache_groups_to_worker(
     return projected_groups
 
 
+# Mirror of turboquant_attn._CONTINUATION_DECODE_THRESHOLD: continuation
+# prefill only enters the large-dequant workspace path when the batched-token
+# budget exceeds this value. Kept local to avoid importing the CUDA/triton
+# attention backend into the (CPU-side) KV cache planner.
+_TQ_CONTINUATION_DECODE_THRESHOLD = 128
+
+
+def _turboquant_prefill_workspace_reserve_bytes(vllm_config: VllmConfig) -> int:
+    """Per-rank VRAM (bytes) that the runtime turboquant continuation-prefill
+    dequant workspace will occupy at deep prefill.
+
+    This is subtracted from the KV cache budget *before* ``num_gpu_blocks`` is
+    derived. Without it, the KV cache is sized to consume nearly all VRAM and
+    the continuation workspace (allocated after warmup, then locked) reads out
+    of bounds -> illegal memory access, instead of a clean startup cap.
+
+    The formula mirrors ``TurboQuantAttentionImpl._reserve_continuation_workspace``
+    exactly: two fp16 buffers of shape
+    ``(1, num_kv_heads_per_rank, reserve_cached_len, head_size)`` (k and v),
+    each 256-byte aligned (``WorkspaceManager.get_simultaneous`` alignment),
+    replicated across every workspace ubatch slot.
+
+    Returns 0 when the reservation does not apply: feature disabled, the cache
+    is not a ``turboquant_*`` cache, or the continuation path never triggers.
+    """
+    if not envs.VLLM_TQ_RESERVE_PREFILL_WORKSPACE:
+        return 0
+
+    cache_config = getattr(vllm_config, "cache_config", None)
+    cache_dtype = getattr(cache_config, "cache_dtype", None)
+    if not (isinstance(cache_dtype, str) and cache_dtype.startswith("turboquant_")):
+        return 0
+
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_batched_tokens = int(
+        getattr(scheduler_config, "max_num_batched_tokens", 0)
+        if scheduler_config is not None
+        else 0
+    )
+    if max_batched_tokens <= _TQ_CONTINUATION_DECODE_THRESHOLD:
+        return 0
+
+    block_size = int(getattr(cache_config, "block_size", 0) or 0)
+    if block_size <= 0:
+        block_size = max_batched_tokens
+    if block_size <= 0:
+        return 0
+
+    reserve_tokens = max(
+        max_batched_tokens,
+        int(envs.VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS),
+    )
+    reserve_cached_len = math.ceil(reserve_tokens / block_size) * block_size
+    if reserve_cached_len <= 0:
+        return 0
+
+    model_config = vllm_config.model_config
+    parallel_config = vllm_config.parallel_config
+    num_kv_heads = model_config.get_num_kv_heads(parallel_config)
+    head_size = model_config.get_head_size()
+
+    # One fp16 (2 bytes) buffer of shape (1, num_kv_heads, reserve_cached_len,
+    # head_size), 256-byte aligned to match get_simultaneous.
+    buf_bytes = round_up(num_kv_heads * reserve_cached_len * head_size * 2, 256)
+    # k + v are requested simultaneously (aligned bytes summed) ...
+    per_ubatch_bytes = 2 * buf_bytes
+    # ... and reserve_simultaneous_for_all_ubatches replicates the reservation
+    # across every workspace ubatch slot (2 under DBO, else 1; see
+    # gpu_worker.init_workspace_manager).
+    num_ubatches = 2 if getattr(parallel_config, "enable_dbo", False) else 1
+    return per_ubatch_bytes * num_ubatches
+
+
 def get_kv_cache_configs(
     vllm_config: VllmConfig,
     kv_cache_specs: list[dict[str, KVCacheSpec]],
@@ -1980,6 +2053,32 @@ def get_kv_cache_configs(
         _project_kv_cache_groups_to_worker(global_kv_cache_groups, worker_spec)
         for worker_spec in kv_cache_specs
     ]
+
+    # Reserve VRAM for the runtime turboquant continuation-prefill dequant
+    # workspace *before* deriving the KV cache budget. Otherwise the KV cache
+    # is sized to consume nearly all VRAM and the workspace (allocated after
+    # warmup, then locked) reads out of bounds -> illegal memory access at deep
+    # prefill. Subtracting here makes auto-fit, the admission check, and the
+    # per-worker config builder all plan against a budget that leaves room for
+    # the workspace, so an over-large max_model_len becomes a clean startup cap
+    # (the "estimated maximum model length" ValueError) instead of a crash.
+    # Applied before the num_gpu_blocks_override adjustment below so an explicit
+    # operator override still pins num_blocks exactly (reserve is a no-op then).
+    workspace_reserve = _turboquant_prefill_workspace_reserve_bytes(vllm_config)
+    if workspace_reserve > 0:
+        available_memory = [
+            avail_mem
+            if not groups
+            else max(0, avail_mem - workspace_reserve)
+            for groups, avail_mem in zip(projected_groups_per_worker, available_memory)
+        ]
+        logger.info(
+            "Reserving %s GiB per rank for the turboquant continuation-prefill "
+            "workspace before sizing the KV cache "
+            "(VLLM_TQ_RESERVE_PREFILL_WORKSPACE=1); set it to 0 to restore the "
+            "legacy sizing.",
+            format_gib(workspace_reserve),
+        )
 
     # If `num_gpu_blocks_override` is set, the cache size that will actually
     # be allocated is decoupled from the profiled `available_memory`:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -455,16 +455,28 @@ class Worker(WorkerBase):
         # exists at measurement time so the explicit reserve applies exactly
         # once, deterministically.
         if envs.VLLM_TQ_RESERVE_PREFILL_WORKSPACE:
+            from vllm.v1.core.kv_cache_utils import (
+                _turboquant_prefill_workspace_reserve_bytes,
+            )
             from vllm.v1.worker.workspace import workspace_manager_total_bytes
 
-            _tq_arena_bytes = workspace_manager_total_bytes()
-            if _tq_arena_bytes > 0:
-                self.available_kv_cache_memory_bytes += _tq_arena_bytes
+            # Add back ONLY the portion of the arena the KV-sizing reserve will
+            # re-subtract (review #111: the arena is shared with the decode /
+            # DCP / fused-moe workspaces, and the reserve is 0 for
+            # non-turboquant caches — adding back the whole arena would inflate
+            # the KV budget with no matching reserve).
+            _tq_reserve_bytes = _turboquant_prefill_workspace_reserve_bytes(
+                self.vllm_config
+            )
+            _tq_add_back = min(workspace_manager_total_bytes(), _tq_reserve_bytes)
+            if _tq_add_back > 0:
+                self.available_kv_cache_memory_bytes += _tq_add_back
                 logger.info(
-                    "Excluding %s GiB turboquant workspace arena from the "
-                    "profiled non-KV footprint (explicit reserve is applied "
-                    "once at KV sizing).",
-                    format_gib(_tq_arena_bytes),
+                    "Excluding %s GiB of the workspace arena (the turboquant "
+                    "continuation reserve portion) from the profiled non-KV "
+                    "footprint; the explicit reserve is applied once at KV "
+                    "sizing.",
+                    format_gib(_tq_add_back),
                 )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -446,6 +446,27 @@ class Worker(WorkerBase):
             - cudagraph_memory_estimate_applied
         )
 
+        # [FORK] With VLLM_TQ_RESERVE_PREFILL_WORKSPACE the turboquant
+        # continuation workspace is explicitly subtracted at KV-sizing time
+        # (get_kv_cache_configs). Whether the arena was ALSO captured in the
+        # profiled torch peak depends on allocation timing (load-time vs lazy
+        # first-touch), which made available memory vary boot-to-boot and
+        # intermittently double-counted the reserve. Add back whatever arena
+        # exists at measurement time so the explicit reserve applies exactly
+        # once, deterministically.
+        if envs.VLLM_TQ_RESERVE_PREFILL_WORKSPACE:
+            from vllm.v1.worker.workspace import workspace_manager_total_bytes
+
+            _tq_arena_bytes = workspace_manager_total_bytes()
+            if _tq_arena_bytes > 0:
+                self.available_kv_cache_memory_bytes += _tq_arena_bytes
+                logger.info(
+                    "Excluding %s GiB turboquant workspace arena from the "
+                    "profiled non-KV footprint (explicit reserve is applied "
+                    "once at KV sizing).",
+                    format_gib(_tq_arena_bytes),
+                )
+
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
         logger.debug(
             "Initial free memory: %s GiB; Requested memory: %f (util), %s GiB",

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -207,6 +207,22 @@ def is_workspace_manager_initialized() -> bool:
     return _manager is not None
 
 
+def workspace_manager_total_bytes() -> int:
+    """Total bytes currently allocated across all ubatch workspace arenas.
+
+    0 when the manager is not initialized. Used by memory profiling to keep
+    the turboquant workspace out of the measured non-KV footprint so the
+    explicit boot-time reserve (VLLM_TQ_RESERVE_PREFILL_WORKSPACE) is applied
+    exactly once regardless of when the arena happened to be allocated.
+    """
+    mgr = _manager
+    if mgr is None:
+        return 0
+    return sum(
+        mgr._workspace_size_bytes(ws) for ws in mgr._current_workspaces
+    )
+
+
 def current_workspace_manager() -> "WorkspaceManager":
     """Get the current workspace manager instance.
 


### PR DESCRIPTION
## Summary

At high `--max-model-len` with a `turboquant_*` KV cache, the KV pool is sized against all remaining VRAM — but the turboquant continuation-prefill workspace allocates lazily at request time. On memory-tight configs the pool claims memory the workspace later needs, and a large-context request then faults with an illegal memory access (Xid 31, MMU FAULT_PDE) instead of a clean error.

This PR reserves the workspace (K+V, 256-byte aligned, per ubatch slot) from `available_memory` **before** `get_kv_cache_configs` sizes the pool, so the boot-time `max_model_len` validation becomes honest: over-committed configs are refused at startup with the standard estimated-max message instead of crashing mid-request.

Env-gated: `VLLM_TQ_RESERVE_PREFILL_WORKSPACE` (default **on**; set `0` to restore legacy sizing — happy to flip the default if you prefer opt-in).

## Evidence (2×2080 Ti 22GB, TP=2, Qwen3.8-27B GPTQ-Int4, kv `turboquant_k3v4_nc`, max-model-len 524288, MTP K=2)

Reliable repro: fresh uncached ~380K-token prefills crash the unpatched engine (Xid 31 on both GPUs, variable crash depth — allocator-layout dependent).

Intervention test, one variable changed (this patch):
- unpatched: 380K crash ×2, 400K crash ×2
- **patched: 380K / 400K / 450K all complete correctly** (needle retrieval verified at 90% depth)
- patched boot on the same config also *refused* an over-committed variant with `4.15 GiB KV needed > 3.77 GiB available, estimated max 473824` — the failure the legacy sizing hid.

Quality gate after shipping this on our box: 100-item eval suite at exact parity with baseline; no throughput change measured (3-rep bench).

## Notes
- The reserve formula mirrors `get_simultaneous` alignment (one fp16 K+V pair at `max(max_num_batched_tokens, VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS)` cached length, replicated per ubatch under DBO).
- A residual, much-higher boundary (~450K with speculative decoding enabled) appears to involve a separate spec-config-dependent structure — still under investigation on our side; this patch is independent of it.
- Happy to add a unit test for `get_kv_cache_configs` accounting if you'd like it in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserves the turboquant continuation-prefill workspace from available VRAM before KV cache sizing to prevent deep-prefill illegal memory access (Xid 31) and make sizing deterministic. Over-committed configs now fail at startup with the standard estimated-max error instead of crashing.

- Engages only for `turboquant_*` caches when `max_num_batched_tokens` exceeds the continuation threshold; no effect on other caches or small contexts.
- Reserve mirrors the runtime allocator: two fp16 K+V buffers, 256-byte aligned, replicated per workspace ubatch (2 with DBO, else 1). `VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS` can raise the cached-length floor.
- Implemented in `get_kv_cache_configs`: subtracts the per-rank reserve before auto-fit, admission checks, and per-worker block planning; `num_gpu_blocks_override` still pins blocks exactly.
- Deterministic single-counting: `gpu_worker.determine_available_memory` adds back only `min(workspace_arena_bytes, continuation_reserve_bytes)` under the same gating, so the explicit reserve applies exactly once regardless of allocation timing.
- Adds an info log with reserved GiB. Controlled by `VLLM_TQ_RESERVE_PREFILL_WORKSPACE` (default on).

- Expected side effect: slightly smaller KV budgets on tight VRAM, causing `max_model_len` to auto-cap or fail early; adjust operator configs if caps are hit.
- To restore legacy sizing (and its crash risk), set `VLLM_TQ_RESERVE_PREFILL_WORKSPACE=0`.

<sup>Written for commit d2b243345c675efcb4246ea61f0599455610e692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

