### PR TITLE
fix(tool_parser): prevent None function name in streaming tool call chunks

### DIFF
--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -59,7 +59,7 @@ class StreamingXMLToolCallParser:
         self.tool_call_index = 0
         self.current_call_id = None
         self.last_completed_call_id = None
-        self.current_function_name = None
+        self.current_function_name = ""
         self.current_function_open = False
         self.parameters = {}
         self.current_param_name = None
@@ -1128,7 +1128,7 @@ class StreamingXMLToolCallParser:
         if self.current_call_id:
             self.last_completed_call_id = self.current_call_id
         self.current_call_id = None
-        self.current_function_name = None
+        self.current_function_name = ""
         self.current_function_open = False
         self.parameters = {}
         self.current_param_name = None

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -290,7 +290,7 @@ class StreamingXMLToolCallParser:
                                 index=self.tool_call_index - 1,
                                 id=self.current_call_id,
                                 type="function",
-                                function=DeltaFunctionCall(name=None, arguments=""),
+                                function=DeltaFunctionCall(name=self.current_function_name, arguments=""),
                             )
                         ],
                     )
@@ -684,7 +684,7 @@ class StreamingXMLToolCallParser:
                                 id=self.current_call_id,
                                 type="function",
                                 function=DeltaFunctionCall(
-                                    name=None, arguments=json_start
+                                    name=self.current_function_name, arguments=json_start
                                 ),
                             )
                         ]
@@ -702,7 +702,7 @@ class StreamingXMLToolCallParser:
                                 id=self.current_call_id,
                                 type="function",
                                 function=DeltaFunctionCall(
-                                    name=None, arguments=json_continue
+                                    name=self.current_function_name, arguments=json_continue
                                 ),
                             )
                         ]
@@ -744,7 +744,7 @@ class StreamingXMLToolCallParser:
                             index=self.tool_call_index - 1,
                             id=self.current_call_id,
                             type="function",
-                            function=DeltaFunctionCall(name=None, arguments='"'),
+                            function=DeltaFunctionCall(name=self.current_function_name, arguments='"'),
                         )
                     ]
                 )
@@ -779,7 +779,7 @@ class StreamingXMLToolCallParser:
                         index=self.tool_call_index - 1,
                         id=self.current_call_id,
                         type="function",
-                        function=DeltaFunctionCall(name=None, arguments=delta_data),
+                        function=DeltaFunctionCall(name=self.current_function_name, arguments=delta_data),
                     )
                 ]
             )
@@ -837,7 +837,7 @@ class StreamingXMLToolCallParser:
                             id=self.current_call_id,
                             type="function",
                             function=DeltaFunctionCall(
-                                name=None, arguments=output_arguments
+                                name=self.current_function_name, arguments=output_arguments
                             ),
                         )
                     ]
@@ -872,7 +872,7 @@ class StreamingXMLToolCallParser:
                                 index=self.tool_call_index - 1,
                                 id=self.current_call_id,
                                 type="function",
-                                function=DeltaFunctionCall(name=None, arguments='""'),
+                                function=DeltaFunctionCall(name=self.current_function_name, arguments='""'),
                             )
                         ]
                     )
@@ -885,7 +885,7 @@ class StreamingXMLToolCallParser:
                                 index=self.tool_call_index - 1,
                                 id=self.current_call_id,
                                 type="function",
-                                function=DeltaFunctionCall(name=None, arguments='"'),
+                                function=DeltaFunctionCall(name=self.current_function_name, arguments='"'),
                             )
                         ]
                     )
@@ -908,7 +908,7 @@ class StreamingXMLToolCallParser:
                             index=self.tool_call_index - 1,
                             id=self.current_call_id,
                             type="function",
-                            function=DeltaFunctionCall(name=None, arguments="}"),
+                            function=DeltaFunctionCall(name=self.current_function_name, arguments="}"),
                         )
                     ]
                 )
@@ -921,7 +921,7 @@ class StreamingXMLToolCallParser:
                             index=self.tool_call_index - 1,
                             id=self.current_call_id,
                             type="function",
-                            function=DeltaFunctionCall(name=None, arguments="{}"),
+                            function=DeltaFunctionCall(name=self.current_function_name, arguments="{}"),
                         )
                     ]
                 )
@@ -944,7 +944,7 @@ class StreamingXMLToolCallParser:
                         index=self.tool_call_index - 1,
                         id=self.current_call_id,
                         type="function",
-                        function=DeltaFunctionCall(name=None, arguments=""),
+                        function=DeltaFunctionCall(name=self.current_function_name, arguments=""),
                     )
                 ]
             )

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -968,7 +968,7 @@ class StreamingXMLToolCallParser:
         """Set tool configuration information"""
         self.tools = tools
 
-    def _extract_function_name(self, name: str, attrs: dict[str, str]) -> str | None:
+    def _extract_function_name(self, name: str, attrs: dict[str, str]) -> str:
         """Extract function name from various formats"""
         if attrs and "name" in attrs:
             return attrs["name"]
@@ -978,7 +978,7 @@ class StreamingXMLToolCallParser:
             if len(parts) == 2 and parts[0] == "function":
                 return parts[1]
 
-        return None
+        return ""
 
     def _extract_parameter_name(self, name: str, attrs: dict[str, str]) -> str | None:
         """Extract parameter name from various formats"""


### PR DESCRIPTION
## Summary
- Fix streaming tool call parsing where function.name was None in streaming chunks
- Fixes OpenCode/Codex error: Expected 'function.name' to be a string.

## Root Cause
Three issues in StreamingXMLToolCallParser:
1. Only emitted function name in the first streaming chunk; subsequent chunks had name=None
2. current_function_name was initialized/reset to None instead of empty string
3. _extract_function_name() could return None, overwriting self.current_function_name to None

## Changes
File: vllm/tool_parsers/qwen3xml_tool_parser.py
- 11 lines: DeltaFunctionCall(name=None) to DeltaFunctionCall(name=self.current_function_name)
- 2 lines: self.current_function_name = None to self.current_function_name = empty string (init + reset)
- 1 method: _extract_function_name() return type str|None to str, returns empty string instead of None

## Testing
Verified with streaming tool calls using OpenCode - all chunks now correctly include function.name as a string.

## Impact
- Fixes tool calling in OpenCode/Codex when using vLLM with Qwen3 models
- No impact on non-streaming mode (already worked correctly)
- Backward compatible with all existing clients