### PR TITLE
Fix deadlocks found during qwen 3.8 nvfp4 inference

### DIFF
--- a/tests/distributed/test_shm_broadcast_deadlock.py
+++ b/tests/distributed/test_shm_broadcast_deadlock.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Reproduction test for ring buffer deadlock caused by lost ZMQ notifications.
+
+When the reader is in the SpinCondition hot-path (within busy_loop_s of the
+last read), it only calls sched_yield() and never polls the ZMQ notification
+socket.  If the writer calls notify() during this window the zmq.CONFLATE
+setting can discard the notification.  The reader then enters the cold-path
+and blocks on the poller waiting for a notification that never comes; on the
+writer side acquire_write() spins waiting for the reader's ACK.
+
+The fix adds a non-blocking ZMQ poll at the start of every hot-path wait()
+call so that notifications are never lost.
+"""
+
+import threading
+import time
+from unittest import mock
+
+import zmq
+
+from vllm.distributed.device_communicators.shm_broadcast import (
+    MessageQueue,
+    SpinCondition,
+)
+
+
+def test_spincondition_hot_path_notify_not_lost():
+    """Verify that notify() sent while the reader is in hot-path is still
+    visible via a non-blocking poll.  Without the fix the notify is lost
+    because wait() only calls sched_yield() during the busy-loop window."""
+    ctx = zmq.Context()
+    addr = "inproc://test_spincondition_hot_path"
+
+    # Writer binds first (PUB), then reader connects (SUB)
+    writer_cond = SpinCondition(
+        is_reader=False, context=ctx, notify_address=addr
+    )
+    reader_cond = SpinCondition(
+        is_reader=True, context=ctx, notify_address=addr
+    )
+
+    try:
+        # Force the reader into persistent hot-path mode
+        reader_cond.busy_loop_s = 9999
+        reader_cond.record_read()
+
+        # Writer sends a notification
+        writer_cond.notify()
+
+        # Give ZMQ a moment to deliver the inproc message
+        time.sleep(0.05)
+
+        # Reader calls wait() — without the fix this returns immediately
+        # without ever seeing the notify.  With the fix it drains the
+        # notification via _poll_notifications().
+        reader_cond.wait(timeout_ms=0)
+
+        # Verify the notify was consumed: a second poll on the socket
+        # should return nothing.
+        events = dict(reader_cond.poller.poll(timeout=0))
+        notify_key = reader_cond.local_notify_socket
+        assert notify_key not in events, (
+            "Notify was not consumed by wait() in hot-path"
+        )
+    finally:
+        for sock in (
+            writer_cond.local_notify_socket,
+            reader_cond.local_notify_socket,
+            reader_cond.read_cancel_socket,
+            reader_cond.write_cancel_socket,
+        ):
+            sock.close(linger=0)
+        ctx.term()
+
+
+def test_message_queue_notify_loss_no_deadlock():
+    """Test that the message queue recovers gracefully when a reader
+    experiences notify loss while in the hot-path.
+
+    The scenario:
+      1. Writer fills the ring buffer
+      2. Reader stays in hot-path the whole time
+      3. Writer wraps around and enters acquire_write waiting for ACKs
+      4. The enqueue -> notify() call happens while reader is in hot-path
+      5. Without the fix, the notify is lost and the reader blocks on the
+         cold-path poller until SHM_READER_RECHECK_INTERVAL_MS (5s) elapses.
+         With the fix, the notify is caught during the hot-path poll.
+    """
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024,
+        max_chunks=2,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    writer.wait_until_ready()
+    reader.wait_until_ready()
+
+    try:
+        # Force reader into persistent hot-path
+        reader._spin_condition.busy_loop_s = 9999
+
+        # Fill the ring (writer writes max_chunks blocks)
+        for i in range(writer.buffer.max_chunks):
+            writer.enqueue({"seq": i})
+
+        # Reader consumes all — this puts it in hot-path
+        for i in range(writer.buffer.max_chunks):
+            msg = reader.dequeue(timeout=5)
+            assert msg["seq"] == i
+
+        # Now the writer wraps the ring: the next enqueue triggers
+        # acquire_write which waits for the reader's ACK.  The notify
+        # is sent while the reader is in hot-path (busy_loop_s >> 0).
+        writer.enqueue({"seq": 100})
+
+        # Without the fix, this dequeue blocks for up to 5s
+        # (SHM_READER_RECHECK_INTERVAL_MS) before seeing the data.
+        # With the fix, it returns almost immediately.
+        start = time.monotonic()
+        msg = reader.dequeue(timeout=10)
+        elapsed = time.monotonic() - start
+        assert msg["seq"] == 100
+
+        # With the fix, the dequeue should complete well under the
+        # SHM_READER_RECHECK_INTERVAL_MS (5s).  We allow 1s to account
+        # for scheduling jitter.
+        assert elapsed < 1.0, (
+            f"Dequeue took {elapsed:.2f}s, expected <1.0s with fix. "
+            "This suggests the notify was missed and the reader relied "
+            "on the periodic SHM recheck timeout."
+        )
+    finally:
+        writer.shutdown()
+        reader.shutdown()
+        for sock in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            sock.close(linger=0)

--- a/tests/distributed/test_shm_broadcast_deadlock.py
+++ b/tests/distributed/test_shm_broadcast_deadlock.py
@@ -75,17 +75,22 @@ def test_spincondition_hot_path_notify_not_lost():
 
 
 def test_message_queue_notify_loss_no_deadlock():
-    """Test that the message queue recovers gracefully when a reader
-    experiences notify loss while in the hot-path.
+    """Verify that a notify() sent while the reader is in hot-path is
+    drained by _poll_notifications() inside wait().
 
     The scenario:
-      1. Writer fills the ring buffer
-      2. Reader stays in hot-path the whole time
-      3. Writer wraps around and enters acquire_write waiting for ACKs
-      4. The enqueue -> notify() call happens while reader is in hot-path
-      5. Without the fix, the notify is lost and the reader blocks on the
-         cold-path poller until SHM_READER_RECHECK_INTERVAL_MS (5s) elapses.
-         With the fix, the notify is caught during the hot-path poll.
+      1. Reader is in persistent hot-path (busy_loop_s >> 0) with no data
+         in the ring buffer, so acquire_read()'s check() returns False
+         and the reader spins in wait().
+      2. Writer calls notify() (the SUB socket receives the message).
+      3. Without the fix, wait() only calls sched_yield() and never polls
+         the ZMQ socket, so the notify stays in the SUB socket.
+      4. With the fix, _poll_notifications() drains the notify on the
+         first wait() call after it arrives.
+
+    After letting the reader spin for 0.5 s we poll the reader's SUB
+    socket non-blocking.  Without the fix the notify is still pending
+    (events non-empty); with the fix it was drained (events empty).
     """
     writer = MessageQueue(
         n_reader=1,
@@ -97,41 +102,170 @@ def test_message_queue_notify_loss_no_deadlock():
     writer.wait_until_ready()
     reader.wait_until_ready()
 
+    stop = threading.Event()
+    errors: list = []
+
+    def reader_thread():
+        try:
+            while not stop.is_set():
+                reader._spin_condition.wait(timeout_ms=0)
+        except Exception as e:
+            errors.append(e)
+
+    t = threading.Thread(target=reader_thread, daemon=True)
     try:
-        # Force reader into persistent hot-path
+        # Force reader into persistent hot-path.
         reader._spin_condition.busy_loop_s = 9999
+        reader._spin_condition.record_read()
 
-        # Fill the ring (writer writes max_chunks blocks)
-        for i in range(writer.buffer.max_chunks):
-            writer.enqueue({"seq": i})
+        t.start()
 
-        # Reader consumes all — this puts it in hot-path
-        for i in range(writer.buffer.max_chunks):
+        # Give the reader a moment to enter the hot-path spin loop.
+        time.sleep(0.05)
+
+        # Writer sends a notification (no data written — the ring is empty,
+        # so the reader's check() would return False and it relies solely on
+        # wait() to observe the notify).
+        writer._spin_condition.notify()
+
+        # Let the reader spin long enough to call wait() many times.  With
+        # the fix the notify is drained on the first wait() after arrival.
+        time.sleep(0.5)
+
+        # Verify the notify was consumed from the SUB socket.  A
+        # non-blocking poll should return no events for the notify socket.
+        events = dict(
+            reader._spin_condition.poller.poll(timeout=0)
+        )
+        notify_key = reader._spin_condition.local_notify_socket
+        assert notify_key not in events, (
+            "Notify was not drained during hot-path wait(); it is still "
+            "pending in the SUB socket.  Without the fix, wait() only "
+            "calls sched_yield() and never polls the ZMQ socket, so a "
+            "notify sent while the reader is in hot-path is never "
+            "consumed — leading to a lost-wakeup deadlock."
+        )
+    finally:
+        stop.set()
+        t.join(timeout=5)
+        writer.shutdown()
+        reader.shutdown()
+        for sock in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            sock.close(linger=0)
+
+
+def test_writer_ring_buffer_deadlock_recovered():
+    """Verify that the writer calls notify() inside the acquire_write()
+    spin loop.
+
+    Deadlock cycle (observed in production via GDB traces):
+      1. GPU stall or long computation on a worker delays it from reading
+         the shared-memory ring buffer.
+      2. Writer (EngineCore) fills all max_chunks slots.
+      3. Worker finishes GPU work, returns to dequeue() — but more than
+         busy_loop_s has elapsed, so SpinCondition.wait() enters the
+         **cold path** and blocks on zmq.Poller.poll().
+      4. Writer wraps the ring: acquire_write() finds the next slot still
+         written (not yet ACKed by the reader).  Writer enters the spin
+         loop.
+      5. Without the fix the spin loop only calls sched_yield(), so the
+         reader stays blocked on the ZMQ poller forever — the writer
+         cannot exit acquire_write() to call the post-enqueue notify(),
+         and the reader never wakes to ACK the slot.  **Complete deadlock.**
+
+    The fix adds self._spin_condition.notify() inside the acquire_write()
+    spin loop so that any reader parked in the cold path is woken to
+    re-check and ACK the ring-buffer slot.
+
+    Test strategy: fill the ring buffer so the next enqueue() must spin
+    in acquire_write() (slot is written but never ACKed).  Spy on
+    SpinCondition.notify() to verify it is called *during* the spin loop.
+    Without the fix, notify() is never called while spinning — the only
+    notify() is the post-enqueue one at line 907, which cannot fire until
+    acquire_write() returns (which requires the reader to ACK — a
+    deadlock).  After verifying the spy, drain the reader so the writer
+    can proceed and the test exits cleanly.
+    """
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024,
+        max_chunks=2,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    writer.wait_until_ready()
+    reader.wait_until_ready()
+
+    t = None
+    original_notify = writer._spin_condition.notify
+    try:
+        # Fill the ring buffer (max_chunks = 2).  Reader never dequeues.
+        writer.enqueue({"seq": 0})
+        writer.enqueue({"seq": 1})
+        # Writer's current_idx is now 0 (wrapped).  Slot 0 is
+        # written_flag=1, read_count=0 (never ACKed by the reader).
+
+        # Spy on notify() to count calls from the spin loop.  Any notify()
+        # calls observed while the writer is spinning in acquire_write()
+        # must originate from the spin loop itself — the post-enqueue
+        # notify() (line 907) cannot fire until acquire_write() returns.
+        notify_calls: list = []
+        def counting_notify():
+            notify_calls.append(time.monotonic())
+            original_notify()
+        writer._spin_condition.notify = counting_notify
+
+        # Start a writer thread that will spin in acquire_write().
+        # The timeout prevents an indefinite hang if the test breaks.
+        errors: list = []
+        def writer_thread():
+            try:
+                writer.enqueue({"seq": 2}, timeout=30)
+            except Exception as e:
+                errors.append(e)
+
+        t = threading.Thread(target=writer_thread, daemon=True)
+        t.start()
+
+        # Let the writer spin for 0.5 s.  During this window any
+        # notify() calls can only come from the acquire_write() spin
+        # loop — the writer cannot exit acquire_write() until the
+        # reader ACKs, which hasn't happened yet.
+        time.sleep(0.5)
+        spin_notify_count = len(notify_calls)
+        assert spin_notify_count > 0, (
+            "Writer did not call notify() during the acquire_write() spin "
+            f"loop (0 calls in 0.5 s).  Without the fix, only sched_yield() "
+            "is called in the spin loop, so a reader blocked in the "
+            "SpinCondition cold-path would never be woken — deadlock."
+        )
+
+        # Drain the ring so the writer can proceed and exit the spin.
+        for i in range(3):
             msg = reader.dequeue(timeout=5)
             assert msg["seq"] == i
 
-        # Now the writer wraps the ring: the next enqueue triggers
-        # acquire_write which waits for the reader's ACK.  The notify
-        # is sent while the reader is in hot-path (busy_loop_s >> 0).
-        writer.enqueue({"seq": 100})
-
-        # Without the fix, this dequeue blocks for up to 5s
-        # (SHM_READER_RECHECK_INTERVAL_MS) before seeing the data.
-        # With the fix, it returns almost immediately.
-        start = time.monotonic()
-        msg = reader.dequeue(timeout=10)
-        elapsed = time.monotonic() - start
-        assert msg["seq"] == 100
-
-        # With the fix, the dequeue should complete well under the
-        # SHM_READER_RECHECK_INTERVAL_MS (5s).  We allow 1s to account
-        # for scheduling jitter.
-        assert elapsed < 1.0, (
-            f"Dequeue took {elapsed:.2f}s, expected <1.0s with fix. "
-            "This suggests the notify was missed and the reader relied "
-            "on the periodic SHM recheck timeout."
-        )
+        t.join(timeout=5)
+        assert not errors, f"Writer thread errored: {errors}"
+        assert not t.is_alive(), "Writer thread did not finish"
     finally:
+        writer._spin_condition.notify = original_notify
+        # Drain any unread data so the writer thread (if still alive)
+        # can exit acquire_write() instead of spinning until timeout.
+        if t is not None and t.is_alive():
+            try:
+                for _ in range(3):
+                    reader.dequeue(timeout=2)
+            except Exception:
+                pass
+            t.join(timeout=5)
         writer.shutdown()
         reader.shutdown()
         for sock in (

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -189,6 +189,20 @@ class SpinCondition:
             logger.debug("Canceling waiting reads on SHM Buffer")
             self.write_cancel_socket.send(b"\x00")
 
+    def _poll_notifications(self):
+        """Non-blocking poll of the ZMQ notification socket.
+
+        Drains any pending notify or cancel message that arrived on the
+        underlying sockets.  Returns without blocking even when no message
+        is available.
+        """
+        events = dict(self.poller.poll(timeout=0))
+        if self.read_cancel_socket in events:
+            logger.debug("Poller received cancel event (hot-path)")
+        elif self.local_notify_socket in events:
+            logger.debug("Poller received notify event (hot-path)")
+            self.local_notify_socket.recv(flags=zmq.NOBLOCK, copy=False)
+
     def wait(self, timeout_ms: int | None = None) -> None:
         """Wait for data on the shared memory buffer.
 
@@ -202,6 +216,12 @@ class SpinCondition:
 
         current_time = time.monotonic()
         if current_time <= self.last_read + self.busy_loop_s:
+            # Poll the ZMQ socket even during the hot-path to prevent
+            # notification loss.  The writer may call notify() while the
+            # reader is in the busy-loop phase; without this poll the ZMQ
+            # CONFLATE option would discard the notification and the reader
+            # would never know a new message is available.
+            self._poll_notifications()
             sched_yield()
         else:
             events = dict(self.poller.poll(timeout=timeout_ms))

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -691,6 +691,15 @@ class MessageQueue:
                     # Release the processor to other threads
                     sched_yield()
 
+                    # Readers may be in the SpinCondition cold-path (blocked
+                    # on zmq.Poller.poll()) waiting for a write notification.
+                    # Without waking them here, the writer would spin forever:
+                    # readers never wake to ACK the ring buffer slot, the
+                    # writer never exits acquire_write to call notify(), and
+                    # readers stay stuck in the cold path.
+                    if self._spin_condition is not None:
+                        self._spin_condition.notify()
+
                     # if we time out, raise an exception
                     elapsed = time.monotonic() - start_time
                     if timeout is not None and elapsed > timeout:


### PR DESCRIPTION
Found two deadlocks during testing of 0.2.x dev branch.

These two deadlocks are basically made of entering spinlocks, when the reader missing a notify (commit 1) and trying to write to a full buffer without actually waking up readers.

Fixing these helped me (or I was lucky I did not get deadlocks). I wonder, if this are real problems, they have to be already fixex in vllm upstream.

Bugs seem severe. I will spend some time figuring out if there commits fixing those in upstream. Probably there are. If so, it is better to cherry-pick them or sync to a fixed revision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents two SHM broadcast deadlocks observed during qwen 3.8 NVFP4 inference. Previously, the reader’s hot-path never polled `zmq` and could lose a notify, and the writer’s full-buffer spin loop did not wake cold-path readers; now the hot-path polls non-blocking and the writer notifies while spinning.

- Reader: `SpinCondition.wait()` performs a non-blocking poll via `_poll_notifications()` on the hot-path to drain notify/cancel messages and avoid lost-wakeup deadlocks.
- Writer: `acquire_write()` calls `notify()` inside its spin loop so readers blocked on the cold-path `zmq.Poller` wake and ACK, preventing full-buffer deadlocks.
- Tests: adds `tests/distributed/test_shm_broadcast_deadlock.py` with reproductions for both issues and a writer-side recovery check.

**Reviewer notes**
- Review `SpinCondition._poll_notifications()` and the hot-path branch in `wait()`; the poll is non-blocking and only drains pending events.
- In `acquire_write()`, the added `notify()` runs while spinning; `zmq` `CONFLATE` and PUB `SNDHWM=1` bound redundant notifies. Minimal hot-path overhead; no behavior change to message semantics.

<sup>Written for commit c1b577f7b56a299c9a313b5801dd1cd0e570c129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

