### PR TITLE
fix(tool-parser): emit Qwen XML function name once per call

### DIFF
--- a/tests/tool_parsers/test_qwen3xml_streaming.py
+++ b/tests/tool_parsers/test_qwen3xml_streaming.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
+
+def _deltas(parser, chunks):
+    return [parser.parse_single_streaming_chunks(chunk) for chunk in chunks]
+
+
+def _tool_calls(deltas):
+    return [tool_call for delta in deltas for tool_call in delta.tool_calls]
+
+
+def test_function_name_is_only_emitted_in_first_delta():
+    parser = StreamingXMLToolCallParser()
+    deltas = _deltas(
+        parser,
+        [
+            "<tool_call>",
+            "<function=search_weather>",
+            "<parameter=city>Shanghai</parameter>",
+            "</function>",
+            "</tool_call>",
+        ],
+    )
+
+    calls = _tool_calls(deltas)
+    assert [call.function.name for call in calls if call.function and call.function.name] == [
+        "search_weather"
+    ]

--- a/tests/tool_parsers/test_qwen3xml_streaming.py
+++ b/tests/tool_parsers/test_qwen3xml_streaming.py
@@ -26,6 +26,14 @@ def test_function_name_is_only_emitted_in_first_delta():
     )
 
     calls = _tool_calls(deltas)
-    assert [call.function.name for call in calls if call.function and call.function.name] == [
-        "search_weather"
-    ]
+    assert calls
+    assert calls[0].function is not None
+    assert calls[0].function.name == "search_weather"
+    assert all(
+        call.function is None or call.function.name is None for call in calls[1:]
+    )
+    assert all(
+        "name" not in call.function.model_dump(exclude_unset=True)
+        for call in calls[1:]
+        if call.function is not None
+    )

--- a/tests/tool_parsers/test_qwen3xml_streaming.py
+++ b/tests/tool_parsers/test_qwen3xml_streaming.py
@@ -37,3 +37,43 @@ def test_function_name_is_only_emitted_in_first_delta():
         for call in calls[1:]
         if call.function is not None
     )
+
+
+def test_function_name_is_emitted_once_for_each_tool_call():
+    parser = StreamingXMLToolCallParser()
+    deltas = _deltas(
+        parser,
+        [
+            "<tool_call>",
+            "<function=search_weather>",
+            "<parameter=city>Shanghai</parameter>",
+            "</function>",
+            "</tool_call>",
+            "<tool_call>",
+            "<function=get_time>",
+            "<parameter=timezone>UTC</parameter>",
+            "</function>",
+            "</tool_call>",
+        ],
+    )
+
+    calls_by_index = {}
+    for call in _tool_calls(deltas):
+        calls_by_index.setdefault(call.index, []).append(call)
+
+    assert set(calls_by_index) == {0, 1}
+    for expected_name, calls in zip(
+        ("search_weather", "get_time"),
+        (calls_by_index[0], calls_by_index[1]),
+        strict=True,
+    ):
+        assert calls[0].function is not None
+        assert calls[0].function.name == expected_name
+        assert all(
+            call.function is None or call.function.name is None for call in calls[1:]
+        )
+        assert all(
+            "name" not in call.function.model_dump(exclude_unset=True)
+            for call in calls[1:]
+            if call.function is not None
+        )

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -60,6 +60,9 @@ class StreamingXMLToolCallParser:
         self.current_call_id = None
         self.last_completed_call_id = None
         self.current_function_name = ""
+        # A streaming tool call carries its function name only in the first
+        # delta. Subsequent deltas contain argument fragments.
+        self._function_name_emitted = False
         self.current_function_open = False
         self.parameters = {}
         self.current_param_name = None
@@ -593,6 +596,17 @@ class StreamingXMLToolCallParser:
 
     def _emit_delta(self, delta: DeltaMessage):
         """Emit Delta response (streaming output)"""
+        # The parser builds each argument fragment with the current function
+        # name for convenience. Normalize that at the emission boundary so a
+        # client never receives the name repeatedly on every chunk.
+        for tool_call in delta.tool_calls:
+            function = tool_call.function
+            if function is None or not function.name:
+                continue
+            if self._function_name_emitted:
+                function.name = None
+            else:
+                self._function_name_emitted = True
         self.deltas.append(delta)
 
     def _auto_close_open_parameter_if_needed(self, incoming_tag: str | None = None):
@@ -644,6 +658,7 @@ class StreamingXMLToolCallParser:
             self._auto_close_open_parameter_if_needed("function")
             function_name = self._extract_function_name(name, attrs)
             self.current_function_name = function_name
+            self._function_name_emitted = False
             self.current_function_open = True
             if function_name:
                 delta = DeltaMessage(
@@ -1129,6 +1144,7 @@ class StreamingXMLToolCallParser:
             self.last_completed_call_id = self.current_call_id
         self.current_call_id = None
         self.current_function_name = ""
+        self._function_name_emitted = False
         self.current_function_open = False
         self.parameters = {}
         self.current_param_name = None

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -604,7 +604,10 @@ class StreamingXMLToolCallParser:
             if function is None or not function.name:
                 continue
             if self._function_name_emitted:
-                function.name = None
+                # Do not keep an explicitly-set ``name=None`` field on
+                # continuation deltas. OpenAI serialization must omit the
+                # field entirely after the first delta.
+                tool_call.function = DeltaFunctionCall(arguments=function.arguments)
             else:
                 self._function_name_emitted = True
         self.deltas.append(delta)


### PR DESCRIPTION
## Problem

The Qwen XML streaming parser included `function.name` in every delta. OpenAI-compatible clients expect the function name and id in the first tool-call delta, followed by argument-only deltas. Repeating the name can cause duplicate or invalid tool-call assembly and is the direct parser-side issue behind #127.

## Fix

Track whether the function name has already been emitted for the current call and clear it when a new function/tool call starts. Subsequent deltas now carry only argument fragments.

This PR is intentionally limited to function-name emission; close-tag recovery is handled separately in another PR.

## Validation

- Direct streaming parser validation on `.31` with the 0.1.16 CUDA 12.8 environment.
- The function name appeared exactly once across the complete stream.
- Added a regression test for first-delta versus continuation-delta behavior.
- `py_compile` and `git diff --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit the Qwen XML tool function name only in the first streaming delta to match OpenAI tool-call semantics. Previously every delta repeated function.name; now only the first delta includes it and later deltas carry only arguments.

- Normalize at emission: strip repeated names and omit any name=null field on continuation deltas.
- Track per-call emission with a flag; reset when a new function starts and after call reset.
- Tests cover first-delta vs continuation and multiple tool calls; each call emits its name exactly once.
- No API changes; clients must read the function name from the first delta.

<sup>Written for commit b0025de50b5e1a4f1cd26cf2b6a34bf48a6b755f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

