### PR TITLE
responses: merge instructions into leading developer system message; normalize developer role

### DIFF
--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -83,20 +83,44 @@ def construct_input_messages(
     prev_msg: list[ChatCompletionMessageParam] | None = None,
     prev_response_output: list[ResponseOutputItem] | None = None,
 ):
-    messages: list[ChatCompletionMessageParam] = []
-    if request_instructions:
-        messages.append(
-            {
-                "role": "system",
-                "content": request_instructions,
-            }
-        )
+    if isinstance(request_input, str):
+        input_messages: list[ChatCompletionMessageParam] = [
+            {"role": "user", "content": request_input}
+        ]
+    else:
+        input_messages = construct_chat_messages_with_tool_call(request_input)
 
+    # [local 2080ti fork] Clients such as codex send the system prompt BOTH
+    # in top-level `instructions` AND as a role="developer" input message.
+    # Naively emitting both as system messages yields [system, system, user,
+    # ...], which Qwen-family chat templates reject ("System message must be
+    # at the beginning."). When the input already opens with the system
+    # message converted from role="developer" and there is no earlier
+    # server-side history, merge `instructions` into it.
+    lead: ChatCompletionMessageParam | None = None
+    if request_instructions:
+        if (
+            prev_msg is None
+            and prev_response_output is None
+            and input_messages
+            and input_messages[0].get("role") == "system"
+        ):
+            first = input_messages[0]
+            old_content = first.get("content")
+            if isinstance(old_content, str) and old_content:
+                first["content"] = f"{request_instructions}\n{old_content}"
+            else:
+                first["content"] = request_instructions
+        else:
+            lead = {"role": "system", "content": request_instructions}
+
+    messages: list[ChatCompletionMessageParam] = []
+    if lead is not None:
+        messages.append(lead)
     # Prepend the conversation history.
     if prev_msg is not None:
         # Filter out system messages from previous conversation -- per the
         # OpenAI spec, instructions should NOT carry over across responses.
-        # The current request's instructions (if any) were already added above.
         messages.extend(m for m in prev_msg if m.get("role") != "system")
     if prev_response_output is not None:
         # Add the previous output.
@@ -111,13 +135,9 @@ def construct_input_messages(
                         }
                     )
 
-    # Append the new input.
-    # Responses API supports simple text inputs without chat format.
-    if isinstance(request_input, str):
-        messages.append({"role": "user", "content": request_input})
-    else:
-        input_messages = construct_chat_messages_with_tool_call(request_input)
-        messages.extend(input_messages)
+    # Append the new input (the leading system message is already merged in
+    # via `input_messages` when applicable).
+    messages.extend(input_messages)
     return messages
 
 
@@ -228,6 +248,41 @@ def _construct_single_message_from_response_item(
             content=item.get("output"),
             tool_call_id=item.get("call_id"),
         )
+    elif isinstance(item, dict) and item.get("type") == "message":
+        # [local 2080ti fork] Normalize Responses-API input messages to
+        # chat-template roles. Clients such as codex submit system context
+        # as role="developer" (the OpenAI-recommended alias of "system"),
+        # which Qwen-family chat templates reject with
+        # "Unexpected message role.". Map it to "system" (same aliasing the
+        # chat-completions path performs) and flatten input_text parts.
+        role = item.get("role") or "user"
+        if role == "developer":
+            role = "system"
+        content = item.get("content")
+        if isinstance(content, list):
+            texts: list[str] = []
+            kept: list[dict] = []
+            for part in content:
+                if (
+                    isinstance(part, dict)
+                    and part.get("type")
+                    in ("input_text", "output_text", "text")
+                ):
+                    if part.get("text"):
+                        texts.append(part["text"])
+                else:
+                    # Non-text parts (images, files, ...): pass through
+                    # untouched for now; codex-style text traffic never
+                    # carries them.
+                    kept.append(part)
+            if not kept:
+                content = "".join(texts)
+            else:
+                content = [{"type": "text", "text": t} for t in texts] + kept
+        msg: dict = {"role": role, "content": content}
+        if item.get("name") and role != "system":
+            msg["name"] = item.get("name")
+        return msg
     return item  # type: ignore
 
 


### PR DESCRIPTION
## Problem

Codex-style clients send the system prompt **twice**: in the top-level `instructions`
field AND as a `role="developer"` message in `input`. Two failures result on
Qwen-family models:

1. Naively emitting both yields `[system, system, user, ...]`, which Qwen chat
   templates reject with *"System message must be at the beginning."*
2. The Responses-API input message role `"developer"` was never normalized to
   `"system"` (the chat-completions path already does this aliasing), so Qwen
   templates reject it with *"Unexpected message role."*; `input_text` content
   parts were also passed through unflattened.

Every codex turn therefore 400s against any Qwen model — the endpoint is unusable
for codex-style agents.

## Fix (`vllm/entrypoints/openai/responses/utils.py`)

- When there is no prior server-side history and the input already opens with the
  converted system message, merge `instructions` into that leading message
  instead of emitting a second one.
- Normalize `role="developer"` → `"system"` for Responses-API input messages and
  flatten `input_text`/`output_text` parts into plain text.

## Testing

All on a local vLLM serving `Qwen3.8-27B` GPTQ INT4 (2x RTX 2080 Ti,
`--tool-call-parser qwen3_coder --reasoning-parser qwen3`):

- [x] Single-turn `/v1/responses` with top-level `instructions` + leading
      `role=developer` input: 200/completed; instructions correctly merged
      (marker-phrase adherence check passes).
- [x] Multi-turn codex-style full replay with `function_call` +
      `function_call_output`: 200/completed, final answer uses the tool result.
- [x] Streaming (`stream=true`) tool call via SSE: `function_call` item +
      `function_call_arguments.delta` assemble into valid JSON.
- [x] Real codex CLI end-to-end against `/v1/responses`: full agent loop with
      shell tool execution succeeds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 400s on Qwen models by merging top-level `instructions` into the first developer/system message and normalizing `role="developer"` to `role="system"` in the Responses API. Previously, inputs with both `instructions` and a `developer` message produced duplicate system messages and an unexpected role; now Qwen templates accept the sequence and text parts are flattened.

- Merge `instructions` into the leading system message when there is no prior server-side history and the input already starts with a system/developer message (prevents `[system, system, ...]`).
- Normalize Responses-API `role="developer"` to `role="system"` and flatten `input_text`/`output_text` parts into plain text; non-text parts pass through unchanged.
- Preserve history semantics: filter prior system messages; append tool-call outputs as before. No client changes required.

<sup>Written for commit d2452ee2f90cd145f659eb3042f3271aae721021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

