### PR TITLE
fix(openai): disable implicit repetition detection for tool arguments

### DIFF
--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.sampling_params import RepetitionDetectionParams
+from vllm.v1.core.sched.utils import check_sequence_repetition
+
+
+def test_repetition_detection_is_still_available_when_explicitly_configured():
+    params = RepetitionDetectionParams(
+        max_pattern_size=2,
+        min_pattern_size=1,
+        min_count=3,
+    )
+    assert check_sequence_repetition([1, 2, 1, 2, 1, 2], params)
+
+
+def test_repetition_detection_does_not_match_non_repeating_tool_arguments():
+    params = RepetitionDetectionParams(
+        max_pattern_size=32,
+        min_pattern_size=1,
+        min_count=8,
+    )
+    # Markdown table separators can repeat in a JSON string without the
+    # generated argument being a repeated model response.
+    tokens = [10, 11, 12, 13, 14, 15, 16, 17] * 2 + [18, 19]
+    assert not check_sequence_repetition(tokens, params)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -71,7 +71,6 @@ from vllm.reasoning import ReasoningParser
 from vllm.renderers import ChatParams
 from vllm.sampling_params import (
     BeamSearchParams,
-    RepetitionDetectionParams,
     SamplingParams,
 )
 from vllm.tokenizers import TokenizerLike
@@ -95,14 +94,6 @@ def _default_thinking_token_budget() -> int | None:
             "Ignoring invalid VLLM_DEFAULT_THINKING_TOKEN_BUDGET=%r", value
         )
         return None
-
-
-def _tool_calling_requested(request: ChatCompletionRequest) -> bool:
-    return bool(request.tools) and (
-        request.tool_choice == "auto"
-        or request.tool_choice == "required"
-        or isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
-    )
 
 
 class OpenAIServingChat(OpenAIServing):
@@ -339,16 +330,6 @@ class OpenAIServingChat(OpenAIServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
-                if (
-                    _tool_calling_requested(request)
-                    and sampling_params.repetition_detection is None
-                ):
-                    sampling_params.repetition_detection = RepetitionDetectionParams(
-                        max_pattern_size=32,
-                        min_pattern_size=1,
-                        min_count=8,
-                    )
-
             self._log_inputs(
                 sub_request_id,
                 engine_input,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from fastapi import Request
 
+from vllm import envs
 from vllm.engine.protocol import EngineClient
 from vllm.entrypoints.chat_utils import (
     ChatTemplateContentFormatOption,
@@ -71,6 +72,7 @@ from vllm.reasoning import ReasoningParser
 from vllm.renderers import ChatParams
 from vllm.sampling_params import (
     BeamSearchParams,
+    RepetitionDetectionParams,
     SamplingParams,
 )
 from vllm.tokenizers import TokenizerLike
@@ -94,6 +96,14 @@ def _default_thinking_token_budget() -> int | None:
             "Ignoring invalid VLLM_DEFAULT_THINKING_TOKEN_BUDGET=%r", value
         )
         return None
+
+
+def _tool_calling_requested(request: ChatCompletionRequest) -> bool:
+    return bool(request.tools) and (
+        request.tool_choice == "auto"
+        or request.tool_choice == "required"
+        or isinstance(request.tool_choice, ChatCompletionNamedToolChoiceParam)
+    )
 
 
 class OpenAIServingChat(OpenAIServing):
@@ -330,6 +340,16 @@ class OpenAIServingChat(OpenAIServing):
                     max_tokens,
                     self.default_sampling_params,
                 )
+                if (
+                    _tool_calling_requested(request)
+                    and sampling_params.repetition_detection is None
+                    and envs.VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT > 0
+                ):
+                    sampling_params.repetition_detection = RepetitionDetectionParams(
+                        max_pattern_size=32,
+                        min_pattern_size=1,
+                        min_count=envs.VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT,
+                    )
             self._log_inputs(
                 sub_request_id,
                 engine_input,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -282,6 +282,7 @@ if TYPE_CHECKING:
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
+    VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT: int = 0
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
@@ -1875,6 +1876,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     #     Allows viewing and setting breakpoints in Inductor's code output files.
     "VLLM_COMPILE_CACHE_SAVE_FORMAT": env_with_choices(
         "VLLM_COMPILE_CACHE_SAVE_FORMAT", "binary", ["binary", "unpacked"]
+    ),
+    # Tool arguments commonly contain repeated markdown/code structure. Keep
+    # the generic repetition detector opt-in for tool calls because its
+    # default n-gram heuristic can terminate a valid JSON argument mid-string.
+    "VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT": lambda: int(
+        os.getenv("VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT", "0")
     ),
     # Flag to enable v2 model runner.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: bool(


### PR DESCRIPTION
## Problem

The Chat Completions serving layer automatically enabled repetition detection for every tool-calling request. Repeated markdown/code structure inside a valid JSON argument could therefore trigger `FINISHED_REPETITION` and truncate the argument.

## Fix

- Add `VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT`.
- Default is `0`, so tool calls no longer enable the heuristic implicitly.
- A positive value explicitly opts back in.
- Request-level `repetition_detection` remains unchanged.

This PR does not change MTP defaults and does not include the pending MTP1 mitigation.

## Validation

- Reproduced the truncation root cause on the 0.1.16 runtime with long Markdown tool arguments.
- Verified on the `.31` CUDA 12.8 environment that the default is `0`, explicit request-level configuration is retained, and positive env values are parsed.
- `py_compile` and `git diff --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable implicit repetition detection for tool-call arguments in `vllm` Chat Completions to prevent truncating valid JSON when markdown/code repeats. Previously tool-call requests implicitly enabled the detector (min_count=8) and could end with FINISHED_REPETITION; now it is off by default and only enabled via request config or an env var.

- Add `VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT` (default 0). Set a positive value to opt in and use it as min_count.
- Request-level `repetition_detection` is unchanged; no other defaults are modified.
- Migration: if you relied on the old implicit behavior, set `VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT` (e.g., 8) or pass `repetition_detection` in the request.
- Tests confirm explicit config still works and typical markdown-in-JSON patterns do not trigger detection.

<sup>Written for commit b5dc99039eac9d6ebfc02fb8e3acd2b9170d7d1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

