### PR TITLE
fix(turboquant): reserve continuation workspace for max context

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -829,8 +829,21 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         if block_size <= 0:
             block_size = max_batched_tokens
 
+        # Continuation prefill dequantizes the complete cached prefix into the
+        # shared workspace.  Reserving only max_num_batched_tokens is not
+        # sufficient for long-context profiles: the workspace is locked before
+        # the first request and cannot grow when a 128K/256K prefix arrives.
+        # Use max_model_len as the default bound, while retaining the env var
+        # as an explicit lower bound for deployments with a smaller route.
+        model_cfg = getattr(vllm_config, "model_config", None)
+        max_model_len = int(
+            getattr(model_cfg, "max_model_len", 0) if model_cfg is not None else 0
+        )
+        configured_reserve = _TQ_CONTINUATION_WORKSPACE_RESERVE_TOKENS
         reserve_tokens = max(
-            max_batched_tokens, _TQ_CONTINUATION_WORKSPACE_RESERVE_TOKENS
+            max_batched_tokens,
+            max_model_len,
+            configured_reserve,
         )
         reserve_cached_len = math.ceil(reserve_tokens / block_size) * block_size
         if reserve_cached_len <= 0:

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1969,6 +1969,7 @@ def _turboquant_prefill_workspace_reserve_bytes(vllm_config: VllmConfig) -> int:
 
     reserve_tokens = max(
         max_batched_tokens,
+        int(getattr(vllm_config.model_config, "max_model_len", 0)),
         int(envs.VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS),
     )
     reserve_cached_len = math.ceil(reserve_tokens / block_size) * block_size


### PR DESCRIPTION
## Summary

- Reserve TurboQuant continuation-prefill workspace using `max_model_len` before KV-cache sizing.
- Keep `VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS` as an explicit lower bound.
- Prevent the first 128K/256K continuation request from growing a workspace after it has been locked for CUDA Graph/runtime use.

## Validation

- `bash -n build.sh launcher.sh`
- `bash tools/validate_profiles.sh` (`profile_validation_ok total=17`)
- `python3 -m py_compile vllm/v1/attention/backends/turboquant_attn.py vllm/v1/core/kv_cache_utils.py`
- `git diff --check`
- On dual RTX 2080 Ti (`.31`), Qwen3.8-27B-FP8, TQK8V4, MTP3, CUDA Graph enabled, a 128K/512 request completed successfully without workspace-lock/OOM errors.

## Scope

This fixes continuation workspace sizing. It does not claim to eliminate the normal TurboQuant decode-throughput reduction as KV context grows, and it does not include the separate 256K Marlin decode temporary-allocation OOM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reserve TurboQuant continuation prefill workspace using the model’s max context length. Previously we reserved up to max batched tokens (or the env lower bound), which could under-size the workspace for 128K/256K prefixes after CUDA Graph locking and trigger OOM/lock errors.

- Reserve tokens are now max(max_batched_tokens, model_config.max_model_len, VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS) in both the attention backend and KV-cache sizing paths.
- Side effect: higher upfront memory reservation on long-context models; unchanged behavior for smaller routes where the env var or batch cap remains lower.
- No migration required; operators may still set VLLM_TURBOQUANT_CONTINUATION_WORKSPACE_RESERVE_TOKENS to enforce a lower bound.

<sup>Written for commit 88cc2ab250bffa62e9ee28477c9354a613604cef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

