### PR TITLE
offload: re-align Mamba hit boundary after per-group clamps

### DIFF
--- a/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
+++ b/tests/v1/kv_connector/unit/test_mamba_cpu_offload_compat.py
@@ -47,7 +47,8 @@ def test_hybrid_mamba_external_hit_is_aligned_and_does_not_crash():
     assert offload_scheduler._lookup(state) == 32
 
     scheduler = SimpleNamespace(
-        cache_config=SimpleNamespace(block_size=16), use_eagle=False
+        cache_config=SimpleNamespace(block_size=16),
+        use_eagle=False,
     )
     model_request = SimpleNamespace(
         num_computed_tokens=0, num_prompt_tokens=33, num_tokens=34
@@ -62,3 +63,76 @@ def test_hybrid_mamba_external_hit_is_aligned_and_does_not_crash():
         )
         == 16
     )
+
+
+def test_hybrid_hit_realigns_after_non_divisor_group():
+    """A group whose offloaded_block_size is not a divisor of the Mamba
+    alignment must not report an unaligned hit that includes a Mamba state
+    beyond it.
+
+    Group 0 (full attention) uses offloaded_block_size=12; group 1 (Mamba,
+    align mode) uses offloaded_block_size=16. 12 is not a divisor of 16, so the
+    per-group ``min(max_hit, len_keys * block_size)`` tightening lands the
+    boundary on a multiple of 12 that is not a multiple of 16. Unless the
+    boundary is re-aligned to the Mamba block after *each* per-group constraint,
+    ``_lookup`` reports 24 tokens (not aligned to 16) while the Mamba group's
+    key lookup already reached the block covering tokens 16..32 -- a recurrent
+    state beyond the reported hit, which would restore a Mamba state
+    inconsistent with the attention prefix. With the fix the hit is rounded
+    back to the 16-token boundary and the Mamba lookup stops there.
+    """
+    # Record how far into the Mamba (group 1) keys the lookup actually reached.
+    mamba_blocks_looked_up: list[int] = []
+
+    class _RecordingAllHitManager:
+        def lookup(self, key, req_context):
+            if isinstance(key, bytes) and key.startswith(b"m"):
+                mamba_blocks_looked_up.append(int(key[1:]))
+            return True
+
+    offload_scheduler = object.__new__(OffloadingConnectorScheduler)
+    offload_scheduler._sliding_window_groups = (1,)
+    offload_scheduler._lookup_groups = (0, 1)
+    offload_scheduler._mamba_align_size = 16
+    offload_scheduler._blocks_being_loaded = None
+    offload_scheduler.manager = _RecordingAllHitManager()
+    offload_scheduler.config = SimpleNamespace(
+        kv_group_configs=(
+            # full attention; 12 is NOT a divisor of the Mamba alignment (16)
+            SimpleNamespace(
+                offloaded_block_size=12, sliding_window_size_in_blocks=None
+            ),
+            # Mamba align group; its block size is the alignment
+            SimpleNamespace(offloaded_block_size=16, sliding_window_size_in_blocks=1),
+        )
+    )
+    request = SimpleNamespace(num_tokens=34, request_id="unit")
+    state = SimpleNamespace(
+        req=request,
+        req_context=None,
+        num_locally_computed_tokens=0,
+        group_states=(
+            SimpleNamespace(offload_keys=[b"fa0", b"fa1"]),
+            SimpleNamespace(offload_keys=[b"m0", b"m1", b"m2"]),
+        ),
+    )
+
+    num_hit_tokens = offload_scheduler._lookup(state)
+
+    mamba_align = offload_scheduler._mamba_align_size
+    # Tokens covered by the Mamba group's key lookup (block idx + 1) * block_size.
+    assert mamba_blocks_looked_up, "Mamba group was never looked up"
+    mamba_covered_tokens = (max(mamba_blocks_looked_up) + 1) * mamba_align
+
+    # 1) The reported hit must be aligned to the Mamba boundary (pre-fix: 24).
+    assert num_hit_tokens % mamba_align == 0, (
+        f"unaligned hit {num_hit_tokens} is not a multiple of {mamba_align}"
+    )
+    # 2) The Mamba state included must correspond to <= the reported hit, i.e.
+    #    no recurrent state beyond the attention prefix we report as hit.
+    assert mamba_covered_tokens <= num_hit_tokens, (
+        f"Mamba lookup reached {mamba_covered_tokens} tokens, beyond the "
+        f"reported hit of {num_hit_tokens}"
+    )
+    # Concretely, the fix reports the 16-token boundary, not the unaligned 24.
+    assert num_hit_tokens == 16

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -318,6 +318,16 @@ class OffloadingConnectorScheduler:
                     req_status.req_context,
                 )
 
+    def _align_hit_boundary(self, num_tokens: int) -> int:
+        """Round a hit boundary down to the Mamba alignment (no-op when Mamba
+        align mode is off). Every tightening of max_hit_size_tokens must pass
+        through this, or a group whose offloaded_block_size is not a multiple
+        of the alignment can report an unaligned hit that includes a Mamba
+        state beyond the boundary."""
+        if self._mamba_align_size is None:
+            return num_tokens
+        return round_down(num_tokens, self._mamba_align_size)
+
     def _lookup(self, req_status: RequestOffloadState) -> int | None:
         """
         Find how many tokens beyond num_locally_computed_tokens can be loaded.
@@ -334,12 +344,9 @@ class OffloadingConnectorScheduler:
             # for sliding window attention, we must reduce by 1 to make sure
             # we still have a hit after reduction
             max_hit_size_tokens -= 1
-        if self._mamba_align_size is not None:
-            # Mamba align stores a single recurrent state at block boundaries.
-            # Never load a partial boundary or a state beyond the valid hit.
-            max_hit_size_tokens = round_down(
-                max_hit_size_tokens, self._mamba_align_size
-            )
+        # Mamba align stores a single recurrent state at block boundaries.
+        # Never load a partial boundary or a state beyond the valid hit.
+        max_hit_size_tokens = self._align_hit_boundary(max_hit_size_tokens)
         num_hit_tokens: int = 0
         defer_lookup = False
         lookup_groups = self._lookup_groups
@@ -360,9 +367,15 @@ class OffloadingConnectorScheduler:
                     >= req_status.req.num_tokens // offloaded_block_size
                 )
 
-                # Constrain to block-aligned boundary for this group
-                max_hit_size_tokens = min(
-                    max_hit_size_tokens, len(offload_keys) * offloaded_block_size
+                # Constrain to block-aligned boundary for this group, then
+                # re-align to the Mamba boundary (the per-group min can undo
+                # the initial round_down when offloaded_block_size is not a
+                # multiple of the alignment)
+                max_hit_size_tokens = self._align_hit_boundary(
+                    min(
+                        max_hit_size_tokens,
+                        len(offload_keys) * offloaded_block_size,
+                    )
                 )
                 if max_hit_size_tokens - num_computed_tokens < offloaded_block_size:
                     # we can only load less than a block, better skip
@@ -396,9 +409,14 @@ class OffloadingConnectorScheduler:
                 if num_hit_blocks is None:
                     defer_lookup = True
                 else:
-                    max_hit_size_tokens = min(
-                        max_hit_size_tokens,
-                        offloaded_block_size * (start_block_idx + num_hit_blocks),
+                    # same re-alignment as above for the backend-confirmed
+                    # hit boundary
+                    max_hit_size_tokens = self._align_hit_boundary(
+                        min(
+                            max_hit_size_tokens,
+                            offloaded_block_size
+                            * (start_block_idx + num_hit_blocks),
+                        )
                     )
 
                 new_num_hit_tokens = max_hit_size_tokens - num_computed_tokens


### PR DESCRIPTION
## Purpose
Split out of #126 per your request (one PR per fix) — this is the mechanical bugfix half, independent of the MTP retention feature.

## Bug
`OffloadingConnectorScheduler._lookup` rounds `max_hit_size_tokens` down to the Mamba alignment once up front, but two later clamps can produce a **new, unaligned** boundary when a group's `offloaded_block_size` is not a multiple of the Mamba align size:
1. the per-group `min(max_hit_size_tokens, len(offload_keys) * offloaded_block_size)`
2. the backend-confirmed `offloaded_block_size * (start_block_idx + num_hit_blocks)` clamp

An unaligned hit reports tokens that include a Mamba recurrent state beyond the valid boundary.

## Fix
Every tightening of the hit boundary now routes through `_align_hit_boundary()` (round-down to the alignment; no-op when align mode is off). No behavior change for aligned/divisor group shapes.

## Test
`test_hybrid_hit_realigns_after_non_divisor_group` constructs the non-divisor group shape and asserts the re-aligned hit (fails before the fix). Full file: 2 passed.

The MTP retention change from #126 will return as its own PR with the invariant analysis and performance A/B you asked for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-aligns the Mamba hit boundary after per-group clamps in `OffloadingConnectorScheduler._lookup` to prevent reporting unaligned hits. Previously, per-group clamps could create a new boundary not divisible by the Mamba align size, causing a recurrent state beyond the valid hit; now all tightenings are re-aligned.

- Adds `_align_hit_boundary()` and applies it after each boundary clamp, including backend-confirmed `num_hit_blocks`.
- No behavior change when Mamba align mode is off or when group `offloaded_block_size` divides the alignment.
- Adds `test_hybrid_hit_realigns_after_non_divisor_group`, which reproduces the non-divisor case and asserts the aligned 16-token hit.

<sup>Written for commit 9c4f6d2051eba6ce74b9b6cb82074bb0986ff5a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

