### PR TITLE
kv-cache: tolerate required-below-allocated in Mamba align allocate

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -219,3 +219,43 @@ def test_mamba_align_eagle_split_stops_at_reusable_boundary() -> None:
         eagle, request, 2 * block_size - 2
     )
     assert request.num_computed_tokens + scheduled == 2 * block_size
+
+
+def test_mamba_align_allocate_tolerates_required_below_allocated() -> None:
+    """Regression (EXP-039 windows): with variable-width drafts (an MTP draft
+    cap below the scheduler's num_spec_tokens, or the S4 gate flipping between
+    2- and 16-wide drafts) plus rejection rollback, a later step can require
+    FEWER Mamba blocks than the request already holds. The base allocate path
+    tolerates that (num_new_blocks <= 0 -> []); align mode asserted:
+    ``num_required_blocks 17 < len(req_blocks) 18`` -> engine death on first
+    spec-decode traffic. Align mode must tolerate it the same way."""
+    from vllm.v1.core.single_type_kv_cache_manager import MambaManager
+    from vllm.v1.core.block_pool import BlockPool
+
+    block_size = 16
+    spec = MambaSpec(
+        block_size=block_size,
+        shapes=(1, 1),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    pool = BlockPool(num_gpu_blocks=64, enable_caching=True, hash_block_size=block_size)
+    mgr = MambaManager(
+        kv_cache_spec=spec,
+        block_pool=pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+    )
+    rid = "req-varwidth"
+    # Step 1: a wide step (e.g. 16-token draft scheduled) grows the block list.
+    first = mgr.allocate_new_blocks(rid, num_tokens=18 * block_size,
+                                    num_tokens_main_model=17 * block_size)
+    assert first, "first allocation should create blocks"
+    held = len(mgr.req_to_blocks[rid])
+    # Step 2: rejection rollback / narrow draft -> requirement DROPS below the
+    # held count. Must be a graceful no-op, not an AssertionError.
+    out = mgr.allocate_new_blocks(rid, num_tokens=16 * block_size,
+                                  num_tokens_main_model=15 * block_size)
+    assert out == []
+    assert len(mgr.req_to_blocks[rid]) == held  # nothing freed mid-request

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -982,13 +982,17 @@ class MambaManager(SingleTypeKVCacheManager):
             num_required_blocks = (
                 cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
             )
-            if num_required_blocks == len(req_blocks):
+            if num_required_blocks <= len(req_blocks):
+                # The requirement can legitimately drop below what the request
+                # already holds: with a draft-width cap (or a gated drafter)
+                # the per-step speculative width varies, and rejection rollback
+                # shrinks num_tokens between steps. Mirror the base allocate
+                # path (num_new_blocks <= 0 -> no-op); the extra blocks stay
+                # attached to the request and are freed with it. Previously
+                # this asserted (num_required_blocks > len(req_blocks)) and
+                # killed the engine on the first variable-width spec step.
                 return []
             else:
-                assert num_required_blocks > len(req_blocks), (
-                    "num_required_blocks "
-                    f"{num_required_blocks} < len(req_blocks) {len(req_blocks)}"
-                )
                 prev_block_len = len(req_blocks)
                 blocks_allocated = request_id in self._allocated_block_reqs
                 # Record the last state block


### PR DESCRIPTION
## Purpose
In align mode, `MambaManager.allocate_new_blocks` asserts `num_required_blocks >= len(req_blocks)` — but under speculative decoding the per-step required count legitimately SHRINKS below what is already allocated: variable-width drafts (accepted length fluctuates step to step) and rejection rollback both reduce `num_tokens` for an already-widely-allocated request. The assert then kills the engine mid-serve.

Empirically hit on a dual-2080 Ti rig running MTP + `mamba_cache_mode=align` (crash RCA 2026-08-24); reproduced deterministically in the added unit test by allocating an 18-block-wide request and then requiring fewer blocks.

## Fix
Treat required <= allocated as a no-op (`return []`) instead of asserting — mirroring the base (non-align) path's existing tolerance. Comment documents the two legitimate shrink mechanisms.

## Not #53479
This is distinct from vllm-project/vllm#53479 (align-mode *state sparsity* in `_mamba_block_aligned_split`): that PR changes where states materialize during prefill chunking; this one fixes the allocator's per-step assert under spec-decode width fluctuation. Verified no overlap in touched code paths.

## Test
`test_mamba_align_allocate_tolerates_required_below_allocated` (tests/v1/core/test_prefix_caching.py) — constructs a MambaManager with caching enabled, reproduces the exact assert pre-fix, passes post-fix. Green on this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerates required-below-allocated in Mamba align-mode allocation to prevent engine crashes during speculative decoding. Old behavior: assert when num_required_blocks < allocated; new behavior: no-op (return []), leaving surplus blocks attached and freed with the request, matching the base allocator.

- Touches only the align-mode branch in `vllm.v1.core.single_type_kv_cache_manager.MambaManager.allocate_new_blocks`.
- Adds regression test `tests/v1/core/test_prefix_caching.py::test_mamba_align_allocate_tolerates_required_below_allocated` that reproduced the pre-fix assert and now passes.

<sup>Written for commit 490a87f4e70ea7b44f4725251e5de6f7917b3ec5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/weicj/vLLM-2080Ti-Definitive/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

