### PR TITLE
kv-cache: reserve the speculative-decode verify working set before sizing KV (fixes post-profiling OOM at large K)

### DIFF
--- a/tests/v1/core/test_spec_decode_workspace.py
+++ b/tests/v1/core/test_spec_decode_workspace.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-python unit tests for the speculative-decode verify-workspace reserve.
+
+Validates the sizing formula (shapes -> bytes) in
+``vllm/v1/core/spec_decode_workspace.py`` against the measured OOM facts, without
+importing torch / CUDA. The module is stdlib-only, so it is loaded directly by
+path.
+
+Measured facts being pinned (Qwen3.8-27B GPTQ-Int4 TP=2, vocab=248320,
+mtp num_speculative_tokens config):
+  * K=16, max_num_seqs=16: boot OOM'd post-profiling; actual allocations blew
+    ~5 GiB past what profiling budgeted.
+  * K=16 booted only after dropping max_num_seqs 16 -> 4 (~4x less overshoot).
+  * K=2 at max_num_seqs=16 profiles fine (no meaningful overshoot).
+
+Run: ``python3 tests/v1/core/test_spec_decode_workspace.py`` (stdlib only).
+"""
+
+import importlib.util
+import os
+import sys
+
+GIB = 1 << 30
+VOCAB = 248320  # Qwen3.8-27B
+
+
+def _load_module():
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = os.path.abspath(os.path.join(here, "..", "..", ".."))
+    path = os.path.join(repo, "vllm", "v1", "core", "spec_decode_workspace.py")
+    name = "_spec_decode_workspace"
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so the frozen dataclass's string annotations
+    # (`from __future__ import annotations`) resolve their module.
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+M = _load_module()
+reserve_bytes = M.spec_verify_reserve_bytes
+reserve = M.spec_verify_reserve
+decision = M.spec_verify_reserve_decision
+
+
+def _gib(b):
+    return b / GIB
+
+
+# ---------------------------------------------------------------------------
+
+def test_predicts_observed_5gib_gap_at_k16_seqs16():
+    """The default reserve must cover the observed ~5 GiB post-profiling gap."""
+    r = reserve_bytes(16, 16, VOCAB)  # default overshoot_mult=24
+    assert r >= 5 * GIB, f"expected >=5 GiB, got {_gib(r):.3f} GiB"
+    # sanity upper bound so a typo can't silently reserve the whole card
+    assert r <= 8 * GIB, f"unexpectedly large reserve {_gib(r):.3f} GiB"
+
+
+def test_small_at_k2_seqs16():
+    """K=2 profiles fine on hardware -> reserve must be small and << K=16."""
+    r2 = reserve_bytes(2, 16, VOCAB)
+    r16 = reserve_bytes(16, 16, VOCAB)
+    assert r2 < 0.5 * GIB, f"K=2 reserve not small: {_gib(r2):.3f} GiB"
+    assert r2 < r16 / 10, f"K=2 ({_gib(r2):.3f}) not << K=16 ({_gib(r16):.3f})"
+
+
+def test_seqs_scaling_matches_boot_evidence():
+    """K=16 booted after seqs 16->4; overshoot must scale ~linearly with seqs."""
+    r_s16 = reserve_bytes(16, 16, VOCAB)
+    r_s4 = reserve_bytes(16, 4, VOCAB)
+    # (K-1)*seqs scaling => exactly 4x for seqs 16 vs 4.
+    assert abs(r_s16 - 4 * r_s4) <= 1, (
+        f"seqs scaling off: s16={_gib(r_s16):.3f} s4={_gib(r_s4):.3f}"
+    )
+    # and s4 must be small enough that it booted (well under the s16 gap).
+    assert r_s4 < 2 * GIB, f"K16/s4 reserve too large to have booted: {_gib(r_s4):.3f}"
+
+
+def test_noop_below_or_at_k1_and_no_spec():
+    """Nothing beyond the profiled K=1 baseline -> zero reserve."""
+    assert reserve_bytes(1, 16, VOCAB) == 0
+    assert reserve_bytes(0, 16, VOCAB) == 0
+    assert reserve_bytes(2, 0, VOCAB) == 0
+    assert reserve_bytes(2, 16, 0) == 0
+    assert reserve_bytes(16, 16, VOCAB, overshoot_mult=0) == 0
+
+
+def test_per_request_delta_width_is_k_minus_one():
+    """Profiler covers 2 positions/req; real verify width is K+1 -> delta K-1."""
+    for k in (2, 4, 8, 16):
+        b = reserve(k, 16, VOCAB)
+        assert b.per_req_delta_width == k - 1, (k, b.per_req_delta_width)
+        assert b.delta_positions == (k - 1) * 16
+
+
+def test_monotonic_in_k_and_seqs():
+    prev = -1
+    for k in (2, 3, 4, 8, 16, 32):
+        r = reserve_bytes(k, 16, VOCAB)
+        assert r > prev, f"not increasing in K at K={k}"
+        prev = r
+    prev = -1
+    for s in (1, 2, 4, 8, 16, 32):
+        r = reserve_bytes(16, s, VOCAB)
+        assert r >= prev, f"not increasing in seqs at seqs={s}"
+        prev = r
+
+
+def test_mechanistic_floor_is_honest_1_to_2_gib():
+    """The physics-only reserve (concurrent verify buffers, mult=6) is ~1.3 GiB.
+
+    This documents that the raw verify buffers CANNOT be ~5 GiB (the arithmetic
+    ceiling is ~2 GiB at this vocab/batch); the default's larger envelope covers
+    the un-instrumented residual (GDN align-decode workspace + allocator
+    fragmentation), not more logits.
+    """
+    r = reserve_bytes(16, 16, VOCAB, overshoot_mult=M.MECHANISTIC_OVERSHOOT_MULT)
+    assert 1.0 * GIB <= r <= 2.0 * GIB, f"mechanistic floor {_gib(r):.3f} GiB"
+
+
+def test_exact_bytes_k16_seqs16():
+    """Pin the exact arithmetic: 24 * (16-1)*16 * 248320 * 4 bytes."""
+    expected = 24 * (16 - 1) * 16 * VOCAB * 4
+    assert reserve_bytes(16, 16, VOCAB) == expected
+    assert expected == 5_721_292_800  # 5.328 GiB
+
+
+# --- gating decision (drives the always-on boot diagnostic) ----------------
+
+def _dec(**kw):
+    base = dict(
+        speculative_present=True,
+        enabled=True,
+        num_speculative_tokens=16,
+        max_num_seqs=16,
+        vocab_size=VOCAB,
+        overshoot_mult=24,
+    )
+    base.update(kw)
+    return decision(**base)
+
+
+def test_decision_applies_when_spec_present_and_enabled():
+    b, reason = _dec()
+    assert b == reserve_bytes(16, 16, VOCAB)
+    assert reason.startswith("applied:")
+    assert "K=16" in reason and "5.328 GiB" in reason
+
+
+def test_decision_skips_reasons_are_explicit():
+    # These are exactly the branches the coordinator asked to be diagnosable.
+    assert _dec(speculative_present=False) == (0, "skipped: no speculative_config")
+    b, r = _dec(enabled=False)
+    assert b == 0 and "VLLM_SPEC_RESERVE_VERIFY_WORKSPACE=0" in r
+    b, r = _dec(num_speculative_tokens=1)
+    assert b == 0 and "num_speculative_tokens=1 <= 1" in r
+    b, r = _dec(num_speculative_tokens=2, overshoot_mult=0)
+    assert b == 0 and "VLLM_SPEC_VERIFY_OVERSHOOT_MULT=0" in r
+    b, r = _dec(max_num_seqs=0)
+    assert b == 0 and "degenerate" in r
+
+
+def test_decision_default_on_when_spec_present():
+    """Env default (enabled=True) must reach the gate and produce a reserve.
+
+    Mirrors the boot config: spec present, K=16, default mult -> non-zero.
+    """
+    b, reason = _dec()  # enabled defaults True here as it does via envs
+    assert b > 5 * GIB, reason
+
+
+def test_decision_bytes_match_reserve_bytes_everywhere():
+    for k in (1, 2, 8, 16, 32):
+        for s in (0, 1, 4, 16):
+            b, _ = _dec(num_speculative_tokens=k, max_num_seqs=s)
+            if k <= 1 or s <= 0:
+                assert b == 0
+            else:
+                assert b == reserve_bytes(k, s, VOCAB)
+
+
+# ---------------------------------------------------------------------------
+
+def _print_table():
+    print(f"{'K':>4} {'seqs':>5} {'mult':>5} {'delta_pos':>10} {'reserve_GiB':>12}")
+    for (k, s, mult) in [
+        (2, 16, 24),
+        (16, 4, 24),
+        (16, 16, 24),
+        (16, 16, M.MECHANISTIC_OVERSHOOT_MULT),
+        (16, 32, 24),
+        (32, 16, 24),
+    ]:
+        b = reserve(k, s, VOCAB, overshoot_mult=mult)
+        print(
+            f"{k:>4} {s:>5} {mult:>5} {b.delta_positions:>10} "
+            f"{_gib(b.reserve_bytes):>12.3f}"
+        )
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except Exception as e:
+            # Catch Exception (not just AssertionError) so a non-assertion failure
+            # (AttributeError/TypeError/...) is counted and reported like the rest
+            # instead of aborting the script and skipping the summary/exit code.
+            failed += 1
+            print(f"FAIL {t.__name__}: {type(e).__name__}: {e}")
+    print()
+    _print_table()
+    print()
+    if failed:
+        raise SystemExit(f"{failed}/{len(tests)} tests failed")
+    print(f"All {len(tests)} tests passed.")

--- a/tests/v1/core/test_spec_decode_workspace.py
+++ b/tests/v1/core/test_spec_decode_workspace.py
@@ -201,6 +201,36 @@ def _print_table():
         )
 
 
+def test_last_stage_mask_pp1_all_true():
+    """pp=1: every worker is last-stage (our TP=2 prod shape)."""
+    assert M.spec_verify_last_stage_mask(1, 2, 2) == [True, True]
+
+
+def test_last_stage_mask_normal_pp():
+    """Per-DP-rank executor, pp=2 tp=2: last stage is the tail slice."""
+    assert M.spec_verify_last_stage_mask(2, 2, 4) == [False, False, True, True]
+
+
+def test_last_stage_mask_external_launcher_dp():
+    """external_launcher dp=2 pp=2 tp=1 (n_workers=4, DP outermost):
+    each DP group has its own last stage — NOT a contiguous tail.
+    This is the cubic-#131-P2 scenario."""
+    assert M.spec_verify_last_stage_mask(2, 1, 4) == [False, True, False, True]
+
+
+def test_last_stage_mask_external_launcher_dp_tp():
+    """external_launcher dp=2 pp=2 tp=2 (n_workers=8)."""
+    assert M.spec_verify_last_stage_mask(2, 2, 8) == [
+        False, False, True, True, False, False, True, True,
+    ]
+
+
+def test_last_stage_mask_defensive_fallback():
+    """Non-divisible n_workers: layout assumption is off -> reserve on all
+    (safe over-reserve, never a missed reserve on the rank that needs it)."""
+    assert M.spec_verify_last_stage_mask(2, 2, 6) == [True] * 6
+
+
 if __name__ == "__main__":
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -283,6 +283,13 @@ if TYPE_CHECKING:
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT: int = 0
+    # Reserve VRAM for the speculative-decode verify working set that KV-cache
+    # memory profiling under-counts at large num_speculative_tokens (see
+    # vllm/v1/core/spec_decode_workspace.py). Auto no-op when speculative
+    # decoding is off or num_speculative_tokens <= 1.
+    VLLM_SPEC_RESERVE_VERIFY_WORKSPACE: bool = True
+    # Peak-overshoot multiplier for that reserve. 0 disables the reserve.
+    VLLM_SPEC_VERIFY_OVERSHOOT_MULT: int = 24
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
@@ -1884,6 +1891,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT", "0")
     ),
     # Flag to enable v2 model runner.
+    "VLLM_SPEC_RESERVE_VERIFY_WORKSPACE": lambda: bool(
+        int(os.getenv("VLLM_SPEC_RESERVE_VERIFY_WORKSPACE", "1"))
+    ),
+    "VLLM_SPEC_VERIFY_OVERSHOOT_MULT": lambda: int(
+        os.getenv("VLLM_SPEC_VERIFY_OVERSHOOT_MULT", "24")
+    ),
     "VLLM_USE_V2_MODEL_RUNNER": lambda: bool(
         int(os.getenv("VLLM_USE_V2_MODEL_RUNNER", "0"))
     ),

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1890,13 +1890,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT": lambda: int(
         os.getenv("VLLM_TOOL_REPETITION_DETECTION_MIN_COUNT", "0")
     ),
-    # Flag to enable v2 model runner.
+    # Reserve VRAM for the speculative-decode verify working set that memory
+    # profiling under-counts at num_speculative_tokens > 1 (see
+    # vllm/v1/core/spec_decode_workspace.py). Auto no-op when spec decoding is
+    # off or K <= 1; the multiplier bounds the peak-overshoot estimate.
     "VLLM_SPEC_RESERVE_VERIFY_WORKSPACE": lambda: bool(
         int(os.getenv("VLLM_SPEC_RESERVE_VERIFY_WORKSPACE", "1"))
     ),
     "VLLM_SPEC_VERIFY_OVERSHOOT_MULT": lambda: int(
         os.getenv("VLLM_SPEC_VERIFY_OVERSHOOT_MULT", "24")
     ),
+    # Flag to enable v2 model runner.
     "VLLM_USE_V2_MODEL_RUNNER": lambda: bool(
         int(os.getenv("VLLM_USE_V2_MODEL_RUNNER", "0"))
     ),

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -2148,11 +2148,26 @@ def get_kv_cache_configs(
             "KV sizing: speculative-decode verify workspace reserve %s", spec_verify_reason
         )
     if spec_verify_reserve > 0:
+        # Only the last pipeline stage runs compute_logits + rejection
+        # sampling, so only its workers need the reserve (review: reserving on
+        # every rank shrinks earlier stages' KV for buffers they never
+        # allocate). Ranks are laid out PP-outermost / TP-innermost
+        # (parallel_state.initialize_model_parallel reshape), so the last
+        # stage is the final `world/pp` slice. With pp_size == 1 (the common
+        # case) every worker is the last stage and behavior is unchanged.
+        pp_size = max(
+            1, int(getattr(vllm_config.parallel_config, "pipeline_parallel_size", 1))
+        )
+        n_workers = len(available_memory)
+        per_stage = max(1, n_workers // pp_size)
+        last_stage_start = (pp_size - 1) * per_stage
         available_memory = [
             avail_mem
-            if not groups
+            if (not groups or idx < last_stage_start)
             else max(0, avail_mem - spec_verify_reserve)
-            for groups, avail_mem in zip(projected_groups_per_worker, available_memory)
+            for idx, (groups, avail_mem) in enumerate(
+                zip(projected_groups_per_worker, available_memory)
+            )
         ]
         logger.info(
             "Reserved %s GiB per rank for the speculative-decode verify working "

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,6 +18,7 @@ from vllm.logger import init_logger
 from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
+from vllm.v1.core.spec_decode_workspace import spec_verify_reserve_decision
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -1992,6 +1993,49 @@ def _turboquant_prefill_workspace_reserve_bytes(vllm_config: VllmConfig) -> int:
     return per_ubatch_bytes * num_ubatches
 
 
+def spec_decode_verify_reserve_decision(vllm_config: VllmConfig) -> tuple[int, str]:
+    """``(reserve_bytes, human_reason)`` for the speculative-decode verify
+    working set that KV-cache memory profiling under-counts at large
+    ``num_speculative_tokens``.
+
+    Subtracted from the KV budget *before* ``num_gpu_blocks`` is derived (same
+    contract as ``_turboquant_prefill_workspace_reserve_bytes``). See
+    ``vllm/v1/core/spec_decode_workspace.py`` for the root cause and formula.
+    Returns bytes=0 (with a reason) when it does not apply.
+
+    Unlike the turboquant continuation workspace, these are plain transient torch
+    allocations that profiling never triggers at full width, so there is nothing
+    to add back in ``determine_available_memory`` — the reserve applies once.
+    Exposed (not private) so ``gpu_worker.determine_available_memory`` can emit
+    the same decision as an always-on boot diagnostic.
+    """
+    speculative_present = getattr(vllm_config, "speculative_config", None) is not None
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    max_num_seqs = int(getattr(scheduler_config, "max_num_seqs", 0) or 0)
+    # Only a MISSING model_config is the degenerate "no vocab" shape. The
+    # get_vocab_size() call is made outside the AttributeError guard so that an
+    # AttributeError raised INSIDE it (a real bug) propagates instead of being
+    # silently mapped to vocab_size=0 -- which would disable the spec-verify OOM
+    # reserve unnoticed. A non-int / uncastable return is still an expected
+    # "invalid vocab" shape and maps to 0.
+    model_config = getattr(vllm_config, "model_config", None)
+    if model_config is None:
+        vocab_size = 0
+    else:
+        try:
+            vocab_size = int(model_config.get_vocab_size())
+        except (TypeError, ValueError):
+            vocab_size = 0
+    return spec_verify_reserve_decision(
+        speculative_present=speculative_present,
+        enabled=bool(envs.VLLM_SPEC_RESERVE_VERIFY_WORKSPACE),
+        num_speculative_tokens=int(vllm_config.num_speculative_tokens),
+        max_num_seqs=max_num_seqs,
+        vocab_size=vocab_size,
+        overshoot_mult=int(envs.VLLM_SPEC_VERIFY_OVERSHOOT_MULT),
+    )
+
+
 def get_kv_cache_configs(
     vllm_config: VllmConfig,
     kv_cache_specs: list[dict[str, KVCacheSpec]],
@@ -2078,6 +2122,43 @@ def get_kv_cache_configs(
             "(VLLM_TQ_RESERVE_PREFILL_WORKSPACE=1); set it to 0 to restore the "
             "legacy sizing.",
             format_gib(workspace_reserve),
+        )
+
+    # [FORK] Reserve VRAM for the speculative-decode verify working set *before*
+    # deriving the KV budget. Memory profiling only exercises the rejection /
+    # verify path at K=1 width (`_dummy_sampler_run`), so at large
+    # `num_speculative_tokens` the full (1+K)-wide compute_logits + rejection
+    # sampler buffers land lazily on the first real decode step and OOM
+    # post-profiling. Subtracting here makes auto-fit, the admission check, and
+    # the per-worker config builder all plan against a budget that leaves room
+    # for those buffers (an over-large max_model_len becomes a clean startup cap
+    # rather than a crash). Applied before the num_gpu_blocks_override adjustment
+    # so an explicit operator override still pins num_blocks exactly (reserve is
+    # a no-op then). No add-back is needed in determine_available_memory: unlike
+    # the turboquant continuation workspace, these buffers are never allocated
+    # during profiling, so there is no double-count.
+    spec_verify_reserve, spec_verify_reason = spec_decode_verify_reserve_decision(
+        vllm_config
+    )
+    if getattr(vllm_config, "speculative_config", None) is not None:
+        # Always-on so a boot is attributable (mirrors the diagnostic in
+        # determine_available_memory, which prints even when an earlier phase
+        # OOMs before this point).
+        logger.info(
+            "KV sizing: speculative-decode verify workspace reserve %s", spec_verify_reason
+        )
+    if spec_verify_reserve > 0:
+        available_memory = [
+            avail_mem
+            if not groups
+            else max(0, avail_mem - spec_verify_reserve)
+            for groups, avail_mem in zip(projected_groups_per_worker, available_memory)
+        ]
+        logger.info(
+            "Reserved %s GiB per rank for the speculative-decode verify working "
+            "set before sizing the KV cache; set "
+            "VLLM_SPEC_RESERVE_VERIFY_WORKSPACE=0 to restore the legacy sizing.",
+            format_gib(spec_verify_reserve),
         )
 
     # If `num_gpu_blocks_override` is set, the cache size that will actually

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,7 +18,10 @@ from vllm.logger import init_logger
 from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
-from vllm.v1.core.spec_decode_workspace import spec_verify_reserve_decision
+from vllm.v1.core.spec_decode_workspace import (
+    spec_verify_last_stage_mask,
+    spec_verify_reserve_decision,
+)
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -2151,19 +2154,22 @@ def get_kv_cache_configs(
         # Only the last pipeline stage runs compute_logits + rejection
         # sampling, so only its workers need the reserve (review: reserving on
         # every rank shrinks earlier stages' KV for buffers they never
-        # allocate). Ranks are laid out PP-outermost / TP-innermost
-        # (parallel_state.initialize_model_parallel reshape), so the last
-        # stage is the final `world/pp` slice. With pp_size == 1 (the common
-        # case) every worker is the last stage and behavior is unchanged.
-        pp_size = max(
-            1, int(getattr(vllm_config.parallel_config, "pipeline_parallel_size", 1))
+        # allocate). With pp_size == 1 (the common case) every worker is the
+        # last stage and behavior is unchanged; see spec_verify_last_stage_mask
+        # for the rank-layout derivation (incl. external_launcher DP folding).
+        pc = vllm_config.parallel_config
+        last_stage = spec_verify_last_stage_mask(
+            pp_size=max(1, int(getattr(pc, "pipeline_parallel_size", 1))),
+            inner_size=max(
+                1,
+                int(getattr(pc, "prefill_context_parallel_size", 1))
+                * int(getattr(pc, "tensor_parallel_size", 1)),
+            ),
+            n_workers=len(available_memory),
         )
-        n_workers = len(available_memory)
-        per_stage = max(1, n_workers // pp_size)
-        last_stage_start = (pp_size - 1) * per_stage
         available_memory = [
             avail_mem
-            if (not groups or idx < last_stage_start)
+            if (not groups or not last_stage[idx])
             else max(0, avail_mem - spec_verify_reserve)
             for idx, (groups, avail_mem) in enumerate(
                 zip(projected_groups_per_worker, available_memory)

--- a/vllm/v1/core/spec_decode_workspace.py
+++ b/vllm/v1/core/spec_decode_workspace.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""[FORK] Analytical sizing for the speculative-decode *verify* working set that
+KV-cache memory profiling under-counts at large ``num_speculative_tokens``.
+
+Kept torch-free on purpose: the pure formula (:func:`spec_verify_reserve_bytes`)
+is unit-tested against the measured OOM facts without importing CUDA/torch. The
+config-facing wrapper lives in ``kv_cache_utils`` and only pulls scalars out of
+``VllmConfig`` before delegating here.
+
+Root cause (see ``docs/exp039-scoped-drafter-design.md`` §5, K-sizing finding #2)
+-----------------------------------------------------------------------------
+``GPUModelRunner.profile_run`` runs a *prefill*-shaped ``_dummy_run`` and then
+``_dummy_sampler_run``. In the spec-decode branch of ``_dummy_sampler_run`` the
+rejection sampler is exercised with ``draft_token_ids = [[0]] * num_reqs`` — i.e.
+**one** draft token per request (``logits = randn(2 * num_reqs, vocab)``), and
+``compute_logits`` in the prefill dummy run only produces ``num_reqs`` logit rows
+(one per request). A *real* decode step with ``num_speculative_tokens = K`` must
+instead verify ``K`` draft positions + 1 bonus position per request, so it:
+
+* runs ``compute_logits`` over ``logits_indices`` of length ``(1 + K) * num_reqs``
+  (``gpu_model_runner._calc_spec_decode_metadata`` builds target+bonus indices),
+  producing a ``((1 + K) * num_reqs, vocab)`` fp32 tensor, and
+* drives the rejection sampler (``vllm/v1/sample/rejection_sampler.py``) whose
+  working set is several concurrent full-vocab **fp32** tensors sized by the
+  ``K * num_reqs`` target positions: ``raw_target_logits`` (fancy-index copy),
+  its ``.clone()``, the top-k/top-p sort scratch, and the ``target_probs``
+  softmax.
+
+None of that full-width verify peak is materialised during profiling, so it
+lands lazily on the *first real decode step* — after the KV cache has already
+been sized to consume the rest of VRAM — and OOMs post-profiling. The gap scales
+with ``(K - 1) * num_reqs`` (the per-request verify width beyond the profiled
+K=1 baseline), which is exactly why it is invisible at K=2 but ~5 GiB at K=16,
+and why it shrinks ~4x when ``max_num_seqs`` drops 16 -> 4.
+
+Fix strategy: subtract an analytical reserve for this working set from the KV
+budget *before* ``num_gpu_blocks`` is derived, mirroring
+``_turboquant_prefill_workspace_reserve_bytes``. Unlike the turboquant
+continuation workspace (a ``WorkspaceManager`` arena that can be allocated at
+load time and therefore needs an add-back in ``determine_available_memory`` to
+avoid double-counting), the verify buffers are plain transient torch allocations
+that profiling **never** triggers at full width — so there is nothing to add
+back and the reserve is applied exactly once.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Profiling (`_dummy_sampler_run`) exercises the rejection sampler with one draft
+# token per request, i.e. `num_draft (=1) + bonus (=1) = 2` logit positions per
+# request. This is the width already reflected in the profiled torch peak.
+PROFILED_BASELINE_WIDTH = 2
+
+# fp32: `compute_logits` returns float32 and the rejection sampler upcasts
+# (`raw_target_logits.to(torch.float32)`, `softmax(dtype=torch.float32)`,
+# `torch.zeros_like(logits, dtype=torch.float32)`).
+VERIFY_DTYPE_BYTES = 4
+
+# Mechanistic lower bound on the number of concurrent full-vocab fp32 tensors the
+# verify path holds *beyond* the profiled K=1 baseline, counted from the code:
+#   1x compute_logits verify-output delta
+#   1x raw_target_logits (fancy-index copy)
+#   1x target_logits clone
+#   2x top-k/top-p sort scratch (sorted values + scatter/cumsum)
+#   1x target_probs softmax
+# ~= 6.  This is the floor; see OVERSHOOT_MULT_DEFAULT for why the default is
+# larger.
+MECHANISTIC_OVERSHOOT_MULT = 6
+
+# Default multiplier. The mechanistic verify buffers (~6x) explain ~1.4 GiB of
+# the measured ~5 GiB post-profiling overshoot at K=16 / max_num_seqs=16 /
+# vocab=248320. The remainder is *not* verify logits (the arithmetic ceiling of
+# the verify buffers is ~2 GiB) — it is the un-instrumented residual that also
+# scales with the (1+K)-wide decode batch: the GDN/Mamba align-mode decode scan
+# workspace and PyTorch caching-allocator fragmentation. Until that residual is
+# attributed with an instrumented boot, the default reserves the full observed
+# envelope so a high-util / high-seqs boot does not OOM. Operators who have
+# separately accounted for the residual can lower this toward
+# MECHANISTIC_OVERSHOOT_MULT.
+OVERSHOOT_MULT_DEFAULT = 24
+
+
+@dataclass(frozen=True)
+class SpecVerifyReserve:
+    """Breakdown of the spec-decode verify reserve (for logging / tests)."""
+
+    num_speculative_tokens: int
+    max_num_seqs: int
+    vocab_size: int
+    overshoot_mult: int
+    dtype_bytes: int
+    profiled_baseline_width: int
+
+    @property
+    def per_req_delta_width(self) -> int:
+        """Per-request verify logit positions the profiler misses.
+
+        Real width is ``K + 1`` (K target + 1 bonus); profiling covers
+        ``profiled_baseline_width`` (=2).
+        """
+        return max(0, (self.num_speculative_tokens + 1) - self.profiled_baseline_width)
+
+    @property
+    def delta_positions(self) -> int:
+        return self.per_req_delta_width * max(0, self.max_num_seqs)
+
+    @property
+    def base_bytes(self) -> int:
+        """One full-vocab fp32 row-group over the missed positions."""
+        return self.delta_positions * max(0, self.vocab_size) * self.dtype_bytes
+
+    @property
+    def reserve_bytes(self) -> int:
+        return self.overshoot_mult * self.base_bytes
+
+
+def spec_verify_reserve(
+    num_speculative_tokens: int,
+    max_num_seqs: int,
+    vocab_size: int,
+    *,
+    overshoot_mult: int = OVERSHOOT_MULT_DEFAULT,
+    dtype_bytes: int = VERIFY_DTYPE_BYTES,
+    profiled_baseline_width: int = PROFILED_BASELINE_WIDTH,
+) -> SpecVerifyReserve:
+    """Build the reserve breakdown (does not gate on any env)."""
+    return SpecVerifyReserve(
+        num_speculative_tokens=int(num_speculative_tokens),
+        max_num_seqs=int(max_num_seqs),
+        vocab_size=int(vocab_size),
+        overshoot_mult=int(overshoot_mult),
+        dtype_bytes=int(dtype_bytes),
+        profiled_baseline_width=int(profiled_baseline_width),
+    )
+
+
+def spec_verify_reserve_bytes(
+    num_speculative_tokens: int,
+    max_num_seqs: int,
+    vocab_size: int,
+    *,
+    overshoot_mult: int = OVERSHOOT_MULT_DEFAULT,
+    dtype_bytes: int = VERIFY_DTYPE_BYTES,
+    profiled_baseline_width: int = PROFILED_BASELINE_WIDTH,
+) -> int:
+    """Per-rank VRAM (bytes) to reserve for the spec-decode verify working set.
+
+    Returns 0 for the non-spec / K<=1 case (nothing beyond the profiled
+    baseline) and for any degenerate input.
+
+    The reserve models the peak of the concurrent full-vocab fp32 verify buffers
+    that profiling under-counts, scaled by ``(K - 1) * max_num_seqs`` — the
+    per-request verify width beyond the profiled K=1 baseline, times the batch.
+    """
+    if (
+        num_speculative_tokens is None
+        or max_num_seqs is None
+        or vocab_size is None
+        or overshoot_mult is None
+        or dtype_bytes is None
+        or profiled_baseline_width is None
+    ):
+        # Any None kwarg is a degenerate input; return 0 before int() so the
+        # documented "0 for degenerate input" contract holds instead of TypeError.
+        return 0
+    if (
+        int(num_speculative_tokens) <= 1
+        or int(max_num_seqs) <= 0
+        or int(vocab_size) <= 0
+        or int(overshoot_mult) <= 0
+        or int(dtype_bytes) <= 0
+    ):
+        return 0
+    return spec_verify_reserve(
+        num_speculative_tokens,
+        max_num_seqs,
+        vocab_size,
+        overshoot_mult=overshoot_mult,
+        dtype_bytes=dtype_bytes,
+        profiled_baseline_width=profiled_baseline_width,
+    ).reserve_bytes
+
+
+def spec_verify_reserve_decision(
+    *,
+    speculative_present: bool,
+    enabled: bool,
+    num_speculative_tokens: int,
+    max_num_seqs: int,
+    vocab_size: int,
+    overshoot_mult: int,
+) -> tuple[int, str]:
+    """Return ``(reserve_bytes, human_reason)`` for the spec-verify reserve.
+
+    Pure (scalars in, tuple out) so the *always-on* boot diagnostic and the
+    actual subtraction agree by construction and can be unit-tested without an
+    engine. ``reason`` is safe to log verbatim; it says either ``applied ...`` or
+    ``skipped: <why>`` so a boot is attributable even when a *different* phase
+    (e.g. cudagraph-memory profiling) OOMs before the reserve is used.
+    """
+    if not speculative_present:
+        return 0, "skipped: no speculative_config"
+    if not enabled:
+        return 0, "skipped: VLLM_SPEC_RESERVE_VERIFY_WORKSPACE=0"
+    if int(num_speculative_tokens) <= 1:
+        return 0, (
+            f"skipped: num_speculative_tokens={num_speculative_tokens} <= 1 "
+            "(nothing beyond the profiled K=1 baseline)"
+        )
+    if int(overshoot_mult) <= 0:
+        return 0, "skipped: VLLM_SPEC_VERIFY_OVERSHOOT_MULT=0"
+    if int(max_num_seqs) <= 0 or int(vocab_size) <= 0:
+        return 0, (
+            f"skipped: degenerate (max_num_seqs={max_num_seqs}, "
+            f"vocab_size={vocab_size})"
+        )
+    b = spec_verify_reserve_bytes(
+        num_speculative_tokens,
+        max_num_seqs,
+        vocab_size,
+        overshoot_mult=overshoot_mult,
+    )
+    reason = (
+        f"applied: K={num_speculative_tokens} max_num_seqs={max_num_seqs} "
+        f"vocab={vocab_size} mult={overshoot_mult} "
+        f"({b / (1 << 30):.3f} GiB)"
+    )
+    return b, reason

--- a/vllm/v1/core/spec_decode_workspace.py
+++ b/vllm/v1/core/spec_decode_workspace.py
@@ -210,7 +210,9 @@ def spec_verify_reserve_decision(
             "(nothing beyond the profiled K=1 baseline)"
         )
     if int(overshoot_mult) <= 0:
-        return 0, "skipped: VLLM_SPEC_VERIFY_OVERSHOOT_MULT=0"
+        return 0, (
+            f"skipped: VLLM_SPEC_VERIFY_OVERSHOOT_MULT={overshoot_mult} <= 0"
+        )
     if int(max_num_seqs) <= 0 or int(vocab_size) <= 0:
         return 0, (
             f"skipped: degenerate (max_num_seqs={max_num_seqs}, "

--- a/vllm/v1/core/spec_decode_workspace.py
+++ b/vllm/v1/core/spec_decode_workspace.py
@@ -230,3 +230,26 @@ def spec_verify_reserve_decision(
         f"({b / (1 << 30):.3f} GiB)"
     )
     return b, reason
+
+
+def spec_verify_last_stage_mask(
+    pp_size: int, inner_size: int, n_workers: int
+) -> list[bool]:
+    """Per-worker mask of last-pipeline-stage membership.
+
+    Worker lists follow the parallel_state rank layout (DP x) PP x PCP x TP
+    with TP innermost. A per-DP-rank executor covers PP*PCP*TP workers;
+    ``external_launcher`` folds DP in outermost, so the last stage is NOT a
+    contiguous tail slice there -- each DP group has its own last stage.
+    Deriving the stage from the PCP*TP inner block size is correct in both
+    modes: ``stage(idx) = (idx // (pcp*tp)) % pp``.
+
+    Defensive: if n_workers is not a multiple of inner_size * pp_size the
+    layout assumption is off, so reserve on every worker (safe over-reserve
+    rather than a missed reserve on the rank that actually needs it).
+    """
+    if pp_size <= 1:
+        return [True] * n_workers
+    if n_workers % (inner_size * pp_size) != 0:
+        return [True] * n_workers
+    return [(idx // inner_size) % pp_size == pp_size - 1 for idx in range(n_workers)]

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -367,6 +367,27 @@ class Worker(WorkerBase):
             # still need a profile run which compiles the model for
             # max_num_batched_tokens
             self.model_runner.profile_run()
+            # [FORK] Same always-on reserve diagnostic as the profiled path below:
+            # the kv_cache_memory_bytes early return would otherwise skip it and
+            # leave such boots unattributable.
+            # workspace reserve decision. Emitted HERE (before cudagraph-memory
+            # profiling) on purpose: at large num_speculative_tokens the very
+            # next step can OOM inside profile_cudagraph_memory (allocating the
+            # minimal KV cache for capture) — which is *upstream* of
+            # get_kv_cache_configs where the reserve is actually applied — so a
+            # log placed only there would never print. This makes every boot
+            # attributable either way.
+            if self.vllm_config.speculative_config is not None:
+                from vllm.v1.core.kv_cache_utils import (
+                    spec_decode_verify_reserve_decision,
+                )
+
+                _spec_reason = spec_decode_verify_reserve_decision(self.vllm_config)[1]
+                logger.info(
+                    "Speculative-decode verify workspace reserve (applied later "
+                    "in get_kv_cache_configs): %s",
+                    _spec_reason,
+                )
 
             msg = (
                 f"Initial free memory {format_gib(self.init_snapshot.free_memory)} "

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -395,6 +395,26 @@ class Worker(WorkerBase):
                 "allocated_bytes.all.peak", 0
             )
 
+            # [FORK] Always-on diagnostic of the speculative-decode verify
+            # workspace reserve decision. Emitted HERE (before cudagraph-memory
+            # profiling) on purpose: at large num_speculative_tokens the very
+            # next step can OOM inside profile_cudagraph_memory (allocating the
+            # minimal KV cache for capture) — which is *upstream* of
+            # get_kv_cache_configs where the reserve is actually applied — so a
+            # log placed only there would never print. This makes every boot
+            # attributable either way.
+            if self.vllm_config.speculative_config is not None:
+                from vllm.v1.core.kv_cache_utils import (
+                    spec_decode_verify_reserve_decision,
+                )
+
+                _spec_reason = spec_decode_verify_reserve_decision(self.vllm_config)[1]
+                logger.info(
+                    "Speculative-decode verify workspace reserve (applied later "
+                    "in get_kv_cache_configs): %s",
+                    _spec_reason,
+                )
+
             # Profile CUDA graph memory if graphs will be captured.
             # Skip on ROCm/HIP/XPU as graph pool handles and mem_get_info behave
             # differently and can produce incorrect/negative estimates.
@@ -404,6 +424,18 @@ class Worker(WorkerBase):
                 and self.vllm_config.compilation_config.cudagraph_mode
                 != CUDAGraphMode.NONE
             ):
+                # [FORK] profile_run leaves its (1+K)-wide activation peak in the
+                # caching allocator as reserved-but-unallocated blocks. The next
+                # call, profile_cudagraph_memory -> _init_minimal_kv_cache_for_
+                # profiling, must allocate a *fresh contiguous* minimal KV cache
+                # (min_blocks = max_cudagraph_capture_size); at K=16/seqs=16 the
+                # fragmented cache cannot serve it and CUDA has <1 GiB free, so
+                # it OOM'd here (868 MiB) before the KV budget was ever sized.
+                # Return the cache to the driver so the minimal-KV alloc + graph
+                # capture have contiguous room. Peak was already recorded above
+                # (profile_torch_peak), so this does not perturb the measurement.
+                gc.collect()
+                torch.accelerator.empty_cache()
                 cudagraph_memory_estimate = self.model_runner.profile_cudagraph_memory()
 
         # Use the pre-cudagraph torch peak to avoid double-counting.


### PR DESCRIPTION
## Problem

Memory profiling exercises the rejection/verify path only at **K=1 width** (`_dummy_sampler_run`), so at larger `num_speculative_tokens` the full (1+K)-wide `compute_logits` + rejection-sampler buffers land lazily on the **first real decode step** — after the KV cache has already consumed the headroom → post-profiling OOM that looks like a mystery crash. Observed concretely at K=16 / seqs=16 / vocab=248320 on 2×2080 Ti 22GB (engine died at first spec-decode traffic; also reproducible as a cudagraph-profiling OOM at boot, see below).

## Fix (same contract as the merged #111)

- **`vllm/v1/core/spec_decode_workspace.py`** (new, pure-stdlib): reserve formula + decision function returning `(bytes, human-readable reason)` — 12 unit tests included.
- **`kv_cache_utils.get_kv_cache_configs`**: subtract the reserve **before** `num_gpu_blocks` is derived. No add-back is needed (unlike the #111 turboquant workspace): these buffers are never allocated during profiling, so there is no double-count.
- **`gpu_worker`**: an always-on one-line boot diagnostic of the decision (so any boot is attributable), plus `empty_cache()` before cudagraph profiling — `profile_run`'s (1+K)-wide activation peak leaves the caching allocator fragmented, and the minimal-KV allocation for graph capture then OOMs at large K with <1 GiB free.
- **envs**: `VLLM_SPEC_RESERVE_VERIFY_WORKSPACE` (default on; **auto no-op** when spec decoding is off or K≤1 — zero effect on non-spec configs) and `VLLM_SPEC_VERIFY_OVERSHOOT_MULT`.

## Evidence

Running in production on this lineage (MTP K=2 / seqs 16): reserve = 0.355 GiB, boot-attributable via the diagnostic line; the K=16 boot that previously died now caps cleanly at sizing time. Built against `add5ec0`; `tests/v1/core/test_spec_decode_workspace.py` 12/12 on this branch.

Related: #111 (accepted; same reserve-before-sizing family), #126 (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-reserves VRAM for the speculative-decode verify workspace before KV-cache sizing to prevent post-profiling OOM at large K. Previously profiling exercised only K=1; the first real decode allocated (1+K)-wide logits/sampler buffers after KV sizing and OOMed.

- Subtracts a configurable reserve in `get_kv_cache_configs` before deriving `num_gpu_blocks`; no add-back in availability since profiling never allocates these buffers at full width.
- Applies reserve only on last pipeline-stage workers; DP-aware mask handles `external_launcher` DP correctly, `pp_size==1` unchanged; defensive all-True fallback on inconsistent layouts.
- Always-on boot diagnostic logs the reserve decision (including the `kv_cache_memory_bytes` early-return path) and logs again during KV sizing.
- Calls `gc.collect()` and `torch.accelerator.empty_cache()` before CUDA graph profiling to avoid allocator-fragmentation OOMs.
- Envs: `VLLM_SPEC_RESERVE_VERIFY_WORKSPACE` (default 1; no-op when speculative is off or K<=1) and `VLLM_SPEC_VERIFY_OVERSHOOT_MULT` (default 24; 0 disables; reason string reports the configured value).
- Adds pure-stdlib helper and tests (`vllm/v1/core/spec_decode_workspace.py`), including DP-aware last-stage masking; default reserve envelopes the observed ~5 GiB gap at K=16/seqs=16.

<sup>Written for commit e0fdaa4145b144137d1032cc60ebe6302b5c856b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

